### PR TITLE
Add checkpoint resumption to SFT notebook

### DIFF
--- a/Trainers/notebooks/sft_colab_tool_calling.ipynb
+++ b/Trainers/notebooks/sft_colab_tool_calling.ipynb
@@ -200,35 +200,14 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 10. Train!\n\n**What this does:** The actual learning happens here!\n\nThe model will:\n1. **Read examples** from the dataset\n2. **Predict** what the response should be\n3. **Compare** its prediction to the correct answer\n4. **Update weights** to get closer to the correct answer\n5. **Repeat** this process for 3 epochs (3 full passes through the data)\n\n**What to expect:**\n- Training takes ~45 minutes for 7B models on T4 GPU\n- You'll see progress updates every 5 steps\n- Loss should generally decrease over time (learning is working!)\n- Checkpoints are saved every 100 steps to Google Drive\n\n**What the metrics mean:**\n- **Loss:** How \"wrong\" the model is (lower = better, aim for <1.0)\n- **Learning Rate:** Gradually decreases as training progresses\n- **Samples/sec:** Training speed (depends on GPU)"
+   "source": "## 10. Train!\n\n**What this does:** The actual learning happens here!\n\nThe model will:\n1. **Read examples** from the dataset\n2. **Predict** what the response should be\n3. **Compare** its prediction to the correct answer\n4. **Update weights** to get closer to the correct answer\n5. **Repeat** this process for 3 epochs (3 full passes through the data)\n\n**What to expect:**\n- Training takes ~45 minutes for 7B models on T4 GPU\n- You'll see progress updates every 5 steps\n- Loss should generally decrease over time (learning is working!)\n- Checkpoints are saved every 100 steps to Google Drive\n\n**What the metrics mean:**\n- **Loss:** How \"wrong\" the model is (lower = better, aim for <1.0)\n- **Learning Rate:** Gradually decreases as training progresses\n- **Samples/sec:** Training speed (depends on GPU)\n\n**💾 Checkpoint Resumption:**\nIf your Colab session disconnects, don't worry! Your checkpoints are saved to Google Drive. You can resume training by:\n1. Re-running cells 1-9 (setup, model loading, dataset prep, config)\n2. In the training cell below, the code will automatically detect the latest checkpoint and resume from there\n3. Your progress is preserved!"
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Check GPU memory\n",
-    "gpu_stats = torch.cuda.get_device_properties(0)\n",
-    "start_gpu_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)\n",
-    "max_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)\n",
-    "print(f\"GPU = {gpu_stats.name}. Max memory = {max_memory} GB.\")\n",
-    "print(f\"{start_gpu_memory} GB of memory reserved.\")\n",
-    "print()\n",
-    "\n",
-    "# Start training\n",
-    "print(\"=\" * 60)\n",
-    "print(\"STARTING TRAINING\")\n",
-    "print(\"=\" * 60)\n",
-    "print()\n",
-    "\n",
-    "trainer_stats = trainer.train()\n",
-    "\n",
-    "print()\n",
-    "print(\"=\" * 60)\n",
-    "print(\"TRAINING COMPLETED\")\n",
-    "print(\"=\" * 60)"
-   ]
+   "source": "# Check GPU memory\ngpu_stats = torch.cuda.get_device_properties(0)\nstart_gpu_memory = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)\nmax_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)\nprint(f\"GPU = {gpu_stats.name}. Max memory = {max_memory} GB.\")\nprint(f\"{start_gpu_memory} GB of memory reserved.\")\nprint()\n\n# ════════════════════════════════════════════════════════════════════════════\n# 🔍 Check for existing checkpoints (automatic resumption)\n# ════════════════════════════════════════════════════════════════════════════\nimport glob\nimport os\n\ncheckpoint_dirs = sorted(glob.glob(f\"{output_dir}/checkpoint-*\"))\nresume_from_checkpoint = None\n\nif checkpoint_dirs:\n    # Found checkpoints - get the latest one\n    latest_checkpoint = max(checkpoint_dirs, key=lambda x: int(x.split(\"-\")[-1]))\n    resume_from_checkpoint = latest_checkpoint\n    print(f\"✓ Found existing checkpoint: {os.path.basename(latest_checkpoint)}\")\n    print(f\"  Resuming training from this checkpoint\")\n    print(f\"  Total checkpoints found: {len(checkpoint_dirs)}\")\nelse:\n    print(\"ℹ️  No existing checkpoints found - starting fresh training\")\n\nprint()\n\n# Start training (or resume)\nprint(\"=\" * 60)\nif resume_from_checkpoint:\n    print(\"RESUMING TRAINING FROM CHECKPOINT\")\nelse:\n    print(\"STARTING TRAINING\")\nprint(\"=\" * 60)\nprint()\n\ntrainer_stats = trainer.train(resume_from_checkpoint=resume_from_checkpoint)\n\nprint()\nprint(\"=\" * 60)\nprint(\"TRAINING COMPLETED\")\nprint(\"=\" * 60)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
- Automatically detect existing checkpoints in output directory
- Resume from latest checkpoint if found
- Explain checkpoint resumption in markdown documentation
- Useful when Colab session disconnects mid-training
- Checkpoints saved every 100 steps to Google Drive (already configured)