### PR TITLE
Fix SFT data loader to handle tool-calling format with null content

### DIFF
--- a/Trainers/rtx3090_sft/src/data_loader.py
+++ b/Trainers/rtx3090_sft/src/data_loader.py
@@ -102,14 +102,30 @@ def print_dataset_samples(dataset: Dataset, num_samples: int = 3):
             print(f"Format: Conversational ({len(example['conversations'])} messages)")
             for msg in example['conversations']:
                 role = msg['role']
-                content = msg['content'][:100]
-                print(f"  [{role}]: {content}...")
+                # Handle both text content and tool calls
+                if msg.get('content'):
+                    content = msg['content'][:100]
+                    print(f"  [{role}]: {content}...")
+                elif msg.get('tool_calls'):
+                    num_tools = len(msg['tool_calls'])
+                    tool_names = [tc['function']['name'] for tc in msg['tool_calls']]
+                    print(f"  [{role}]: <{num_tools} tool call(s): {', '.join(tool_names[:2])}...>")
+                else:
+                    print(f"  [{role}]: <empty>")
         elif "messages" in example:
             print(f"Format: Conversational ({len(example['messages'])} messages)")
             for msg in example['messages']:
                 role = msg['role']
-                content = msg['content'][:100]
-                print(f"  [{role}]: {content}...")
+                # Handle both text content and tool calls
+                if msg.get('content'):
+                    content = msg['content'][:100]
+                    print(f"  [{role}]: {content}...")
+                elif msg.get('tool_calls'):
+                    num_tools = len(msg['tool_calls'])
+                    tool_names = [tc['function']['name'] for tc in msg['tool_calls']]
+                    print(f"  [{role}]: <{num_tools} tool call(s): {', '.join(tool_names[:2])}...>")
+                else:
+                    print(f"  [{role}]: <empty>")
         elif "text" in example:
             print(f"Format: Text")
             print(f"Content: {example['text'][:200]}...")


### PR DESCRIPTION
Problem:
- Workspace-aware SFT dataset uses OpenAI tool-calling format
- Assistant messages have content=null when using tool_calls
- print_dataset_samples() assumed content is always a string
- TypeError: 'NoneType' object is not subscriptable

Fix:
- Check if content exists before accessing it
- Handle tool_calls format: show "<N tool call(s): tool_name...>"
- Handle empty messages: show "<empty>"
- Works with both text content and tool calls

This allows training with tool-calling format datasets like syngen_tools_sft_11.23.25_workspace_aware.jsonl