### PR TITLE
Fix SFT trainer to work with TRL 0.15.0+ conversational format

### DIFF
--- a/Trainers/rtx3090_sft/src/data_loader.py
+++ b/Trainers/rtx3090_sft/src/data_loader.py
@@ -56,6 +56,11 @@ def load_and_prepare_dataset(
 
     print(f"\nRaw dataset size: {len(raw_datasets)} examples")
 
+    # Convert 'conversations' to 'messages' (TRL 0.15.0+ requirement)
+    if "conversations" in raw_datasets.column_names and "messages" not in raw_datasets.column_names:
+        print("Converting 'conversations' key to 'messages' (TRL 0.15.0+ requirement)")
+        raw_datasets = raw_datasets.rename_column("conversations", "messages")
+
     # Optional: Filter for desirable examples only
     if filter_desirable and "label" in raw_datasets.column_names:
         print("\nFiltering for desirable examples (label=True)...")

--- a/Trainers/rtx3090_sft/train_sft.py
+++ b/Trainers/rtx3090_sft/train_sft.py
@@ -312,6 +312,8 @@ def run(args: argparse.Namespace):
     check_gpu_memory()
 
     # Configure SFT training arguments
+    # Note: For conversational format (messages key), SFTTrainer auto-detects and applies chat template
+    # No dataset_text_field needed for messages format (TRL 0.15.0+)
     training_args = SFTConfig(
         output_dir=config.training.output_dir,
         per_device_train_batch_size=config.training.per_device_train_batch_size,
@@ -321,7 +323,6 @@ def run(args: argparse.Namespace):
         lr_scheduler_type=config.training.lr_scheduler_type,
         max_seq_length=config.training.max_seq_length,
         packing=config.training.packing,
-        dataset_text_field="text" if "text" in train_dataset.column_names else None,
         gradient_checkpointing=config.training.gradient_checkpointing,
         optim=config.training.optim,
         fp16=not is_bfloat16_supported() if config.training.fp16 is False else config.training.fp16,


### PR DESCRIPTION
Problem:
- Dataset uses "conversations" key (older format)
- TRL 0.15.0+ requires "messages" key for conversational data
- SFTTrainer error: "You need to provide either dataset_text_field or formatting_func"
- Attempted fix with skip_prepare_dataset was incorrect (that's for pre-tokenized data)

Root Cause:
- TRL 0.15.0+ deprecated "conversations" key in favor of "messages"
- SFTTrainer auto-detects "messages" format but not "conversations"
- Our workspace-aware SFT dataset uses "conversations" from OpenAI format

Solution:
1. Data loader now converts "conversations" → "messages" automatically
2. Removed incorrect skip_prepare_dataset approach
3. Let SFTTrainer auto-detect "messages" format and apply chat template
4. Added comment explaining TRL 0.15.0+ behavior

Changes:
- src/data_loader.py: Auto-rename "conversations" to "messages" on load
- train_sft.py: Removed dataset_kwargs, rely on auto-detection
- Trainer now properly applies chat template to tool-calling data

This allows training with both:
- Legacy datasets with "conversations" key (auto-converted)
- Modern datasets with "messages" key (used as-is)

References:
- TRL 0.15.0 breaking change: conversations → messages
- https://huggingface.co/docs/trl/en/sft_trainer