### PR TITLE
Add agentic search (RAG agent) case study and skill templates

### DIFF
--- a/.agents/skills/case-studies/SKILL.md
+++ b/.agents/skills/case-studies/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: case-studies
-description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers two complete worked examples — tool-calling training and essay-style training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
+description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers three complete worked examples — tool-calling training, essay-style training, and agentic search (RAG agent) training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
 allowed-tools: Read, Bash, Write, Grep, Glob
 ---
 
 # Case Studies: Implementing the Training Pipeline
 
-Two end-to-end worked examples showing how to take a capability from concept to trained model.
+Three end-to-end worked examples showing how to take a capability from concept to trained model.
 
 ## Why Case Studies?
 
@@ -18,16 +18,17 @@ The other skills teach you how to use individual tools:
 
 This skill shows you **how they all connect** — the decisions, the iteration, and the order of operations that turn an idea into a trained capability.
 
-## The Two Case Studies
+## The Three Case Studies
 
 | Case Study | What It Teaches | Reference |
 |-----------|----------------|-----------|
 | **Tool Calling** | Structured output training — teaching a model to call APIs with correct syntax, context objects, and parameters | `reference/tool-calling-pipeline.md` |
 | **Essay Style** | Creative output training — teaching a model to transform messy brainstorms into structured outlines with voice and personality | `reference/essay-style-pipeline.md` |
+| **Agentic Search** | RAG agent training — teaching a model to search a corpus, select relevant documents, and answer grounded in sources | `reference/agentic-search-pipeline.md` |
 
 ## The Universal Pipeline
 
-Both case studies follow the same high-level pipeline, but diverge in dataset design and validation:
+All three case studies follow the same high-level pipeline, but diverge in dataset design and validation:
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -96,7 +97,8 @@ After evaluation, the failure analysis tells you exactly what to generate next. 
 |-----------|-------------|
 | **Tool Calling Pipeline** | Understanding the full tools training journey — from schema to trained model | `reference/tool-calling-pipeline.md` |
 | **Essay Style Pipeline** | Understanding the full essay training journey — from brainstorm to outline model | `reference/essay-style-pipeline.md` |
-| **Pipeline Comparison** | Side-by-side comparison of how the two pipelines differ at each stage | `reference/pipeline-comparison.md` |
+| **Agentic Search Pipeline** | Understanding the full RAG agent training journey — from corpus to grounded-answer model | `reference/agentic-search-pipeline.md` |
+| **Pipeline Comparison** | Side-by-side comparison of how the pipelines differ at each stage | `reference/pipeline-comparison.md` |
 
 ## Cross-References to Other Skills
 
@@ -114,5 +116,6 @@ At each stage of the pipeline, you'll use tools documented in the other skills:
 
 - Read the tool-calling case study first — it's the simpler, more mechanical pipeline
 - The essay case study shows how to adapt the pipeline for creative/subjective outputs
-- Both pipelines use the same trainers, evaluator, and upload tools — only the data differs
+- The agentic search case study shows how to train multi-step reasoning where tools are means to an end
+- All three pipelines use the same trainers, evaluator, and upload tools — only the data differs
 - When planning a new capability, map it to whichever case study is closer, then adapt

--- a/.agents/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.agents/skills/case-studies/configs/agentic_search_eval.yaml
@@ -2,29 +2,28 @@
 # AGENTIC SEARCH EVALUATION — TEMPLATE
 # ============================================================
 #
-# TOOL-AGNOSTIC: This template uses placeholder tool names.
-# You MUST customize before running:
+# TOOL-AGNOSTIC: Replace YOUR_SEARCH_TOOL / YOUR_READ_TOOL
+# with your actual tools before running.
 #
-#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
-#      (e.g., searchManager_searchContent, rag_search, etc.)
+# TWO EVALUATION MODES:
 #
-#   2. Replace YOUR_READ_TOOL with your actual document-read tool
-#      (e.g., contentManager_read, doc_reader, etc.)
+#   STATIC MODE (no --env-backend flag)
+#     Corpus embedded in system prompt. Tests whether the model
+#     knows HOW to search/read/answer. Quick, no extra setup.
+#     Run: python -m Evaluator.cli --preset agentic_search
 #
-#   3. If using environment-backed evaluation, supply:
-#        --env-tool-schema <path>    (tool JSON schemas)
-#        --env-exec-config <path>    (execution backend config)
-#
-#   4. Adapt the embedded corpus in each system prompt to your
-#      domain if desired. The default corpus is domain-neutral.
-#
-# Each test embeds a small self-contained corpus (3-5 short docs)
-# inside the system prompt so scenarios are portable and do not
-# require an external document store.
+#   RUNTIME MODE (--env-backend local)
+#     Real files in an isolated temp filesystem. Tool calls are
+#     ACTUALLY EXECUTED — search returns real matches, read
+#     returns real content. Tests real search-find-answer ability.
+#     Run: python -m Evaluator.cli --preset agentic_search_runtime \
+#       --env-backend local \
+#       --env-tool-schema path/to/your_tool_schema.yaml \
+#       --env-exec-config path/to/your_exec_config.yaml
 #
 # Tags: agentic_search, search_quality, grounding, multi_hop,
-#        distractor_resistance, no_answer
-# ID convention: AS_<description>
+#        distractor_resistance, no_answer, runtime
+# ID conventions: AS_* (static), ASR_* (runtime)
 # ============================================================
 
 name: Agentic Search Evaluation
@@ -615,38 +614,368 @@ tests:
       Including S3 in the answer is a failure. The s3-deep-dive doc is
       a distractor.
 
+  # ================================================================
+  # RUNTIME MODE TESTS (ASR_*)
+  #
+  # These tests use fixture-based filesystems and agentic loops.
+  # The model's tool calls are ACTUALLY EXECUTED against real files.
+  # The system prompt does NOT contain the corpus — the model must
+  # discover content by searching and reading.
+  #
+  # Requires: --env-backend local --env-tool-schema --env-exec-config
+  # ================================================================
+
+  # ------------------------------------------------------------------
+  # R1. Runtime: Single-doc lookup
+  # ------------------------------------------------------------------
+  - id: ASR_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/config-reference.md
+            body: |
+              # Data Loader Configuration Reference
+              The data loader supports batch sizes from 1 to 512. The default
+              batch size is 32. Set `batch_size` in loader.yaml to override.
+              Larger batch sizes require proportionally more GPU memory.
+          - path: docs/quickstart-guide.md
+            body: |
+              # Quick Start Guide
+              Install dependencies with `pip install -r requirements.txt`.
+              Run `python main.py` to start. See config-reference for tuning.
+          - path: docs/changelog-v2.md
+            body: |
+              # Changelog v2.0
+              Added streaming mode. Fixed memory leak in tokenizer.
+              Bumped minimum Python version to 3.10.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_single_doc_lookup. Model must actually search
+      and read files to find the answer (512). No corpus in system prompt.
+
+  # ------------------------------------------------------------------
+  # R2. Runtime: Multi-hop reasoning
+  # ------------------------------------------------------------------
+  - id: ASR_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-catalog.md
+            body: |
+              # Service Catalog
+              billing-service: Handles invoicing, payment processing, and
+              retry logic for failed transactions. Owner: see team-directory.
+              auth-service: SSO and token management. Owner: Platform team.
+              notification-service: Email and push alerts. Owner: Comms team.
+          - path: docs/team-directory.md
+            body: |
+              # Team Directory
+              Platform team: auth-service, infra-gateway.
+              Payments team: billing-service, refund-engine.
+              Comms team: notification-service, template-renderer.
+          - path: docs/oncall-schedule.md
+            body: |
+              # On-Call Schedule — Q1
+              Week 1: Platform team. Week 2: Payments team.
+              Week 3: Comms team. Week 4: rotate.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_hop_reasoning. Model must search for
+      payment retries → find billing-service → search for team owner →
+      find Payments team. Requires reading 2 documents minimum.
+
+  # ------------------------------------------------------------------
+  # R3. Runtime: Distractor resistance
+  # ------------------------------------------------------------------
+  - id: ASR_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/gateway-config.md
+            body: |
+              # API Gateway Configuration
+              The gateway forwards requests to backend services. Default
+              timeout: 30 seconds. Override with `gateway.timeout_ms` in
+              gateway.yaml. Health-check interval: 10 seconds.
+          - path: docs/client-sdk-timeouts.md
+            body: |
+              # Client SDK — Timeout Settings
+              The Python client SDK has a default request timeout of 60 seconds.
+              Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+              These are CLIENT-SIDE values and do not affect the gateway.
+          - path: docs/database-pool.md
+            body: |
+              # Database Connection Pool
+              Connection timeout: 5 seconds. Query timeout: 15 seconds.
+              Pool size: 20 connections. Idle timeout: 300 seconds.
+          - path: docs/monitoring-alerts.md
+            body: |
+              # Monitoring & Alerts
+              Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+              Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_distractor_resistance. Four files mention
+      "timeout" — model must find gateway-config.md specifically and
+      answer 30 seconds, not confuse with client 60s or DB 5s values.
+
+  # ------------------------------------------------------------------
+  # R4. Runtime: No-answer detection
+  # ------------------------------------------------------------------
+  - id: ASR_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/remote-work-policy.md
+            body: |
+              # Remote Work Policy — Full-Time Employees
+              Full-time employees may work remotely up to 3 days per week.
+              Manager approval required for fully remote arrangements.
+              Equipment stipend: $500/year. VPN required for all remote access.
+          - path: docs/contractor-onboarding.md
+            body: |
+              # Contractor Onboarding Guide
+              Contractors receive a company laptop and badge access.
+              NDA must be signed before day one. Billing cycle: net-30.
+              Contact procurement@company.com for equipment issues.
+          - path: docs/benefits-summary.md
+            body: |
+              # Benefits Summary — 2025
+              Health insurance, 401k match, PTO policy, parental leave.
+              Applies to full-time employees only.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_no_answer_detection. Remote-work policy covers
+      FTEs only. Contractor onboarding doesn't mention remote work. Model
+      should search, read, and conclude the info isn't in the corpus.
+
+  # ------------------------------------------------------------------
+  # R5. Runtime: Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: ASR_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-overview.md
+            body: |
+              # Microservices Overview
+              The platform runs 12 microservices. Each has its own config.
+              Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+              Service-specific vars documented in each service's config doc.
+          - path: docs/email-service-config.md
+            body: |
+              # Email Notification Service — Configuration
+              Required environment variables:
+                SMTP_HOST: Mail server hostname
+                SMTP_PORT: Mail server port (default: 587)
+                SMTP_USER: Authentication username
+                SMTP_PASS: Authentication password
+                FROM_ADDRESS: Default sender address
+                TEMPLATE_DIR: Path to email templates
+              Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+          - path: docs/push-service-config.md
+            body: |
+              # Push Notification Service — Configuration
+              Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+              Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+          - path: docs/sms-service-config.md
+            body: |
+              # SMS Notification Service — Configuration
+              Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+              Optional: MAX_SMS_LENGTH (default: 160).
+          - path: docs/deploy-runbook.md
+            body: |
+              # Deployment Runbook
+              Step 1: Pull latest images. Step 2: Run migrations.
+              Step 3: Set env vars per service config docs. Step 4: Deploy.
+              Rollback: revert to previous image tag.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_step_refinement. Broad search for
+      "environment variables" hits many files. Model should narrow to
+      "email service" or "email notification config" to find the right
+      doc. Answer: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS,
+      FROM_ADDRESS, TEMPLATE_DIR (required) + RATE_LIMIT_PER_HOUR.
+
 # ============================================================
 # PRESET CONFIGURATION
 # ============================================================
 #
-# Add the following block to Evaluator/config/eval_run.yaml
-# under the existing `presets:` key:
+# Add these blocks to Evaluator/config/eval_run.yaml under `presets:`:
 #
+#   # Static mode — corpus in system prompt, quick behavioral check
 #   agentic_search:
-#     description: "RAG agent: search -> select -> answer from docs"
+#     description: "RAG agent: search -> select -> answer (static corpus)"
 #     scenarios:
 #       - agentic_search_prompts.yaml
 #     tag_filter:
 #       - agentic_search
+#     exclude_tags:
+#       - runtime
 #     scoring:
 #       pass_threshold: 0.8
 #       weights:
 #         tool_correct: 1.0
 #         behavior_pass: 0.5
 #         response_type_match: 0.3
-#     category_thresholds:
-#       multi_hop: 0.70
-#       distractor_resistance: 0.85
-#       grounding: 0.80
-#       no_answer: 0.90
 #
-# Then copy (or symlink) this scenario file into:
-#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#   # Runtime mode — real filesystem, actual tool execution
+#   agentic_search_runtime:
+#     description: "RAG agent: live search -> read -> answer (runtime env)"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - runtime
+#     scoring:
+#       pass_threshold: 0.8
 #
-# Run with:
-#   python -m Evaluator.cli --preset agentic_search
+# Copy this file to: Evaluator/config/scenarios/agentic_search_prompts.yaml
 #
-# Or with environment backend:
-#   python -m Evaluator.cli --preset agentic_search \
-#     --env-tool-schema <path> --env-exec-config <path>
+# Static:  python -m Evaluator.cli --preset agentic_search
+# Runtime: python -m Evaluator.cli --preset agentic_search_runtime \
+#            --env-backend local \
+#            --env-tool-schema <path> --env-exec-config <path>
 # ============================================================

--- a/.agents/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.agents/skills/case-studies/configs/agentic_search_eval.yaml
@@ -1,0 +1,652 @@
+# ============================================================
+# AGENTIC SEARCH EVALUATION — TEMPLATE
+# ============================================================
+#
+# TOOL-AGNOSTIC: This template uses placeholder tool names.
+# You MUST customize before running:
+#
+#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
+#      (e.g., searchManager_searchContent, rag_search, etc.)
+#
+#   2. Replace YOUR_READ_TOOL with your actual document-read tool
+#      (e.g., contentManager_read, doc_reader, etc.)
+#
+#   3. If using environment-backed evaluation, supply:
+#        --env-tool-schema <path>    (tool JSON schemas)
+#        --env-exec-config <path>    (execution backend config)
+#
+#   4. Adapt the embedded corpus in each system prompt to your
+#      domain if desired. The default corpus is domain-neutral.
+#
+# Each test embeds a small self-contained corpus (3-5 short docs)
+# inside the system prompt so scenarios are portable and do not
+# require an external document store.
+#
+# Tags: agentic_search, search_quality, grounding, multi_hop,
+#        distractor_resistance, no_answer
+# ID convention: AS_<description>
+# ============================================================
+
+name: Agentic Search Evaluation
+description: >-
+  Tests a model's ability to search a document corpus, select relevant
+  documents, synthesize information, and provide grounded answers. Covers
+  single-doc lookup, multi-hop reasoning, distractor resistance,
+  no-answer detection, term specificity, vocabulary mismatch,
+  multi-step refinement, and grounded citation.
+
+tests:
+
+  # ------------------------------------------------------------------
+  # 1. Simple single-doc search
+  # ------------------------------------------------------------------
+  - id: AS_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a documentation assistant. Answer the user's question using
+      ONLY the documents available through search. Do not guess.
+
+      <corpus>
+      [doc_id: config-reference]
+      Title: Data Loader Configuration Reference
+      The data loader supports batch sizes from 1 to 512. The default
+      batch size is 32. Set `batch_size` in loader.yaml to override.
+      Larger batch sizes require proportionally more GPU memory.
+
+      [doc_id: quickstart-guide]
+      Title: Quick Start Guide
+      Install dependencies with `pip install -r requirements.txt`.
+      Run `python main.py` to start. See config-reference for tuning.
+
+      [doc_id: changelog-v2]
+      Title: Changelog v2.0
+      Added streaming mode. Fixed memory leak in tokenizer.
+      Bumped minimum Python version to 3.10.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model should search for "batch size" or "data loader", find
+      config-reference, and answer 512. Single search + read is sufficient.
+
+  # ------------------------------------------------------------------
+  # 2. Multi-hop search
+  # ------------------------------------------------------------------
+  - id: AS_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+    system: |
+      You are an internal knowledge-base assistant. Answer using ONLY
+      information retrieved from the available documents.
+
+      <corpus>
+      [doc_id: service-catalog]
+      Title: Service Catalog
+      billing-service: Handles invoicing, payment processing, and
+      retry logic for failed transactions. Owner: see team-directory.
+      auth-service: SSO and token management. Owner: Platform team.
+      notification-service: Email and push alerts. Owner: Comms team.
+
+      [doc_id: team-directory]
+      Title: Team Directory
+      Platform team: auth-service, infra-gateway.
+      Payments team: billing-service, refund-engine.
+      Comms team: notification-service, template-renderer.
+
+      [doc_id: oncall-schedule]
+      Title: On-Call Schedule — Q1
+      Week 1: Platform team. Week 2: Payments team.
+      Week 3: Comms team. Week 4: rotate.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Requires two hops: (1) find that billing-service handles payment
+      retries, (2) find that Payments team owns billing-service. Model
+      must combine information from service-catalog and team-directory.
+
+  # ------------------------------------------------------------------
+  # 3. Distractor resistance
+  # ------------------------------------------------------------------
+  - id: AS_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+    system: |
+      You are a documentation assistant. Answer using ONLY the documents
+      available through search. If multiple documents mention timeouts,
+      use the one specifically about the API gateway.
+
+      <corpus>
+      [doc_id: gateway-config]
+      Title: API Gateway Configuration
+      The gateway forwards requests to backend services. Default
+      timeout: 30 seconds. Override with `gateway.timeout_ms` in
+      gateway.yaml. Health-check interval: 10 seconds.
+
+      [doc_id: client-sdk-timeouts]
+      Title: Client SDK — Timeout Settings
+      The Python client SDK has a default request timeout of 60 seconds.
+      Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+      These are CLIENT-SIDE values and do not affect the gateway.
+
+      [doc_id: database-pool]
+      Title: Database Connection Pool
+      Connection timeout: 5 seconds. Query timeout: 15 seconds.
+      Pool size: 20 connections. Idle timeout: 300 seconds.
+
+      [doc_id: monitoring-alerts]
+      Title: Monitoring & Alerts
+      Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+      Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Three documents mention "timeout" but only gateway-config has the
+      gateway default. Model must not confuse the client SDK 60s timeout
+      or the DB 5s timeout with the gateway 30s value.
+
+  # ------------------------------------------------------------------
+  # 4. No-answer detection
+  # ------------------------------------------------------------------
+  - id: AS_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - search_quality
+    system: |
+      You are an HR knowledge assistant. Answer ONLY from the available
+      documents. If the answer is not in the corpus, clearly state that
+      the information was not found.
+
+      <corpus>
+      [doc_id: remote-work-policy]
+      Title: Remote Work Policy — Full-Time Employees
+      Full-time employees may work remotely up to 3 days per week.
+      Manager approval required for fully remote arrangements.
+      Equipment stipend: $500/year. VPN required for all remote access.
+
+      [doc_id: contractor-onboarding]
+      Title: Contractor Onboarding Guide
+      Contractors receive a company laptop and badge access.
+      NDA must be signed before day one. Billing cycle: net-30.
+      Contact procurement@company.com for equipment issues.
+
+      [doc_id: benefits-summary]
+      Title: Benefits Summary — 2025
+      Health insurance, 401k match, PTO policy, parental leave.
+      Applies to full-time employees only.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      The remote-work policy covers full-time employees only. The
+      contractor-onboarding doc does not address remote work. The model
+      should search, read the relevant docs, and conclude that contractor
+      remote-work policy is not documented in the available corpus.
+
+  # ------------------------------------------------------------------
+  # 5. Broad vs narrow search terms
+  # ------------------------------------------------------------------
+  - id: AS_term_specificity
+    question: "How do I enable debug logging for the payment webhook handler?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer documentation assistant. Answer using the
+      available documents. Choose precise search terms.
+
+      <corpus>
+      [doc_id: logging-overview]
+      Title: Logging Overview
+      The system uses structured JSON logging. Log levels: DEBUG, INFO,
+      WARN, ERROR. Global log level set in logging.yaml. Per-module
+      overrides supported via `modules.<name>.level` keys.
+
+      [doc_id: webhook-handler-config]
+      Title: Payment Webhook Handler — Configuration
+      Enable debug logging: set `modules.payment_webhook.level: DEBUG`
+      in logging.yaml. This produces verbose request/response logs
+      including headers and payload bodies. Caution: may log PII.
+
+      [doc_id: webhook-security]
+      Title: Webhook Security
+      All inbound webhooks are verified via HMAC-SHA256 signature.
+      Invalid signatures return 403. Replay protection: 5-minute window.
+
+      [doc_id: payment-processing]
+      Title: Payment Processing Pipeline
+      Payments flow: webhook receipt -> validation -> ledger entry ->
+      notification. Retry on ledger failure: 3 attempts, exponential
+      backoff.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A broad search for "logging" would match logging-overview. A
+      narrow search for "payment webhook" or "webhook handler debug"
+      should find webhook-handler-config directly. The model should
+      select terms specific enough to reach the right document
+      efficiently.
+
+  # ------------------------------------------------------------------
+  # 6. Vocabulary mismatch
+  # ------------------------------------------------------------------
+  - id: AS_vocabulary_mismatch
+    question: "How do I throttle the request rate to avoid getting blocked?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer assistant. Answer using ONLY the available
+      documents. The user may use different terminology than the docs.
+
+      <corpus>
+      [doc_id: rate-limiting-guide]
+      Title: Rate Limiting Configuration
+      The API enforces per-client rate limits. Default: 100 requests
+      per minute. Configure via `rate_limit.rpm` in api.yaml. Clients
+      exceeding the limit receive HTTP 429. Implement exponential
+      backoff in your client code. Burst allowance: 20 requests.
+
+      [doc_id: caching-layer]
+      Title: Caching Layer
+      Redis-backed response cache. TTL: 60 seconds for GET endpoints.
+      Cache-Control headers respected. Purge via /admin/cache/clear.
+
+      [doc_id: auth-guide]
+      Title: Authentication Guide
+      API keys issued via /admin/keys. Include in X-API-Key header.
+      Keys rotate quarterly. Revoked keys return 401.
+
+      [doc_id: error-handling]
+      Title: Error Handling Reference
+      400: Bad request. 401: Unauthorized. 403: Forbidden.
+      429: Rate limit exceeded — retry after Retry-After header value.
+      500: Internal server error — contact support.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      User says "throttle" and "getting blocked" — the docs say
+      "rate limiting" and "HTTP 429". The model must translate the
+      user's vocabulary to the corpus terminology to find
+      rate-limiting-guide. May also surface error-handling for the
+      429 reference.
+
+  # ------------------------------------------------------------------
+  # 7. Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: AS_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a deployment assistant. Answer from the available
+      documents only. If your first search is too broad, refine it.
+
+      <corpus>
+      [doc_id: service-overview]
+      Title: Microservices Overview
+      The platform runs 12 microservices. Each has its own config.
+      Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+      Service-specific vars documented in each service's config doc.
+
+      [doc_id: email-service-config]
+      Title: Email Notification Service — Configuration
+      Required environment variables:
+        SMTP_HOST: Mail server hostname
+        SMTP_PORT: Mail server port (default: 587)
+        SMTP_USER: Authentication username
+        SMTP_PASS: Authentication password
+        FROM_ADDRESS: Default sender address
+        TEMPLATE_DIR: Path to email templates
+      Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+
+      [doc_id: push-service-config]
+      Title: Push Notification Service — Configuration
+      Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+      Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+
+      [doc_id: sms-service-config]
+      Title: SMS Notification Service — Configuration
+      Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+      Optional: MAX_SMS_LENGTH (default: 160).
+
+      [doc_id: deploy-runbook]
+      Title: Deployment Runbook
+      Step 1: Pull latest images. Step 2: Run migrations.
+      Step 3: Set env vars per service config docs. Step 4: Deploy.
+      Rollback: revert to previous image tag.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A search for "environment variables" hits service-overview (generic)
+      and possibly all service configs. The model should narrow to "email
+      notification" or "email service config" to reach email-service-config.
+      If the first search returns too many results, the model should
+      refine rather than dump all matches.
+
+  # ------------------------------------------------------------------
+  # 8. Grounded citation
+  # ------------------------------------------------------------------
+  - id: AS_grounded_citation
+    question: "Summarize the data retention requirements and cite which document each requirement comes from."
+    tags:
+      - agentic_search
+      - grounding
+      - search_quality
+    system: |
+      You are a compliance assistant. Answer ONLY from the available
+      documents. When stating a fact, cite the source document by name.
+
+      <corpus>
+      [doc_id: data-retention-policy]
+      Title: Data Retention Policy
+      User account data: retained for 7 years after account closure.
+      Transaction logs: retained for 5 years. Audit trails: retained
+      for 10 years. Anonymized analytics data: no retention limit.
+      Review cycle: annual.
+
+      [doc_id: gdpr-compliance]
+      Title: GDPR Compliance Addendum
+      EU user data subject to right-to-erasure. Erasure requests must
+      be fulfilled within 30 days. Retention policy overridden by
+      erasure request except where legal hold applies.
+
+      [doc_id: backup-procedures]
+      Title: Backup Procedures
+      Daily incremental backups retained for 30 days. Weekly full
+      backups retained for 90 days. Disaster recovery backups retained
+      for 1 year. All backups encrypted with AES-256.
+
+      [doc_id: security-overview]
+      Title: Security Overview
+      Encryption at rest and in transit. Access control via RBAC.
+      Penetration testing: quarterly. SOC 2 Type II certified.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must reference specific documents by name in its answer.
+      Expected citations: data-retention-policy for retention periods,
+      gdpr-compliance for erasure override, backup-procedures for
+      backup retention. Answers without citations fail grounding.
+
+  # ------------------------------------------------------------------
+  # 9. Ambiguous query requiring clarification
+  # ------------------------------------------------------------------
+  - id: AS_ambiguous_query_clarification
+    question: "How do I set up the connection?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a documentation assistant. Answer from the available
+      documents. If the question is too ambiguous to search effectively,
+      ask the user to clarify.
+
+      <corpus>
+      [doc_id: database-setup]
+      Title: Database Connection Setup
+      Install the database driver. Set DATABASE_URL in .env.
+      Run `python manage.py migrate` to initialize schema.
+      Connection pool size: 10 (configurable).
+
+      [doc_id: vpn-setup]
+      Title: VPN Connection Setup
+      Download the VPN client from /tools/vpn. Import the .ovpn
+      config file. Authenticate with your SSO credentials.
+      Required for remote access to staging and production.
+
+      [doc_id: api-client-setup]
+      Title: API Client Connection Setup
+      Install the SDK: `pip install our-client`. Initialize with
+      `Client(api_key="...")`. Set base_url for non-production
+      environments.
+
+      [doc_id: websocket-guide]
+      Title: WebSocket Connection Guide
+      Connect to ws://host:8080/stream. Send auth frame first.
+      Heartbeat interval: 30 seconds. Reconnect on close code 1006.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: clarification
+    behavior_expectations:
+      asks_for_user_input: true
+      explains_choice: true
+    anti_patterns:
+      immediate_tool_call: false
+      assumes_user_choice: true
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      "The connection" is ambiguous — four different connection types
+      exist. The model should either ask which connection type the user
+      means or briefly list the options. Picking one without asking is
+      an anti-pattern.
+
+  # ------------------------------------------------------------------
+  # 10. Search with negation constraint
+  # ------------------------------------------------------------------
+  - id: AS_negation_constraint
+    question: "List all storage backends we support OTHER THAN S3."
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a platform documentation assistant. Answer from the
+      available documents only. Pay attention to constraints in the
+      user's question.
+
+      <corpus>
+      [doc_id: storage-backends]
+      Title: Supported Storage Backends
+      The platform supports four storage backends:
+        1. Amazon S3 — default for production deployments
+        2. Google Cloud Storage (GCS) — set STORAGE_BACKEND=gcs
+        3. Azure Blob Storage — set STORAGE_BACKEND=azure
+        4. Local filesystem — for development only, STORAGE_BACKEND=local
+      All backends implement the StorageProvider interface.
+
+      [doc_id: s3-deep-dive]
+      Title: S3 Configuration Deep Dive
+      Bucket naming conventions, IAM policies, cross-region
+      replication, lifecycle rules. Set AWS_REGION and S3_BUCKET.
+
+      [doc_id: migration-guide]
+      Title: Storage Migration Guide
+      To migrate between backends, run `python migrate_storage.py
+      --from s3 --to gcs`. Supports incremental migration.
+      Estimated time: ~1 hour per 100 GB.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must find the storage-backends doc and list GCS, Azure Blob
+      Storage, and local filesystem — excluding S3 as the user requested.
+      Including S3 in the answer is a failure. The s3-deep-dive doc is
+      a distractor.
+
+# ============================================================
+# PRESET CONFIGURATION
+# ============================================================
+#
+# Add the following block to Evaluator/config/eval_run.yaml
+# under the existing `presets:` key:
+#
+#   agentic_search:
+#     description: "RAG agent: search -> select -> answer from docs"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - agentic_search
+#     scoring:
+#       pass_threshold: 0.8
+#       weights:
+#         tool_correct: 1.0
+#         behavior_pass: 0.5
+#         response_type_match: 0.3
+#     category_thresholds:
+#       multi_hop: 0.70
+#       distractor_resistance: 0.85
+#       grounding: 0.80
+#       no_answer: 0.90
+#
+# Then copy (or symlink) this scenario file into:
+#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#
+# Run with:
+#   python -m Evaluator.cli --preset agentic_search
+#
+# Or with environment backend:
+#   python -m Evaluator.cli --preset agentic_search \
+#     --env-tool-schema <path> --env-exec-config <path>
+# ============================================================

--- a/.agents/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.agents/skills/case-studies/configs/agentic_search_eval.yaml
@@ -623,6 +623,22 @@ tests:
   # discover content by searching and reading.
   #
   # Requires: --env-backend local --env-tool-schema --env-exec-config
+  #
+  # ⚠️  DATA CONTAMINATION WARNING
+  #
+  # These fixture documents and questions MUST NOT overlap with your
+  # training data. If the model saw these exact docs or questions
+  # during training, evaluation measures memorization, not capability.
+  #
+  # Best practices:
+  #   - Use a held-out document set that was never in training
+  #   - Or generate fresh questions from the fixture environment
+  #     (e.g., have a teacher model write questions about the fixture
+  #     docs, then use those questions here)
+  #   - Never reuse SynthChat-generated training corpora as eval
+  #     fixtures — write new content or use a different domain
+  #   - The fixture docs below are EXAMPLES — replace them with
+  #     your own held-out content before trusting eval results
   # ================================================================
 
   # ------------------------------------------------------------------

--- a/.agents/skills/case-studies/configs/agentic_search_rubrics.yaml
+++ b/.agents/skills/case-studies/configs/agentic_search_rubrics.yaml
@@ -1,0 +1,463 @@
+# =============================================================================
+# AGENTIC SEARCH RUBRICS — TEMPLATE BUNDLE
+# =============================================================================
+#
+# PURPOSE
+#   Three rubric definitions for evaluating agentic search quality in training
+#   examples where a model must: (1) choose search terms, (2) select documents
+#   to read, and (3) produce a grounded answer from what it read.
+#
+# HOW TO USE
+#   1. Copy the rubric you need into SynthChat/rubrics/<rubric_name>.yaml
+#   2. Customize the judge/improver prompts for your domain and tool schema
+#   3. Run:  python -m SynthChat.services.rubric_runner --list
+#      to confirm your rubric is detected
+#
+# TOOL AGNOSTICISM
+#   These rubrics are intentionally generic. They evaluate BEHAVIOR — what was
+#   searched for, what was opened, what was claimed — not the names or schemas
+#   of specific tools. Whether your pipeline uses searchManager, a RAG
+#   retriever, grep, an MCP tool, or any other search interface, the quality
+#   criteria are the same:
+#
+#     - Did the search terms target the right vocabulary?
+#     - Did the model read the right documents?
+#     - Is the final answer faithful to what the documents actually say?
+#
+#   When you copy a rubric into SynthChat/rubrics/, replace the generic
+#   references (e.g., "search actions", "read actions") with your tool-
+#   specific field names if you want structural validations to fire.
+#
+# AVAILABLE TEMPLATE VARIABLES (for judge/improver prompts)
+#   {current_content}       — The content being evaluated (scoped by rubric scope)
+#   {system_prompt}         — Full system prompt from the training example
+#   {user_request}          — The user's message / question
+#   {assistant_response}    — The assistant's full response
+#   {feedback}              — Judge feedback (improver prompts only)
+#   {thinking_content}      — Thinking block content (if present)
+#   {original_tool_calls}   — Raw tool calls JSON (if present)
+#
+# =============================================================================
+
+
+# =============================================================================
+# RUBRIC 1: search_term_quality
+# =============================================================================
+
+name: Search Term Quality
+description: >
+  Evaluates whether the search terms the model chose would actually surface
+  the target documents in a keyword or grep-style search. Penalizes terms
+  that are too broad, too narrow, or that parrot the user's exact phrasing
+  when the underlying documents use different vocabulary.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating the SEARCH TERMS an assistant chose when answering a
+  user question. The assistant issued one or more search actions before
+  reading documents. Your job is to judge whether those search terms would
+  realistically surface the documents that contain the answer.
+
+  **Tool Calls (containing search actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  # INSTRUCTIONS
+  Examine every search term or query string the assistant used and evaluate
+  along these dimensions:
+
+  1. **Vocabulary match**: Do the search terms use words and phrases that
+     are likely to appear in the target documents? Domain-specific jargon,
+     abbreviations, and canonical names score higher than generic synonyms.
+
+  2. **Specificity**: Are the terms specific enough to filter out irrelevant
+     results? A single common word like "config" is too broad; a phrase like
+     "training learning rate schedule" is appropriately targeted.
+
+  3. **Coverage**: If the answer spans multiple topics or documents, did the
+     assistant issue enough distinct searches to cover the needed ground?
+
+  4. **Avoiding echo**: Did the assistant blindly copy the user's exact
+     question as a search query? Good search reformulates the question into
+     terms the documents are likely to contain. For example, if the user asks
+     "How do I make the model learn faster?" a good search uses terms like
+     "learning_rate" or "lr_scheduler", not "make model learn faster".
+
+  5. **Iteration awareness**: If the first search returned poor results and
+     the assistant searched again, did it adjust terms meaningfully or just
+     repeat the same query?
+
+  # SCORING
+  - **1.0** = Terms are well-chosen: domain-appropriate vocabulary, specific
+    enough to filter noise, cover the needed topics, reformulated from user
+    phrasing into document vocabulary
+  - **0.7-0.9** = Mostly good terms with minor issues (slightly too broad,
+    one redundant search, partial echo of user phrasing)
+  - **0.4-0.6** = Terms are mediocre: overly generic, echo user phrasing
+    without reformulation, or miss an important topic
+  - **0.0-0.3** = Terms are poor: would not surface target docs, completely
+    wrong vocabulary, or no search was performed at all
+
+  # FORMAT
+  Return JSON: {"searchtermquality_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the search terms an assistant used when answering a
+  user question. The judge found issues with the original search terms.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. Search terms use vocabulary that matches the target documents, not the
+     user's exact phrasing
+  2. Terms are specific enough to filter irrelevant results but not so
+     narrow that they miss relevant documents
+  3. Multiple searches cover all topics needed to answer the question
+  4. If the system prompt describes the corpus structure (folders, file
+     names, tags), use that knowledge to craft targeted queries
+
+  Preserve the original tool call structure and format. Only change the
+  search query strings and add/remove search actions as needed.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    searchtermquality_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - searchtermquality_score
+
+validations:
+  # Verify that at least one tool call exists (the model should be searching)
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should issue search actions before answering"
+
+
+# =============================================================================
+# RUBRIC 2: doc_selection
+# =============================================================================
+
+---
+name: Document Selection
+description: >
+  Evaluates whether the model selected the right documents to read after
+  searching. Penalizes reading too few documents (incomplete answer), reading
+  too many (inefficient), skipping relevant results, or falling for distractor
+  documents that match keywords but are irrelevant.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating which documents the assistant chose to READ (open, fetch,
+  or retrieve full content) after performing search actions. Your job is to
+  judge whether the selection was appropriate for answering the user's question.
+
+  **Tool Calls (containing search and read actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  # INSTRUCTIONS
+  Examine the sequence of tool calls to identify which documents were read
+  (opened, fetched, retrieved) and evaluate along these dimensions:
+
+  1. **Relevance**: Did the assistant read documents that actually contain
+     information needed to answer the question? Cross-reference the user's
+     question, the system prompt's description of available content, and what
+     the assistant ultimately said in its response.
+
+  2. **Distractor avoidance**: Did the assistant skip documents that share
+     keywords with the question but contain irrelevant content? For example,
+     a file called "training_logs.md" might match a search for "training"
+     but be irrelevant if the user asked about training configuration.
+
+  3. **Sufficiency**: Did the assistant read ENOUGH documents to fully answer
+     the question? If the answer requires information from three documents
+     and only one was read, that is insufficient.
+
+  4. **Efficiency**: Did the assistant avoid reading everything blindly? If
+     10 results were returned and only 2 are relevant, reading all 10 is
+     wasteful. Reading 2-3 targeted documents is efficient.
+
+  5. **Progressive narrowing**: If the assistant read one document and then
+     decided to read more, was that decision reasonable based on what the
+     first document contained?
+
+  # SCORING
+  - **1.0** = Read exactly the right documents: all relevant docs included,
+    distractors skipped, efficient selection
+  - **0.7-0.9** = Good selection with minor issues (one unnecessary read,
+    or one mildly relevant doc skipped)
+  - **0.4-0.6** = Mediocre selection: missed an important document, read
+    several distractors, or read everything without filtering
+  - **0.0-0.3** = Poor selection: missed the key document entirely, read
+    only distractors, or did not read any documents at all
+
+  # FORMAT
+  Return JSON: {"docselection_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the document selection in an assistant's tool call
+  sequence. The judge found issues with which documents were read.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. The assistant reads documents that contain information needed to answer
+     the question (check the system prompt for clues about document content)
+  2. Distractor documents with misleading names are skipped
+  3. The selection is sufficient — enough documents are read to fully answer
+     the question
+  4. The selection is efficient — no unnecessary reads of clearly irrelevant
+     documents
+  5. Search actions remain the same (or are only adjusted if the original
+     searches could not have surfaced the right documents)
+
+  Preserve the original tool call structure and format. Add or remove read
+  actions as needed, and reorder if the sequence matters.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    docselection_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - docselection_score
+
+validations:
+  # Verify that at least one read/fetch action exists
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should read documents before answering"
+
+
+# =============================================================================
+# RUBRIC 3: groundedness
+# =============================================================================
+
+---
+name: Groundedness
+description: >
+  Evaluates whether the assistant's final answer is faithful to the content
+  of the documents it read. Penalizes fabricated claims, meaning-altering
+  paraphrases, and failure to acknowledge when documents do not cover a topic.
+scope: response
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating whether the assistant's response is GROUNDED in the
+  documents it read. Every factual claim in the response should be traceable
+  to a specific passage in the retrieved content. The assistant should not
+  invent information, and should explicitly say when it cannot find something.
+
+  **Assistant Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Thinking Block (if present):**
+  ```
+  {thinking_content}
+  ```
+
+  # INSTRUCTIONS
+  Evaluate the response along these dimensions:
+
+  1. **Traceability**: Can every factual claim (names, numbers, dates,
+     procedures, configurations) be traced back to a specific passage in the
+     documents the assistant read? Claims that appear in the response but not
+     in any read document are hallucinations.
+
+  2. **No added information**: Does the response avoid introducing facts,
+     details, or context not present in the documents? General knowledge
+     framing ("This is a common pattern...") is acceptable; specific claims
+     ("The default learning rate is 2e-4") must come from the documents.
+
+  3. **Faithful paraphrasing**: When the response paraphrases document
+     content rather than quoting it, does the paraphrase preserve the
+     original meaning? Watch for subtle meaning shifts — e.g., changing
+     "recommended" to "required", or "up to 10" to "exactly 10".
+
+  4. **Appropriate uncertainty**: When the documents do not cover part of
+     the user's question, does the response acknowledge this gap? Phrases
+     like "I could not find information about X in the documents" are good.
+     Silently making up an answer is bad. Confidently stating something the
+     documents do not support is the worst case.
+
+  5. **No over-generalization**: Does the response avoid broadening specific
+     claims from the documents? If a document says "Feature X works with
+     model Y," the response should not claim "Feature X works with all
+     models" unless the document supports that.
+
+  # SCORING
+  - **1.0** = Every claim is traceable to the documents, gaps are
+    acknowledged, paraphrasing is faithful, no added information
+  - **0.7-0.9** = Mostly grounded with minor issues (one slightly loose
+    paraphrase, a minor added detail that is broadly correct)
+  - **0.4-0.6** = Several ungrounded claims, or one significant fabrication,
+    or fails to acknowledge a gap in document coverage
+  - **0.0-0.3** = Major fabrications: invents key facts, contradicts the
+    documents, or confidently answers questions the documents do not address
+
+  # FORMAT
+  Return JSON: {"groundedness_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving an assistant's response to ensure it is grounded in the
+  documents that were read. The judge found issues with faithfulness.
+
+  **Current Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate an improved response where:
+  1. Every factual claim can be traced to a passage in the read documents
+  2. Remove or correct any claims not supported by the documents
+  3. Where the documents do not cover part of the user's question, explicitly
+     state that: "I was not able to find information about [topic] in the
+     available documents"
+  4. Preserve the helpful structure and tone of the original response
+  5. If the original response paraphrased something in a way that changed
+     its meaning, fix the paraphrase to be faithful to the source
+  6. Do not add new information from outside the documents — only use what
+     the assistant actually retrieved
+
+  Output ONLY the improved response text.
+
+output_schema:
+  type: object
+  properties:
+    groundedness_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - groundedness_score
+
+validations:
+  # Verify the response is not empty
+  - match: '\S+'
+    type: regex
+    error: "Response is empty — the assistant must provide an answer after reading documents"

--- a/.agents/skills/case-studies/configs/agentic_search_scenario.yaml
+++ b/.agents/skills/case-studies/configs/agentic_search_scenario.yaml
@@ -1,0 +1,438 @@
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  AGENTIC SEARCH — Scenario Template                            ║
+# ║                                                                ║
+# ║  BEFORE USING: Replace placeholder tool names with YOUR tools  ║
+# ║                                                                ║
+# ║  Placeholders:                                                 ║
+# ║    YOUR_SEARCH_TOOL  → e.g., grep, ripgrep, searchAPI, etc.   ║
+# ║    YOUR_READ_TOOL    → e.g., cat, readFile, fetchDoc, etc.    ║
+# ║    YOUR_LIST_TOOL    → e.g., ls, listFiles, dirList, etc.     ║
+# ║                                                                ║
+# ║  The three-stage pattern (search → read → answer) is the      ║
+# ║  constant. The actual tools are YOUR choice.                   ║
+# ║                                                                ║
+# ║  Run with --env-tool-schema and --env-exec-config to provide   ║
+# ║  your tool definitions.                                        ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+# ---------------------------------------------------------------------------
+# Shared anchors — reused across all agentic search scenarios
+# ---------------------------------------------------------------------------
+
+shared_agentic_environment: &shared_agentic_environment
+  loop:
+    enabled: true
+    mode: agentic
+    max_turns: 6
+    max_tool_steps: 6
+    stop_on_text_response: true
+    require_final_text_after_pass: true
+    final_text_prompt: Reply to the user with a concise answer grounded in the documents you read. Do not call tools.
+    continue_on_execution_error: true
+    stuck_repeat_limit: 2
+    no_progress_window: 3
+
+shared_tutored_judge: &shared_tutored_judge
+  in_loop:
+    enabled: true
+    feedback_visible_to_model: true
+    temperature: 0.1
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    prompt: |
+      You are tutoring an agentic search assistant generating high-quality training data.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      Messages so far:
+      {messages_json}
+
+      Latest assistant response:
+      {assistant_response_json}
+
+      Latest environment step:
+      {environment_step_json}
+
+      Tool feedback shown to the model:
+      {tool_feedback}
+
+      Evaluate the assistant on three dimensions:
+      1. SEARCH QUALITY — Did it generate effective search terms that surface the
+         target documents without being so broad that distractors dominate?
+      2. SELECTIVE READ — Did it read the correct documents and skip irrelevant
+         results? Did it avoid reading every result indiscriminately?
+      3. ANSWER GROUNDEDNESS — Is the answer derived from document content only?
+         Flag any claim not traceable to a read document.
+
+      Treat task_context fields as the source of truth for which documents are
+      targets vs. distractors. Do not accept a distractor document as a valid
+      source even if its content seems related.
+
+      Return passed=true only if the hard requirements are already satisfied by
+      the latest assistant action and tool feedback. If any hard requirement is
+      still unmet, return passed=false and explain the next best corrective step.
+
+      Use feedback_to_model for concise tutoring about the next best move.
+      Only ask for a short final text-only answer after the hard requirements
+      are actually satisfied.
+
+shared_environment_generation_review: &shared_environment_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: environment_payload_shape
+      field: value
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated knowledge base environment for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Normalized environment snapshot:
+      {value_json}
+
+      Return passed=true only if the environment:
+      - Contains 15-20 documents across 3-5 distinct topic areas
+      - Has realistic document content (multi-paragraph, not just titles or stubs)
+      - Includes deliberate distractors: documents with overlapping keywords but
+        different topics that could mislead a naive search
+      - Spreads some answers across multiple files to support multi-hop retrieval
+      - Does not make target documents trivially identifiable by filename alone
+      - Is internally consistent (cross-references between docs are valid)
+
+      Penalize environments that are too sparse, have uniform document lengths,
+      or contain documents that are obviously fake (lorem ipsum, placeholder text).
+
+shared_user_generation_review: &shared_user_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: non_empty_text
+      field: text
+    - type: plain_text
+      field: text
+    - type: no_tool_names
+      field: text
+    - type: no_exact_paths_from_context
+      field: text
+      sources: [task_context]
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated user question for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      User text:
+      {user_text}
+
+      Return passed=true only if:
+      - The question sounds like a real human asking for information
+      - It does NOT leak exact file paths, document IDs, or tool names
+      - It does NOT contain search terms that would trivially match only the
+        target document (the assistant must figure out effective search terms)
+      - It is specific enough that there IS a correct answer in the corpus
+      - For multi-hop scenarios, the question naturally requires synthesizing
+        information from multiple sources
+
+shared_final_review: &shared_final_review
+  enforce: true
+  gates:
+    - type: field_equals
+      field: environment_passed
+      value: true
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a completed agentic search training example.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Final environment result:
+      {environment_result_json}
+
+      Final assistant response:
+      {assistant_response_json}
+
+      Conversation trace:
+      {conversation_trace_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      If environment_result.passed is true, treat the hard requirements as already
+      satisfied by the programmatic environment validator. Do not override that by
+      re-inferring document contents from earlier tool traces.
+
+      In that case, judge only whether this is a high-quality training example:
+      - The search strategy was reasonable (not brute-force read-everything)
+      - The assistant selected the right documents and skipped distractors
+      - The final answer is grounded in document content with no hallucination
+      - The trajectory is coherent and the tutor feedback is sensible
+      - The ending response is a natural answer to the user question
+
+      If environment_result.passed is false, then passed must be false.
+
+shared_assistant_generation: &shared_assistant_generation
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+scenarios:
+
+  # =========================================================================
+  # SEED: Generate a realistic knowledge base for search scenarios
+  # =========================================================================
+  agentic_search_corpus_seed:
+    type: helper
+    environment_mode: generated
+    system_context:
+      available_workspaces:
+        - id: ws_search_corpus
+          name: Knowledge Base
+          description: A document corpus reused across agentic search workflows
+          root_folder: ""
+      selected_workspace:
+        id: default
+        name: Knowledge Base
+      assistant_instructions: >-
+        This seed corpus should support single-document retrieval, multi-hop
+        retrieval across documents, keyword-based search with distractors,
+        selective reading from mixed results, and grounded answer generation.
+    environment_generation:
+      <<: *shared_environment_generation_review
+      schema: canonical_environment
+      prompt: |
+        Generate one shared knowledge base that will be reused across agentic search scenarios.
+
+        Requirements:
+        - Create 15-20 documents organized across 3-5 topic areas as top-level folders.
+          Example topic areas: Engineering, Operations, Product, Research, Policies.
+          Choose your own realistic topic names and vary them across seeds.
+        - Each document must have realistic multi-paragraph content (3-8 paragraphs).
+          Think internal wiki pages, runbooks, design docs, meeting summaries, or
+          policy documents. Do not generate stubs, placeholder text, or lorem ipsum.
+        - Deliberate DISTRACTORS are critical:
+          - At least 3 documents must share keywords with a target document but
+            cover a different topic. For example, a doc about "rate limiting in
+            the CDN layer" vs. "rate limiting in the payment API" — same keyword
+            "rate limiting", different answers.
+          - At least 2 documents must have similar titles but different content.
+        - MULTI-HOP support:
+          - At least 2 answers must require combining information from 2+ documents.
+            For example, Document A says "the migration deadline is in Q3" and
+            Document B says "Q3 runs July-September" — answering "when is the
+            migration deadline?" requires both.
+          - Cross-references between documents are encouraged (e.g., "see the
+            deployment runbook for details").
+        - Include a mix of document types:
+          - Narrative docs (design docs, postmortems, meeting notes)
+          - Structured docs (runbooks with numbered steps, config references)
+          - Short docs (1-2 paragraphs) and long docs (6-8 paragraphs)
+        - Add 3-5 extra distractor files with plausible but tangential content so
+          different seeds are not clones.
+        - Vary filenames, topics, writing styles, and organizational structure
+          across seeds while preserving the role coverage above.
+        - Return environment.assertions as an empty list.
+        - Put seed-specific metadata under task_context: seed_theme,
+          distractor_paths, multi_hop_pairs, and topic_areas.
+    prompts:
+      user: ""
+      assistant: ""
+
+  # =========================================================================
+  # STAGE 1+2+3: Search, selectively read, and answer from documents
+  # =========================================================================
+  agentic_search_find_and_answer:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: search_and_answer
+      primitives: [search, read]
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        examples:
+          - "What's our policy on handling third-party API outages?"
+          - "How do we handle database failovers in production?"
+          - "What was decided about the authentication redesign?"
+      candidate_selector:
+        target:
+          min_content_length: 200
+          preferred_keywords_from: task_context
+          must_contain_answer: true
+        distractors:
+          share_keywords_with_target: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that can be answered
+        from the knowledge base. Do not mention file names, paths, or tool names.
+        Phrase it the way a colleague would ask over chat.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        First use YOUR_SEARCH_TOOL to find relevant documents, then use YOUR_READ_TOOL
+        to read the most promising results. Skip documents that are clearly irrelevant
+        based on search result summaries. After reading, provide a grounded answer.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response
+
+  # =========================================================================
+  # MULTI-HOP: Answer requires combining info from 2+ documents
+  # =========================================================================
+  agentic_search_multi_hop:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, multi_hop, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_1_path}"
+        - type: file_was_read
+          path: "{task_target_doc_2_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_combined_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+        - type: response_contains_text
+          text: "{task_doc_1_contribution}"
+        - type: response_contains_text
+          text: "{task_doc_2_contribution}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. Some
+        questions require combining information from multiple documents. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: multi_hop_search
+      primitives: [search, read]
+      min_source_docs: 2
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        requires_synthesis: true
+        examples:
+          - "When exactly is the migration deadline and what needs to be done before then?"
+          - "Which team owns the rate limiter and what's their on-call rotation?"
+          - "What's the budget impact of the infrastructure changes planned for next quarter?"
+      candidate_selector:
+        target_pair:
+          doc_1:
+            contains_partial_answer: true
+            preferred_keywords_from: task_context
+          doc_2:
+            contains_complementary_answer: true
+            cross_references_doc_1: preferred
+        distractors:
+          share_keywords_with_targets: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that requires combining
+        information from at least two different documents. The question should sound
+        like a single coherent inquiry, not two separate questions joined together.
+        Do not mention file names, paths, or tool names.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        Use YOUR_SEARCH_TOOL to find relevant documents. You may need multiple searches
+        with different terms. Use YOUR_READ_TOOL to read documents that look relevant.
+        Synthesize information from multiple documents into a single coherent answer.
+        Cite which documents contributed which facts when the answer draws from
+        multiple sources.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response

--- a/.agents/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.agents/skills/case-studies/reference/agentic-search-pipeline.md
@@ -295,8 +295,9 @@ presets:
     tags: [search, grounding, rag]
 ```
 
-### Run Evaluation
+### Two Evaluation Modes
 
+**Static mode** — corpus in the system prompt, quick behavioral check:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
@@ -305,6 +306,21 @@ python -m Evaluator.cli \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
 ```
+
+**Runtime mode** — real files, actual tool execution via agentic loop:
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search_runtime \
+  --env-backend local \
+  --env-tool-schema path/to/your_tool_schema.yaml \
+  --env-exec-config path/to/your_exec_rules.yaml \
+  --output Evaluator/results/agentic_search_runtime_v1.json \
+  --markdown Evaluator/results/agentic_search_runtime_v1.md
+```
+
+> **Do not train to the test.** The runtime eval fixtures (documents and questions) must NOT overlap with your training data. If the model saw these exact docs during SynthChat generation, the eval measures memorization, not capability. Use a held-out document set, or generate fresh questions from the fixture environment with a teacher model. The example fixtures in the template are placeholders — replace them with your own held-out content before trusting results.
 
 ### Key Metrics
 

--- a/.agents/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.agents/skills/case-studies/reference/agentic-search-pipeline.md
@@ -1,0 +1,403 @@
+# Case Study: Agentic Search (RAG Agent) Training Pipeline
+
+A complete walkthrough of how to teach a language model to act as a RAG agent — searching a corpus, selecting relevant documents, and answering questions grounded exclusively in what it found.
+
+---
+
+> **YOUR TOOLS ARE NOT OUR TOOLS**
+>
+> This case study describes a **three-stage pattern**: Search, Select, Answer. The tool names used below (`YOUR_SEARCH_TOOL`, `YOUR_READ_TOOL`, `YOUR_LIST_TOOL`) are **placeholders**. Your system might use `grep`, `ripgrep`, a vector DB query, `cat`, `readFile`, an HTTP API, or something else entirely.
+>
+> **Before you proceed past Stage 1, you must know:**
+> 1. What tool does "search" in your system?
+> 2. What tool does "read" in your system?
+> 3. What tool does "list" in your system?
+>
+> The three-stage behavior is the constant. The tools are variables.
+
+---
+
+## Stage 1: Define the Capability
+
+### What We're Teaching
+
+The model must learn a three-stage behavior loop:
+
+1. **Search** — given a question, generate search terms that would surface target documents in a keyword/grep-style search. The model must reason about vocabulary: what words would the answer contain?
+2. **Selective Read** — from the search results, pick the relevant documents and skip distractors. Not everything returned is useful. The model must show judgment.
+3. **Grounded Answer** — answer using ONLY content from the documents it read. No hallucination. If the docs don't contain the answer, say so.
+
+### How This Differs from the Other Case Studies
+
+| Dimension | Tool Calling | Essay Style | Agentic Search |
+|-----------|-------------|-------------|----------------|
+| Goal | Call the right API | Produce creative output | Find and synthesize from sources |
+| Output | Structured JSON | Structured prose | Grounded prose with citations |
+| Tools are... | The end product | Not involved | The means to an end |
+| Validation | Schema match | Rubric scoring | Retrieval recall + groundedness |
+| Key challenge | Syntax precision | Voice preservation | Search strategy + no hallucination |
+
+Tool calling trains a model to use tools correctly. Agentic search trains a model to use tools *strategically* — the tools are a means to producing a grounded answer.
+
+### Inspiration: Explore, Verify, Extend
+
+The data generation pattern draws from Chroma's Context-1 approach: generate a seed corpus, then create training examples where the model must explore (search), verify (read and confirm), and extend (synthesize an answer). Our corpus is generated per-seed via the environment backend rather than pre-indexed, and evaluation is YAML-driven through the existing Evaluator.
+
+### The Three Rubrics
+
+Quality is governed by three rubrics, one per stage:
+
+| Rubric | Stage | What It Checks |
+|--------|-------|---------------|
+| `search_term_quality` | Search | Are the terms specific enough to retrieve target docs? Do they account for vocabulary mismatch? |
+| `doc_selection` | Select | Did the model read relevant docs and skip distractors? Precision and recall. |
+| `groundedness` | Answer | Is every claim traceable to a document? Does it say "not found" when appropriate? |
+
+---
+
+## Stage 2: Create Training Data
+
+### Prerequisites: Confirm Your Tools
+
+> **STOP.** Before writing any scenarios or generating any data, you must map the three-stage pattern to your actual tools.
+
+Define your tool mapping:
+
+| Stage | Placeholder | Your Tool | Example |
+|-------|------------|-----------|---------|
+| Search | `YOUR_SEARCH_TOOL` | ___________ | `grep`, `searchContent`, `vector_query` |
+| Read | `YOUR_READ_TOOL` | ___________ | `cat`, `read`, `fetchDocument` |
+| List | `YOUR_LIST_TOOL` | ___________ | `ls`, `list`, `listDirectory` |
+
+Once you know your tools, create the tool schema and environment execution config that match your system. The scenario YAML references these tools by name — they must match exactly.
+
+### Corpus Design
+
+The environment backend generates the corpus automatically for each training example. A good corpus has:
+
+- **Varied topics** — not all docs about the same thing
+- **Overlapping vocabulary** — docs sharing keywords but covering different topics (forces precise search)
+- **Deliberate distractors** — docs that look relevant but aren't (forces selective reading)
+- **Multi-hop potential** — answers requiring info from 2+ documents
+
+The seed scenario's `environment_generation.prompt` controls corpus shape. Customize it for your domain. Compare to Context-1's domain-specific corpora (web, SEC, patents, email) — same principle: realistic documents with realistic noise.
+
+### Scenario Types
+
+The scenario file defines three scenario types that build on each other:
+
+**1. Seed scenarios** — generate the corpus and a simple single-doc question:
+```yaml
+scenarios:
+  agentic_search_seed:
+    type: tool
+    environment_mode: generated
+    system_template: mocked_workspace_vault
+    rubrics:
+      response: [search_term_quality, doc_selection, groundedness]
+    environment_generation:
+      prompt: |
+        Generate a workspace with 5-8 documents across 2-3 topics.
+        Include 2 distractors per topic that share vocabulary but
+        cover different aspects. One document must contain the answer
+        to a factual question that requires reading (not guessing).
+```
+
+**2. Find-and-answer scenarios** — question requires searching, reading one doc, answering:
+The model must: search with good terms, pick the right doc from results, answer from its content only.
+
+**3. Multi-hop scenarios** — answer requires info from 2+ documents:
+The model must: search, read doc A, recognize it's incomplete, search again or read doc B, synthesize.
+
+### Running Generation
+
+Copy your scenario file into place and generate:
+
+```bash
+# Copy scenario (after replacing YOUR_SEARCH_TOOL etc. with real tool names)
+cp .skills/case-studies/configs/agentic_search_scenario.yaml \
+   SynthChat/scenarios/agentic_search.yaml
+
+# Dry run — check 3 examples without saving
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --count 3 \
+  --dry-run
+
+# Full generation
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --workers 4 \
+  --output Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Example Training Conversation
+
+Tool names below are placeholders — substitute your own:
+
+```
+system: [workspace context with corpus file listing]
+user:   "What's the maximum retry count for the payment service?"
+assistant:
+  <thinking>I should search for payment service configuration.</thinking>
+  [calls YOUR_SEARCH_TOOL with terms: "payment retry max"]
+tool:   [returns: payment_config.md, payment_overview.md, retry_policy.md]
+assistant:
+  <thinking>payment_config.md and retry_policy.md look relevant.
+  payment_overview.md is a high-level summary — skip it.</thinking>
+  [calls YOUR_READ_TOOL on payment_config.md]
+tool:   [returns file content with "max_retries: 5"]
+assistant:
+  Based on payment_config.md, the maximum retry count for the payment
+  service is **5** (configured via `max_retries: 5` in the service config).
+```
+
+All three stages visible: targeted search terms, selective reading (skipped the overview), grounded answer with citation.
+
+---
+
+## Stage 3: Validate & Improve
+
+### Structural Validation
+
+```bash
+python3 .skills/synethetic-data-generation/scripts/validate_syngen.py \
+  Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Rubric-Based Quality Validation
+
+Copy rubric files into place, then validate:
+
+```bash
+# Copy rubrics (one file per rubric)
+cp .skills/case-studies/configs/agentic_search_rubrics/*.yaml \
+   SynthChat/rubrics/
+
+# Validate a small batch
+python -m SynthChat.run validate \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --start-line 1 --end-line 10
+```
+
+**Search term quality:** Specific to the question? Account for vocabulary mismatch? Would plausibly retrieve the target doc? Not too broad or too narrow?
+
+**Document selection:** Read the doc(s) containing the answer? Skipped distractors? Avoided reading every single result?
+
+**Groundedness:** Every claim traceable to a document? No added information? Says "not found" when docs lack the answer? Citations present?
+
+### Improvement Loop
+
+```bash
+python -m SynthChat.run improve \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --max-iterations 5
+```
+
+### Manual Review
+
+Sample 10-20%: Do search terms feel human? Is reading selective? Can you verify the answer from the cited doc? For multi-hop, does the model actually combine info?
+
+---
+
+## Stage 4: Train
+
+### Training Sequence
+
+```
+SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
+      ↓                        ↓                        ↓
+  Search→Read→Answer     Good vs bad search      Reward = did you find it?
+```
+
+### SFT: Teaching the Search-Read-Answer Loop
+
+**Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
+
+```bash
+cd Trainers/rtx3090_sft
+
+python train_sft.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_sft.jsonl \
+  --num-epochs 3 \
+  --learning-rate 2e-4
+```
+
+**What SFT learns:**
+- The three-stage loop structure (search → select → answer)
+- How to generate effective search terms from a question
+- How to decide which results to read (and which to skip)
+- How to ground answers in document content
+- When to say "I couldn't find that information"
+
+### KTO: Teaching Search Judgment
+
+**Dataset:** Interleaved true/false pairs. Same question, contrasting quality.
+
+Negative examples come naturally from rubric failures during validation:
+- **Bad search terms** (too broad, wrong vocabulary) → `label: false`
+- **Reading everything** instead of selecting → `label: false`
+- **Hallucinated answers** that go beyond what the docs say → `label: false`
+- **Missed answers** where the model says "not found" but the doc was there → `label: false`
+
+```bash
+cd Trainers/rtx3090_kto
+
+python train_kto.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_kto.jsonl \
+  --num-epochs 1 \
+  --learning-rate 1e-6
+```
+
+**What KTO learns:**
+- Prefer specific search terms over generic ones
+- Prefer selective reading over reading everything
+- Prefer grounded answers over hallucinated ones
+- Prefer "not found" over fabricated answers
+
+### GRPO: Optimizing Retrieval Reward (Optional)
+
+GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
+
+```bash
+cd Trainers/rtx3090_grpo
+# Set model.lora_path to KTO checkpoint in configs/config.yaml
+python train_grpo.py
+```
+
+**Reward signal:** Binary retrieval recall. The environment backend re-executes the search and checks whether the target doc appeared. 1.0 if yes, 0.0 if no.
+
+---
+
+## Stage 5: Evaluate
+
+### Setup
+
+Copy evaluation scenarios and add a preset:
+
+```bash
+# Copy eval scenarios
+cp .skills/case-studies/configs/agentic_search_eval.yaml \
+   Evaluator/config/scenarios/agentic_search.yaml
+```
+
+Add the preset to `Evaluator/config/eval_run.yaml`:
+
+```yaml
+presets:
+  agentic_search:
+    scenarios:
+      - agentic_search.yaml
+    tags: [search, grounding, rag]
+```
+
+### Run Evaluation
+
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search \
+  --output Evaluator/results/agentic_search_v1.json \
+  --markdown Evaluator/results/agentic_search_v1.md
+```
+
+### Key Metrics
+
+| Metric | What It Measures | Target |
+|--------|-----------------|--------|
+| Search hit rate | Did the search terms retrieve the target doc? | > 80% |
+| Doc selection precision | Of docs read, how many were relevant? | > 70% |
+| Doc selection recall | Of relevant docs, how many were read? | > 90% |
+| Groundedness score | Are all claims traceable to sources? | > 85% |
+| "Not found" accuracy | When docs lack the answer, does the model say so? | > 75% |
+
+### Status Meanings
+
+| Status | Meaning |
+|--------|---------|
+| **PASS** | Found the right docs AND answered with grounding |
+| **WARN** | Found docs but answer has minor grounding issues (KTO signal) |
+| **FAIL** | Wrong docs, hallucinated answer, or missed available answer |
+
+---
+
+## Stage 6: Iterate
+
+### Common Failure Patterns
+
+| Failure | Root Cause | Fix |
+|---------|-----------|-----|
+| Bad search terms (too generic) | Not enough vocabulary-mismatch training | Add scenarios where the question uses different words than the doc |
+| Reads everything instead of selecting | Not enough distractor-heavy scenarios | Add corpora with 3-4 distractors per relevant doc |
+| Hallucinating beyond docs | Insufficient groundedness training | Add KTO negatives where the answer adds plausible-but-absent facts |
+| Missing multi-hop answers | Too few multi-hop scenarios | Add scenarios requiring info from 2+ docs to form a complete answer |
+| Never says "not found" | All training examples have answers | Add scenarios where the corpus genuinely lacks the answer |
+| Searches when answer is in context | Model always follows the loop mechanically | Add examples where the system prompt already contains enough info |
+
+### The Iteration Loop
+
+```
+Evaluate → Identify weakest metric → Generate targeted data → Retrain → Re-evaluate
+    ↑                                                                         │
+    └─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Priority order for iteration:**
+1. Groundedness (most important — hallucination is the worst failure)
+2. Search hit rate (can't answer if you can't find)
+3. Doc selection (efficiency and precision)
+4. Multi-hop (hardest capability, iterate last)
+
+---
+
+## Comparison to Context-1
+
+| Aspect | Context-1 (Chroma) | This Pipeline |
+|--------|-------------------|---------------|
+| Corpus | Pre-indexed domain corpora (web, SEC, patents, email) | Generated per-seed via environment backend |
+| Data pattern | Explore → verify → extend | Search → select → answer (same idea, different names) |
+| RL reward | Retrieval recall (CISPO) | Retrieval recall via GRPO (same signal) |
+| Context pruning | Trained as a separate capability | Not included (train separately if needed) |
+| Parallel tool calls | Part of training | Not included (train separately if needed) |
+| Evaluation | Custom harness | YAML-driven Evaluator with presets |
+| Simplification | Full production pipeline | Focused on the three-stage core |
+
+**What we borrowed:** The explore-verify-extend pattern for data generation, and verifiable retrieval rewards for RL.
+
+**What we simplified:** No context pruning (separate capability, separate training), no parallel tool calls (train via the tool-calling pipeline first).
+
+**What's different:** Corpus generated fresh per seed (easier to control difficulty/coverage). YAML-driven Evaluator shared with every other capability.
+
+---
+
+## File Map
+
+```
+.skills/case-studies/configs/agentic_search_*.yaml  ← Template configs to copy
+SynthChat/scenarios/agentic_search.yaml             ← Generation scenario (after copy)
+SynthChat/rubrics/search_term_quality.yaml          ← Search quality rubric
+SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
+SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
+Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
+Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
+Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
+Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
+Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+```
+
+---
+
+## Cross-References
+
+| Stage | Skill for CLI Details |
+|-------|----------------------|
+| Scenario authoring | `synethetic-data-generation` |
+| Rubric authoring | `synethetic-data-generation` (rubrics section) |
+| SFT / KTO / GRPO flags | `fine-tuning` |
+| Evaluator presets | `evaluation` |
+| Upload trained model | `upload-deployment` |

--- a/.claude/skills/case-studies/SKILL.md
+++ b/.claude/skills/case-studies/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: case-studies
-description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers two complete worked examples — tool-calling training and essay-style training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
+description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers three complete worked examples — tool-calling training, essay-style training, and agentic search (RAG agent) training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
 allowed-tools: Read, Bash, Write, Grep, Glob
 ---
 
 # Case Studies: Implementing the Training Pipeline
 
-Two end-to-end worked examples showing how to take a capability from concept to trained model.
+Three end-to-end worked examples showing how to take a capability from concept to trained model.
 
 ## Why Case Studies?
 
@@ -18,16 +18,17 @@ The other skills teach you how to use individual tools:
 
 This skill shows you **how they all connect** — the decisions, the iteration, and the order of operations that turn an idea into a trained capability.
 
-## The Two Case Studies
+## The Three Case Studies
 
 | Case Study | What It Teaches | Reference |
 |-----------|----------------|-----------|
 | **Tool Calling** | Structured output training — teaching a model to call APIs with correct syntax, context objects, and parameters | `reference/tool-calling-pipeline.md` |
 | **Essay Style** | Creative output training — teaching a model to transform messy brainstorms into structured outlines with voice and personality | `reference/essay-style-pipeline.md` |
+| **Agentic Search** | RAG agent training — teaching a model to search a corpus, select relevant documents, and answer grounded in sources | `reference/agentic-search-pipeline.md` |
 
 ## The Universal Pipeline
 
-Both case studies follow the same high-level pipeline, but diverge in dataset design and validation:
+All three case studies follow the same high-level pipeline, but diverge in dataset design and validation:
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -96,7 +97,8 @@ After evaluation, the failure analysis tells you exactly what to generate next. 
 |-----------|-------------|
 | **Tool Calling Pipeline** | Understanding the full tools training journey — from schema to trained model | `reference/tool-calling-pipeline.md` |
 | **Essay Style Pipeline** | Understanding the full essay training journey — from brainstorm to outline model | `reference/essay-style-pipeline.md` |
-| **Pipeline Comparison** | Side-by-side comparison of how the two pipelines differ at each stage | `reference/pipeline-comparison.md` |
+| **Agentic Search Pipeline** | Understanding the full RAG agent training journey — from corpus to grounded-answer model | `reference/agentic-search-pipeline.md` |
+| **Pipeline Comparison** | Side-by-side comparison of how the pipelines differ at each stage | `reference/pipeline-comparison.md` |
 
 ## Cross-References to Other Skills
 
@@ -114,5 +116,6 @@ At each stage of the pipeline, you'll use tools documented in the other skills:
 
 - Read the tool-calling case study first — it's the simpler, more mechanical pipeline
 - The essay case study shows how to adapt the pipeline for creative/subjective outputs
-- Both pipelines use the same trainers, evaluator, and upload tools — only the data differs
+- The agentic search case study shows how to train multi-step reasoning where tools are means to an end
+- All three pipelines use the same trainers, evaluator, and upload tools — only the data differs
 - When planning a new capability, map it to whichever case study is closer, then adapt

--- a/.claude/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.claude/skills/case-studies/configs/agentic_search_eval.yaml
@@ -2,29 +2,28 @@
 # AGENTIC SEARCH EVALUATION — TEMPLATE
 # ============================================================
 #
-# TOOL-AGNOSTIC: This template uses placeholder tool names.
-# You MUST customize before running:
+# TOOL-AGNOSTIC: Replace YOUR_SEARCH_TOOL / YOUR_READ_TOOL
+# with your actual tools before running.
 #
-#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
-#      (e.g., searchManager_searchContent, rag_search, etc.)
+# TWO EVALUATION MODES:
 #
-#   2. Replace YOUR_READ_TOOL with your actual document-read tool
-#      (e.g., contentManager_read, doc_reader, etc.)
+#   STATIC MODE (no --env-backend flag)
+#     Corpus embedded in system prompt. Tests whether the model
+#     knows HOW to search/read/answer. Quick, no extra setup.
+#     Run: python -m Evaluator.cli --preset agentic_search
 #
-#   3. If using environment-backed evaluation, supply:
-#        --env-tool-schema <path>    (tool JSON schemas)
-#        --env-exec-config <path>    (execution backend config)
-#
-#   4. Adapt the embedded corpus in each system prompt to your
-#      domain if desired. The default corpus is domain-neutral.
-#
-# Each test embeds a small self-contained corpus (3-5 short docs)
-# inside the system prompt so scenarios are portable and do not
-# require an external document store.
+#   RUNTIME MODE (--env-backend local)
+#     Real files in an isolated temp filesystem. Tool calls are
+#     ACTUALLY EXECUTED — search returns real matches, read
+#     returns real content. Tests real search-find-answer ability.
+#     Run: python -m Evaluator.cli --preset agentic_search_runtime \
+#       --env-backend local \
+#       --env-tool-schema path/to/your_tool_schema.yaml \
+#       --env-exec-config path/to/your_exec_config.yaml
 #
 # Tags: agentic_search, search_quality, grounding, multi_hop,
-#        distractor_resistance, no_answer
-# ID convention: AS_<description>
+#        distractor_resistance, no_answer, runtime
+# ID conventions: AS_* (static), ASR_* (runtime)
 # ============================================================
 
 name: Agentic Search Evaluation
@@ -615,38 +614,368 @@ tests:
       Including S3 in the answer is a failure. The s3-deep-dive doc is
       a distractor.
 
+  # ================================================================
+  # RUNTIME MODE TESTS (ASR_*)
+  #
+  # These tests use fixture-based filesystems and agentic loops.
+  # The model's tool calls are ACTUALLY EXECUTED against real files.
+  # The system prompt does NOT contain the corpus — the model must
+  # discover content by searching and reading.
+  #
+  # Requires: --env-backend local --env-tool-schema --env-exec-config
+  # ================================================================
+
+  # ------------------------------------------------------------------
+  # R1. Runtime: Single-doc lookup
+  # ------------------------------------------------------------------
+  - id: ASR_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/config-reference.md
+            body: |
+              # Data Loader Configuration Reference
+              The data loader supports batch sizes from 1 to 512. The default
+              batch size is 32. Set `batch_size` in loader.yaml to override.
+              Larger batch sizes require proportionally more GPU memory.
+          - path: docs/quickstart-guide.md
+            body: |
+              # Quick Start Guide
+              Install dependencies with `pip install -r requirements.txt`.
+              Run `python main.py` to start. See config-reference for tuning.
+          - path: docs/changelog-v2.md
+            body: |
+              # Changelog v2.0
+              Added streaming mode. Fixed memory leak in tokenizer.
+              Bumped minimum Python version to 3.10.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_single_doc_lookup. Model must actually search
+      and read files to find the answer (512). No corpus in system prompt.
+
+  # ------------------------------------------------------------------
+  # R2. Runtime: Multi-hop reasoning
+  # ------------------------------------------------------------------
+  - id: ASR_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-catalog.md
+            body: |
+              # Service Catalog
+              billing-service: Handles invoicing, payment processing, and
+              retry logic for failed transactions. Owner: see team-directory.
+              auth-service: SSO and token management. Owner: Platform team.
+              notification-service: Email and push alerts. Owner: Comms team.
+          - path: docs/team-directory.md
+            body: |
+              # Team Directory
+              Platform team: auth-service, infra-gateway.
+              Payments team: billing-service, refund-engine.
+              Comms team: notification-service, template-renderer.
+          - path: docs/oncall-schedule.md
+            body: |
+              # On-Call Schedule — Q1
+              Week 1: Platform team. Week 2: Payments team.
+              Week 3: Comms team. Week 4: rotate.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_hop_reasoning. Model must search for
+      payment retries → find billing-service → search for team owner →
+      find Payments team. Requires reading 2 documents minimum.
+
+  # ------------------------------------------------------------------
+  # R3. Runtime: Distractor resistance
+  # ------------------------------------------------------------------
+  - id: ASR_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/gateway-config.md
+            body: |
+              # API Gateway Configuration
+              The gateway forwards requests to backend services. Default
+              timeout: 30 seconds. Override with `gateway.timeout_ms` in
+              gateway.yaml. Health-check interval: 10 seconds.
+          - path: docs/client-sdk-timeouts.md
+            body: |
+              # Client SDK — Timeout Settings
+              The Python client SDK has a default request timeout of 60 seconds.
+              Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+              These are CLIENT-SIDE values and do not affect the gateway.
+          - path: docs/database-pool.md
+            body: |
+              # Database Connection Pool
+              Connection timeout: 5 seconds. Query timeout: 15 seconds.
+              Pool size: 20 connections. Idle timeout: 300 seconds.
+          - path: docs/monitoring-alerts.md
+            body: |
+              # Monitoring & Alerts
+              Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+              Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_distractor_resistance. Four files mention
+      "timeout" — model must find gateway-config.md specifically and
+      answer 30 seconds, not confuse with client 60s or DB 5s values.
+
+  # ------------------------------------------------------------------
+  # R4. Runtime: No-answer detection
+  # ------------------------------------------------------------------
+  - id: ASR_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/remote-work-policy.md
+            body: |
+              # Remote Work Policy — Full-Time Employees
+              Full-time employees may work remotely up to 3 days per week.
+              Manager approval required for fully remote arrangements.
+              Equipment stipend: $500/year. VPN required for all remote access.
+          - path: docs/contractor-onboarding.md
+            body: |
+              # Contractor Onboarding Guide
+              Contractors receive a company laptop and badge access.
+              NDA must be signed before day one. Billing cycle: net-30.
+              Contact procurement@company.com for equipment issues.
+          - path: docs/benefits-summary.md
+            body: |
+              # Benefits Summary — 2025
+              Health insurance, 401k match, PTO policy, parental leave.
+              Applies to full-time employees only.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_no_answer_detection. Remote-work policy covers
+      FTEs only. Contractor onboarding doesn't mention remote work. Model
+      should search, read, and conclude the info isn't in the corpus.
+
+  # ------------------------------------------------------------------
+  # R5. Runtime: Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: ASR_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-overview.md
+            body: |
+              # Microservices Overview
+              The platform runs 12 microservices. Each has its own config.
+              Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+              Service-specific vars documented in each service's config doc.
+          - path: docs/email-service-config.md
+            body: |
+              # Email Notification Service — Configuration
+              Required environment variables:
+                SMTP_HOST: Mail server hostname
+                SMTP_PORT: Mail server port (default: 587)
+                SMTP_USER: Authentication username
+                SMTP_PASS: Authentication password
+                FROM_ADDRESS: Default sender address
+                TEMPLATE_DIR: Path to email templates
+              Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+          - path: docs/push-service-config.md
+            body: |
+              # Push Notification Service — Configuration
+              Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+              Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+          - path: docs/sms-service-config.md
+            body: |
+              # SMS Notification Service — Configuration
+              Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+              Optional: MAX_SMS_LENGTH (default: 160).
+          - path: docs/deploy-runbook.md
+            body: |
+              # Deployment Runbook
+              Step 1: Pull latest images. Step 2: Run migrations.
+              Step 3: Set env vars per service config docs. Step 4: Deploy.
+              Rollback: revert to previous image tag.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_step_refinement. Broad search for
+      "environment variables" hits many files. Model should narrow to
+      "email service" or "email notification config" to find the right
+      doc. Answer: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS,
+      FROM_ADDRESS, TEMPLATE_DIR (required) + RATE_LIMIT_PER_HOUR.
+
 # ============================================================
 # PRESET CONFIGURATION
 # ============================================================
 #
-# Add the following block to Evaluator/config/eval_run.yaml
-# under the existing `presets:` key:
+# Add these blocks to Evaluator/config/eval_run.yaml under `presets:`:
 #
+#   # Static mode — corpus in system prompt, quick behavioral check
 #   agentic_search:
-#     description: "RAG agent: search -> select -> answer from docs"
+#     description: "RAG agent: search -> select -> answer (static corpus)"
 #     scenarios:
 #       - agentic_search_prompts.yaml
 #     tag_filter:
 #       - agentic_search
+#     exclude_tags:
+#       - runtime
 #     scoring:
 #       pass_threshold: 0.8
 #       weights:
 #         tool_correct: 1.0
 #         behavior_pass: 0.5
 #         response_type_match: 0.3
-#     category_thresholds:
-#       multi_hop: 0.70
-#       distractor_resistance: 0.85
-#       grounding: 0.80
-#       no_answer: 0.90
 #
-# Then copy (or symlink) this scenario file into:
-#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#   # Runtime mode — real filesystem, actual tool execution
+#   agentic_search_runtime:
+#     description: "RAG agent: live search -> read -> answer (runtime env)"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - runtime
+#     scoring:
+#       pass_threshold: 0.8
 #
-# Run with:
-#   python -m Evaluator.cli --preset agentic_search
+# Copy this file to: Evaluator/config/scenarios/agentic_search_prompts.yaml
 #
-# Or with environment backend:
-#   python -m Evaluator.cli --preset agentic_search \
-#     --env-tool-schema <path> --env-exec-config <path>
+# Static:  python -m Evaluator.cli --preset agentic_search
+# Runtime: python -m Evaluator.cli --preset agentic_search_runtime \
+#            --env-backend local \
+#            --env-tool-schema <path> --env-exec-config <path>
 # ============================================================

--- a/.claude/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.claude/skills/case-studies/configs/agentic_search_eval.yaml
@@ -1,0 +1,652 @@
+# ============================================================
+# AGENTIC SEARCH EVALUATION — TEMPLATE
+# ============================================================
+#
+# TOOL-AGNOSTIC: This template uses placeholder tool names.
+# You MUST customize before running:
+#
+#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
+#      (e.g., searchManager_searchContent, rag_search, etc.)
+#
+#   2. Replace YOUR_READ_TOOL with your actual document-read tool
+#      (e.g., contentManager_read, doc_reader, etc.)
+#
+#   3. If using environment-backed evaluation, supply:
+#        --env-tool-schema <path>    (tool JSON schemas)
+#        --env-exec-config <path>    (execution backend config)
+#
+#   4. Adapt the embedded corpus in each system prompt to your
+#      domain if desired. The default corpus is domain-neutral.
+#
+# Each test embeds a small self-contained corpus (3-5 short docs)
+# inside the system prompt so scenarios are portable and do not
+# require an external document store.
+#
+# Tags: agentic_search, search_quality, grounding, multi_hop,
+#        distractor_resistance, no_answer
+# ID convention: AS_<description>
+# ============================================================
+
+name: Agentic Search Evaluation
+description: >-
+  Tests a model's ability to search a document corpus, select relevant
+  documents, synthesize information, and provide grounded answers. Covers
+  single-doc lookup, multi-hop reasoning, distractor resistance,
+  no-answer detection, term specificity, vocabulary mismatch,
+  multi-step refinement, and grounded citation.
+
+tests:
+
+  # ------------------------------------------------------------------
+  # 1. Simple single-doc search
+  # ------------------------------------------------------------------
+  - id: AS_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a documentation assistant. Answer the user's question using
+      ONLY the documents available through search. Do not guess.
+
+      <corpus>
+      [doc_id: config-reference]
+      Title: Data Loader Configuration Reference
+      The data loader supports batch sizes from 1 to 512. The default
+      batch size is 32. Set `batch_size` in loader.yaml to override.
+      Larger batch sizes require proportionally more GPU memory.
+
+      [doc_id: quickstart-guide]
+      Title: Quick Start Guide
+      Install dependencies with `pip install -r requirements.txt`.
+      Run `python main.py` to start. See config-reference for tuning.
+
+      [doc_id: changelog-v2]
+      Title: Changelog v2.0
+      Added streaming mode. Fixed memory leak in tokenizer.
+      Bumped minimum Python version to 3.10.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model should search for "batch size" or "data loader", find
+      config-reference, and answer 512. Single search + read is sufficient.
+
+  # ------------------------------------------------------------------
+  # 2. Multi-hop search
+  # ------------------------------------------------------------------
+  - id: AS_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+    system: |
+      You are an internal knowledge-base assistant. Answer using ONLY
+      information retrieved from the available documents.
+
+      <corpus>
+      [doc_id: service-catalog]
+      Title: Service Catalog
+      billing-service: Handles invoicing, payment processing, and
+      retry logic for failed transactions. Owner: see team-directory.
+      auth-service: SSO and token management. Owner: Platform team.
+      notification-service: Email and push alerts. Owner: Comms team.
+
+      [doc_id: team-directory]
+      Title: Team Directory
+      Platform team: auth-service, infra-gateway.
+      Payments team: billing-service, refund-engine.
+      Comms team: notification-service, template-renderer.
+
+      [doc_id: oncall-schedule]
+      Title: On-Call Schedule — Q1
+      Week 1: Platform team. Week 2: Payments team.
+      Week 3: Comms team. Week 4: rotate.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Requires two hops: (1) find that billing-service handles payment
+      retries, (2) find that Payments team owns billing-service. Model
+      must combine information from service-catalog and team-directory.
+
+  # ------------------------------------------------------------------
+  # 3. Distractor resistance
+  # ------------------------------------------------------------------
+  - id: AS_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+    system: |
+      You are a documentation assistant. Answer using ONLY the documents
+      available through search. If multiple documents mention timeouts,
+      use the one specifically about the API gateway.
+
+      <corpus>
+      [doc_id: gateway-config]
+      Title: API Gateway Configuration
+      The gateway forwards requests to backend services. Default
+      timeout: 30 seconds. Override with `gateway.timeout_ms` in
+      gateway.yaml. Health-check interval: 10 seconds.
+
+      [doc_id: client-sdk-timeouts]
+      Title: Client SDK — Timeout Settings
+      The Python client SDK has a default request timeout of 60 seconds.
+      Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+      These are CLIENT-SIDE values and do not affect the gateway.
+
+      [doc_id: database-pool]
+      Title: Database Connection Pool
+      Connection timeout: 5 seconds. Query timeout: 15 seconds.
+      Pool size: 20 connections. Idle timeout: 300 seconds.
+
+      [doc_id: monitoring-alerts]
+      Title: Monitoring & Alerts
+      Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+      Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Three documents mention "timeout" but only gateway-config has the
+      gateway default. Model must not confuse the client SDK 60s timeout
+      or the DB 5s timeout with the gateway 30s value.
+
+  # ------------------------------------------------------------------
+  # 4. No-answer detection
+  # ------------------------------------------------------------------
+  - id: AS_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - search_quality
+    system: |
+      You are an HR knowledge assistant. Answer ONLY from the available
+      documents. If the answer is not in the corpus, clearly state that
+      the information was not found.
+
+      <corpus>
+      [doc_id: remote-work-policy]
+      Title: Remote Work Policy — Full-Time Employees
+      Full-time employees may work remotely up to 3 days per week.
+      Manager approval required for fully remote arrangements.
+      Equipment stipend: $500/year. VPN required for all remote access.
+
+      [doc_id: contractor-onboarding]
+      Title: Contractor Onboarding Guide
+      Contractors receive a company laptop and badge access.
+      NDA must be signed before day one. Billing cycle: net-30.
+      Contact procurement@company.com for equipment issues.
+
+      [doc_id: benefits-summary]
+      Title: Benefits Summary — 2025
+      Health insurance, 401k match, PTO policy, parental leave.
+      Applies to full-time employees only.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      The remote-work policy covers full-time employees only. The
+      contractor-onboarding doc does not address remote work. The model
+      should search, read the relevant docs, and conclude that contractor
+      remote-work policy is not documented in the available corpus.
+
+  # ------------------------------------------------------------------
+  # 5. Broad vs narrow search terms
+  # ------------------------------------------------------------------
+  - id: AS_term_specificity
+    question: "How do I enable debug logging for the payment webhook handler?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer documentation assistant. Answer using the
+      available documents. Choose precise search terms.
+
+      <corpus>
+      [doc_id: logging-overview]
+      Title: Logging Overview
+      The system uses structured JSON logging. Log levels: DEBUG, INFO,
+      WARN, ERROR. Global log level set in logging.yaml. Per-module
+      overrides supported via `modules.<name>.level` keys.
+
+      [doc_id: webhook-handler-config]
+      Title: Payment Webhook Handler — Configuration
+      Enable debug logging: set `modules.payment_webhook.level: DEBUG`
+      in logging.yaml. This produces verbose request/response logs
+      including headers and payload bodies. Caution: may log PII.
+
+      [doc_id: webhook-security]
+      Title: Webhook Security
+      All inbound webhooks are verified via HMAC-SHA256 signature.
+      Invalid signatures return 403. Replay protection: 5-minute window.
+
+      [doc_id: payment-processing]
+      Title: Payment Processing Pipeline
+      Payments flow: webhook receipt -> validation -> ledger entry ->
+      notification. Retry on ledger failure: 3 attempts, exponential
+      backoff.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A broad search for "logging" would match logging-overview. A
+      narrow search for "payment webhook" or "webhook handler debug"
+      should find webhook-handler-config directly. The model should
+      select terms specific enough to reach the right document
+      efficiently.
+
+  # ------------------------------------------------------------------
+  # 6. Vocabulary mismatch
+  # ------------------------------------------------------------------
+  - id: AS_vocabulary_mismatch
+    question: "How do I throttle the request rate to avoid getting blocked?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer assistant. Answer using ONLY the available
+      documents. The user may use different terminology than the docs.
+
+      <corpus>
+      [doc_id: rate-limiting-guide]
+      Title: Rate Limiting Configuration
+      The API enforces per-client rate limits. Default: 100 requests
+      per minute. Configure via `rate_limit.rpm` in api.yaml. Clients
+      exceeding the limit receive HTTP 429. Implement exponential
+      backoff in your client code. Burst allowance: 20 requests.
+
+      [doc_id: caching-layer]
+      Title: Caching Layer
+      Redis-backed response cache. TTL: 60 seconds for GET endpoints.
+      Cache-Control headers respected. Purge via /admin/cache/clear.
+
+      [doc_id: auth-guide]
+      Title: Authentication Guide
+      API keys issued via /admin/keys. Include in X-API-Key header.
+      Keys rotate quarterly. Revoked keys return 401.
+
+      [doc_id: error-handling]
+      Title: Error Handling Reference
+      400: Bad request. 401: Unauthorized. 403: Forbidden.
+      429: Rate limit exceeded — retry after Retry-After header value.
+      500: Internal server error — contact support.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      User says "throttle" and "getting blocked" — the docs say
+      "rate limiting" and "HTTP 429". The model must translate the
+      user's vocabulary to the corpus terminology to find
+      rate-limiting-guide. May also surface error-handling for the
+      429 reference.
+
+  # ------------------------------------------------------------------
+  # 7. Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: AS_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a deployment assistant. Answer from the available
+      documents only. If your first search is too broad, refine it.
+
+      <corpus>
+      [doc_id: service-overview]
+      Title: Microservices Overview
+      The platform runs 12 microservices. Each has its own config.
+      Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+      Service-specific vars documented in each service's config doc.
+
+      [doc_id: email-service-config]
+      Title: Email Notification Service — Configuration
+      Required environment variables:
+        SMTP_HOST: Mail server hostname
+        SMTP_PORT: Mail server port (default: 587)
+        SMTP_USER: Authentication username
+        SMTP_PASS: Authentication password
+        FROM_ADDRESS: Default sender address
+        TEMPLATE_DIR: Path to email templates
+      Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+
+      [doc_id: push-service-config]
+      Title: Push Notification Service — Configuration
+      Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+      Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+
+      [doc_id: sms-service-config]
+      Title: SMS Notification Service — Configuration
+      Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+      Optional: MAX_SMS_LENGTH (default: 160).
+
+      [doc_id: deploy-runbook]
+      Title: Deployment Runbook
+      Step 1: Pull latest images. Step 2: Run migrations.
+      Step 3: Set env vars per service config docs. Step 4: Deploy.
+      Rollback: revert to previous image tag.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A search for "environment variables" hits service-overview (generic)
+      and possibly all service configs. The model should narrow to "email
+      notification" or "email service config" to reach email-service-config.
+      If the first search returns too many results, the model should
+      refine rather than dump all matches.
+
+  # ------------------------------------------------------------------
+  # 8. Grounded citation
+  # ------------------------------------------------------------------
+  - id: AS_grounded_citation
+    question: "Summarize the data retention requirements and cite which document each requirement comes from."
+    tags:
+      - agentic_search
+      - grounding
+      - search_quality
+    system: |
+      You are a compliance assistant. Answer ONLY from the available
+      documents. When stating a fact, cite the source document by name.
+
+      <corpus>
+      [doc_id: data-retention-policy]
+      Title: Data Retention Policy
+      User account data: retained for 7 years after account closure.
+      Transaction logs: retained for 5 years. Audit trails: retained
+      for 10 years. Anonymized analytics data: no retention limit.
+      Review cycle: annual.
+
+      [doc_id: gdpr-compliance]
+      Title: GDPR Compliance Addendum
+      EU user data subject to right-to-erasure. Erasure requests must
+      be fulfilled within 30 days. Retention policy overridden by
+      erasure request except where legal hold applies.
+
+      [doc_id: backup-procedures]
+      Title: Backup Procedures
+      Daily incremental backups retained for 30 days. Weekly full
+      backups retained for 90 days. Disaster recovery backups retained
+      for 1 year. All backups encrypted with AES-256.
+
+      [doc_id: security-overview]
+      Title: Security Overview
+      Encryption at rest and in transit. Access control via RBAC.
+      Penetration testing: quarterly. SOC 2 Type II certified.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must reference specific documents by name in its answer.
+      Expected citations: data-retention-policy for retention periods,
+      gdpr-compliance for erasure override, backup-procedures for
+      backup retention. Answers without citations fail grounding.
+
+  # ------------------------------------------------------------------
+  # 9. Ambiguous query requiring clarification
+  # ------------------------------------------------------------------
+  - id: AS_ambiguous_query_clarification
+    question: "How do I set up the connection?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a documentation assistant. Answer from the available
+      documents. If the question is too ambiguous to search effectively,
+      ask the user to clarify.
+
+      <corpus>
+      [doc_id: database-setup]
+      Title: Database Connection Setup
+      Install the database driver. Set DATABASE_URL in .env.
+      Run `python manage.py migrate` to initialize schema.
+      Connection pool size: 10 (configurable).
+
+      [doc_id: vpn-setup]
+      Title: VPN Connection Setup
+      Download the VPN client from /tools/vpn. Import the .ovpn
+      config file. Authenticate with your SSO credentials.
+      Required for remote access to staging and production.
+
+      [doc_id: api-client-setup]
+      Title: API Client Connection Setup
+      Install the SDK: `pip install our-client`. Initialize with
+      `Client(api_key="...")`. Set base_url for non-production
+      environments.
+
+      [doc_id: websocket-guide]
+      Title: WebSocket Connection Guide
+      Connect to ws://host:8080/stream. Send auth frame first.
+      Heartbeat interval: 30 seconds. Reconnect on close code 1006.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: clarification
+    behavior_expectations:
+      asks_for_user_input: true
+      explains_choice: true
+    anti_patterns:
+      immediate_tool_call: false
+      assumes_user_choice: true
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      "The connection" is ambiguous — four different connection types
+      exist. The model should either ask which connection type the user
+      means or briefly list the options. Picking one without asking is
+      an anti-pattern.
+
+  # ------------------------------------------------------------------
+  # 10. Search with negation constraint
+  # ------------------------------------------------------------------
+  - id: AS_negation_constraint
+    question: "List all storage backends we support OTHER THAN S3."
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a platform documentation assistant. Answer from the
+      available documents only. Pay attention to constraints in the
+      user's question.
+
+      <corpus>
+      [doc_id: storage-backends]
+      Title: Supported Storage Backends
+      The platform supports four storage backends:
+        1. Amazon S3 — default for production deployments
+        2. Google Cloud Storage (GCS) — set STORAGE_BACKEND=gcs
+        3. Azure Blob Storage — set STORAGE_BACKEND=azure
+        4. Local filesystem — for development only, STORAGE_BACKEND=local
+      All backends implement the StorageProvider interface.
+
+      [doc_id: s3-deep-dive]
+      Title: S3 Configuration Deep Dive
+      Bucket naming conventions, IAM policies, cross-region
+      replication, lifecycle rules. Set AWS_REGION and S3_BUCKET.
+
+      [doc_id: migration-guide]
+      Title: Storage Migration Guide
+      To migrate between backends, run `python migrate_storage.py
+      --from s3 --to gcs`. Supports incremental migration.
+      Estimated time: ~1 hour per 100 GB.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must find the storage-backends doc and list GCS, Azure Blob
+      Storage, and local filesystem — excluding S3 as the user requested.
+      Including S3 in the answer is a failure. The s3-deep-dive doc is
+      a distractor.
+
+# ============================================================
+# PRESET CONFIGURATION
+# ============================================================
+#
+# Add the following block to Evaluator/config/eval_run.yaml
+# under the existing `presets:` key:
+#
+#   agentic_search:
+#     description: "RAG agent: search -> select -> answer from docs"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - agentic_search
+#     scoring:
+#       pass_threshold: 0.8
+#       weights:
+#         tool_correct: 1.0
+#         behavior_pass: 0.5
+#         response_type_match: 0.3
+#     category_thresholds:
+#       multi_hop: 0.70
+#       distractor_resistance: 0.85
+#       grounding: 0.80
+#       no_answer: 0.90
+#
+# Then copy (or symlink) this scenario file into:
+#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#
+# Run with:
+#   python -m Evaluator.cli --preset agentic_search
+#
+# Or with environment backend:
+#   python -m Evaluator.cli --preset agentic_search \
+#     --env-tool-schema <path> --env-exec-config <path>
+# ============================================================

--- a/.claude/skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.claude/skills/case-studies/configs/agentic_search_eval.yaml
@@ -623,6 +623,22 @@ tests:
   # discover content by searching and reading.
   #
   # Requires: --env-backend local --env-tool-schema --env-exec-config
+  #
+  # ⚠️  DATA CONTAMINATION WARNING
+  #
+  # These fixture documents and questions MUST NOT overlap with your
+  # training data. If the model saw these exact docs or questions
+  # during training, evaluation measures memorization, not capability.
+  #
+  # Best practices:
+  #   - Use a held-out document set that was never in training
+  #   - Or generate fresh questions from the fixture environment
+  #     (e.g., have a teacher model write questions about the fixture
+  #     docs, then use those questions here)
+  #   - Never reuse SynthChat-generated training corpora as eval
+  #     fixtures — write new content or use a different domain
+  #   - The fixture docs below are EXAMPLES — replace them with
+  #     your own held-out content before trusting eval results
   # ================================================================
 
   # ------------------------------------------------------------------

--- a/.claude/skills/case-studies/configs/agentic_search_rubrics.yaml
+++ b/.claude/skills/case-studies/configs/agentic_search_rubrics.yaml
@@ -1,0 +1,463 @@
+# =============================================================================
+# AGENTIC SEARCH RUBRICS — TEMPLATE BUNDLE
+# =============================================================================
+#
+# PURPOSE
+#   Three rubric definitions for evaluating agentic search quality in training
+#   examples where a model must: (1) choose search terms, (2) select documents
+#   to read, and (3) produce a grounded answer from what it read.
+#
+# HOW TO USE
+#   1. Copy the rubric you need into SynthChat/rubrics/<rubric_name>.yaml
+#   2. Customize the judge/improver prompts for your domain and tool schema
+#   3. Run:  python -m SynthChat.services.rubric_runner --list
+#      to confirm your rubric is detected
+#
+# TOOL AGNOSTICISM
+#   These rubrics are intentionally generic. They evaluate BEHAVIOR — what was
+#   searched for, what was opened, what was claimed — not the names or schemas
+#   of specific tools. Whether your pipeline uses searchManager, a RAG
+#   retriever, grep, an MCP tool, or any other search interface, the quality
+#   criteria are the same:
+#
+#     - Did the search terms target the right vocabulary?
+#     - Did the model read the right documents?
+#     - Is the final answer faithful to what the documents actually say?
+#
+#   When you copy a rubric into SynthChat/rubrics/, replace the generic
+#   references (e.g., "search actions", "read actions") with your tool-
+#   specific field names if you want structural validations to fire.
+#
+# AVAILABLE TEMPLATE VARIABLES (for judge/improver prompts)
+#   {current_content}       — The content being evaluated (scoped by rubric scope)
+#   {system_prompt}         — Full system prompt from the training example
+#   {user_request}          — The user's message / question
+#   {assistant_response}    — The assistant's full response
+#   {feedback}              — Judge feedback (improver prompts only)
+#   {thinking_content}      — Thinking block content (if present)
+#   {original_tool_calls}   — Raw tool calls JSON (if present)
+#
+# =============================================================================
+
+
+# =============================================================================
+# RUBRIC 1: search_term_quality
+# =============================================================================
+
+name: Search Term Quality
+description: >
+  Evaluates whether the search terms the model chose would actually surface
+  the target documents in a keyword or grep-style search. Penalizes terms
+  that are too broad, too narrow, or that parrot the user's exact phrasing
+  when the underlying documents use different vocabulary.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating the SEARCH TERMS an assistant chose when answering a
+  user question. The assistant issued one or more search actions before
+  reading documents. Your job is to judge whether those search terms would
+  realistically surface the documents that contain the answer.
+
+  **Tool Calls (containing search actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  # INSTRUCTIONS
+  Examine every search term or query string the assistant used and evaluate
+  along these dimensions:
+
+  1. **Vocabulary match**: Do the search terms use words and phrases that
+     are likely to appear in the target documents? Domain-specific jargon,
+     abbreviations, and canonical names score higher than generic synonyms.
+
+  2. **Specificity**: Are the terms specific enough to filter out irrelevant
+     results? A single common word like "config" is too broad; a phrase like
+     "training learning rate schedule" is appropriately targeted.
+
+  3. **Coverage**: If the answer spans multiple topics or documents, did the
+     assistant issue enough distinct searches to cover the needed ground?
+
+  4. **Avoiding echo**: Did the assistant blindly copy the user's exact
+     question as a search query? Good search reformulates the question into
+     terms the documents are likely to contain. For example, if the user asks
+     "How do I make the model learn faster?" a good search uses terms like
+     "learning_rate" or "lr_scheduler", not "make model learn faster".
+
+  5. **Iteration awareness**: If the first search returned poor results and
+     the assistant searched again, did it adjust terms meaningfully or just
+     repeat the same query?
+
+  # SCORING
+  - **1.0** = Terms are well-chosen: domain-appropriate vocabulary, specific
+    enough to filter noise, cover the needed topics, reformulated from user
+    phrasing into document vocabulary
+  - **0.7-0.9** = Mostly good terms with minor issues (slightly too broad,
+    one redundant search, partial echo of user phrasing)
+  - **0.4-0.6** = Terms are mediocre: overly generic, echo user phrasing
+    without reformulation, or miss an important topic
+  - **0.0-0.3** = Terms are poor: would not surface target docs, completely
+    wrong vocabulary, or no search was performed at all
+
+  # FORMAT
+  Return JSON: {"searchtermquality_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the search terms an assistant used when answering a
+  user question. The judge found issues with the original search terms.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. Search terms use vocabulary that matches the target documents, not the
+     user's exact phrasing
+  2. Terms are specific enough to filter irrelevant results but not so
+     narrow that they miss relevant documents
+  3. Multiple searches cover all topics needed to answer the question
+  4. If the system prompt describes the corpus structure (folders, file
+     names, tags), use that knowledge to craft targeted queries
+
+  Preserve the original tool call structure and format. Only change the
+  search query strings and add/remove search actions as needed.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    searchtermquality_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - searchtermquality_score
+
+validations:
+  # Verify that at least one tool call exists (the model should be searching)
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should issue search actions before answering"
+
+
+# =============================================================================
+# RUBRIC 2: doc_selection
+# =============================================================================
+
+---
+name: Document Selection
+description: >
+  Evaluates whether the model selected the right documents to read after
+  searching. Penalizes reading too few documents (incomplete answer), reading
+  too many (inefficient), skipping relevant results, or falling for distractor
+  documents that match keywords but are irrelevant.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating which documents the assistant chose to READ (open, fetch,
+  or retrieve full content) after performing search actions. Your job is to
+  judge whether the selection was appropriate for answering the user's question.
+
+  **Tool Calls (containing search and read actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  # INSTRUCTIONS
+  Examine the sequence of tool calls to identify which documents were read
+  (opened, fetched, retrieved) and evaluate along these dimensions:
+
+  1. **Relevance**: Did the assistant read documents that actually contain
+     information needed to answer the question? Cross-reference the user's
+     question, the system prompt's description of available content, and what
+     the assistant ultimately said in its response.
+
+  2. **Distractor avoidance**: Did the assistant skip documents that share
+     keywords with the question but contain irrelevant content? For example,
+     a file called "training_logs.md" might match a search for "training"
+     but be irrelevant if the user asked about training configuration.
+
+  3. **Sufficiency**: Did the assistant read ENOUGH documents to fully answer
+     the question? If the answer requires information from three documents
+     and only one was read, that is insufficient.
+
+  4. **Efficiency**: Did the assistant avoid reading everything blindly? If
+     10 results were returned and only 2 are relevant, reading all 10 is
+     wasteful. Reading 2-3 targeted documents is efficient.
+
+  5. **Progressive narrowing**: If the assistant read one document and then
+     decided to read more, was that decision reasonable based on what the
+     first document contained?
+
+  # SCORING
+  - **1.0** = Read exactly the right documents: all relevant docs included,
+    distractors skipped, efficient selection
+  - **0.7-0.9** = Good selection with minor issues (one unnecessary read,
+    or one mildly relevant doc skipped)
+  - **0.4-0.6** = Mediocre selection: missed an important document, read
+    several distractors, or read everything without filtering
+  - **0.0-0.3** = Poor selection: missed the key document entirely, read
+    only distractors, or did not read any documents at all
+
+  # FORMAT
+  Return JSON: {"docselection_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the document selection in an assistant's tool call
+  sequence. The judge found issues with which documents were read.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. The assistant reads documents that contain information needed to answer
+     the question (check the system prompt for clues about document content)
+  2. Distractor documents with misleading names are skipped
+  3. The selection is sufficient — enough documents are read to fully answer
+     the question
+  4. The selection is efficient — no unnecessary reads of clearly irrelevant
+     documents
+  5. Search actions remain the same (or are only adjusted if the original
+     searches could not have surfaced the right documents)
+
+  Preserve the original tool call structure and format. Add or remove read
+  actions as needed, and reorder if the sequence matters.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    docselection_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - docselection_score
+
+validations:
+  # Verify that at least one read/fetch action exists
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should read documents before answering"
+
+
+# =============================================================================
+# RUBRIC 3: groundedness
+# =============================================================================
+
+---
+name: Groundedness
+description: >
+  Evaluates whether the assistant's final answer is faithful to the content
+  of the documents it read. Penalizes fabricated claims, meaning-altering
+  paraphrases, and failure to acknowledge when documents do not cover a topic.
+scope: response
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating whether the assistant's response is GROUNDED in the
+  documents it read. Every factual claim in the response should be traceable
+  to a specific passage in the retrieved content. The assistant should not
+  invent information, and should explicitly say when it cannot find something.
+
+  **Assistant Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Thinking Block (if present):**
+  ```
+  {thinking_content}
+  ```
+
+  # INSTRUCTIONS
+  Evaluate the response along these dimensions:
+
+  1. **Traceability**: Can every factual claim (names, numbers, dates,
+     procedures, configurations) be traced back to a specific passage in the
+     documents the assistant read? Claims that appear in the response but not
+     in any read document are hallucinations.
+
+  2. **No added information**: Does the response avoid introducing facts,
+     details, or context not present in the documents? General knowledge
+     framing ("This is a common pattern...") is acceptable; specific claims
+     ("The default learning rate is 2e-4") must come from the documents.
+
+  3. **Faithful paraphrasing**: When the response paraphrases document
+     content rather than quoting it, does the paraphrase preserve the
+     original meaning? Watch for subtle meaning shifts — e.g., changing
+     "recommended" to "required", or "up to 10" to "exactly 10".
+
+  4. **Appropriate uncertainty**: When the documents do not cover part of
+     the user's question, does the response acknowledge this gap? Phrases
+     like "I could not find information about X in the documents" are good.
+     Silently making up an answer is bad. Confidently stating something the
+     documents do not support is the worst case.
+
+  5. **No over-generalization**: Does the response avoid broadening specific
+     claims from the documents? If a document says "Feature X works with
+     model Y," the response should not claim "Feature X works with all
+     models" unless the document supports that.
+
+  # SCORING
+  - **1.0** = Every claim is traceable to the documents, gaps are
+    acknowledged, paraphrasing is faithful, no added information
+  - **0.7-0.9** = Mostly grounded with minor issues (one slightly loose
+    paraphrase, a minor added detail that is broadly correct)
+  - **0.4-0.6** = Several ungrounded claims, or one significant fabrication,
+    or fails to acknowledge a gap in document coverage
+  - **0.0-0.3** = Major fabrications: invents key facts, contradicts the
+    documents, or confidently answers questions the documents do not address
+
+  # FORMAT
+  Return JSON: {"groundedness_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving an assistant's response to ensure it is grounded in the
+  documents that were read. The judge found issues with faithfulness.
+
+  **Current Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate an improved response where:
+  1. Every factual claim can be traced to a passage in the read documents
+  2. Remove or correct any claims not supported by the documents
+  3. Where the documents do not cover part of the user's question, explicitly
+     state that: "I was not able to find information about [topic] in the
+     available documents"
+  4. Preserve the helpful structure and tone of the original response
+  5. If the original response paraphrased something in a way that changed
+     its meaning, fix the paraphrase to be faithful to the source
+  6. Do not add new information from outside the documents — only use what
+     the assistant actually retrieved
+
+  Output ONLY the improved response text.
+
+output_schema:
+  type: object
+  properties:
+    groundedness_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - groundedness_score
+
+validations:
+  # Verify the response is not empty
+  - match: '\S+'
+    type: regex
+    error: "Response is empty — the assistant must provide an answer after reading documents"

--- a/.claude/skills/case-studies/configs/agentic_search_scenario.yaml
+++ b/.claude/skills/case-studies/configs/agentic_search_scenario.yaml
@@ -1,0 +1,438 @@
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  AGENTIC SEARCH — Scenario Template                            ║
+# ║                                                                ║
+# ║  BEFORE USING: Replace placeholder tool names with YOUR tools  ║
+# ║                                                                ║
+# ║  Placeholders:                                                 ║
+# ║    YOUR_SEARCH_TOOL  → e.g., grep, ripgrep, searchAPI, etc.   ║
+# ║    YOUR_READ_TOOL    → e.g., cat, readFile, fetchDoc, etc.    ║
+# ║    YOUR_LIST_TOOL    → e.g., ls, listFiles, dirList, etc.     ║
+# ║                                                                ║
+# ║  The three-stage pattern (search → read → answer) is the      ║
+# ║  constant. The actual tools are YOUR choice.                   ║
+# ║                                                                ║
+# ║  Run with --env-tool-schema and --env-exec-config to provide   ║
+# ║  your tool definitions.                                        ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+# ---------------------------------------------------------------------------
+# Shared anchors — reused across all agentic search scenarios
+# ---------------------------------------------------------------------------
+
+shared_agentic_environment: &shared_agentic_environment
+  loop:
+    enabled: true
+    mode: agentic
+    max_turns: 6
+    max_tool_steps: 6
+    stop_on_text_response: true
+    require_final_text_after_pass: true
+    final_text_prompt: Reply to the user with a concise answer grounded in the documents you read. Do not call tools.
+    continue_on_execution_error: true
+    stuck_repeat_limit: 2
+    no_progress_window: 3
+
+shared_tutored_judge: &shared_tutored_judge
+  in_loop:
+    enabled: true
+    feedback_visible_to_model: true
+    temperature: 0.1
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    prompt: |
+      You are tutoring an agentic search assistant generating high-quality training data.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      Messages so far:
+      {messages_json}
+
+      Latest assistant response:
+      {assistant_response_json}
+
+      Latest environment step:
+      {environment_step_json}
+
+      Tool feedback shown to the model:
+      {tool_feedback}
+
+      Evaluate the assistant on three dimensions:
+      1. SEARCH QUALITY — Did it generate effective search terms that surface the
+         target documents without being so broad that distractors dominate?
+      2. SELECTIVE READ — Did it read the correct documents and skip irrelevant
+         results? Did it avoid reading every result indiscriminately?
+      3. ANSWER GROUNDEDNESS — Is the answer derived from document content only?
+         Flag any claim not traceable to a read document.
+
+      Treat task_context fields as the source of truth for which documents are
+      targets vs. distractors. Do not accept a distractor document as a valid
+      source even if its content seems related.
+
+      Return passed=true only if the hard requirements are already satisfied by
+      the latest assistant action and tool feedback. If any hard requirement is
+      still unmet, return passed=false and explain the next best corrective step.
+
+      Use feedback_to_model for concise tutoring about the next best move.
+      Only ask for a short final text-only answer after the hard requirements
+      are actually satisfied.
+
+shared_environment_generation_review: &shared_environment_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: environment_payload_shape
+      field: value
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated knowledge base environment for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Normalized environment snapshot:
+      {value_json}
+
+      Return passed=true only if the environment:
+      - Contains 15-20 documents across 3-5 distinct topic areas
+      - Has realistic document content (multi-paragraph, not just titles or stubs)
+      - Includes deliberate distractors: documents with overlapping keywords but
+        different topics that could mislead a naive search
+      - Spreads some answers across multiple files to support multi-hop retrieval
+      - Does not make target documents trivially identifiable by filename alone
+      - Is internally consistent (cross-references between docs are valid)
+
+      Penalize environments that are too sparse, have uniform document lengths,
+      or contain documents that are obviously fake (lorem ipsum, placeholder text).
+
+shared_user_generation_review: &shared_user_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: non_empty_text
+      field: text
+    - type: plain_text
+      field: text
+    - type: no_tool_names
+      field: text
+    - type: no_exact_paths_from_context
+      field: text
+      sources: [task_context]
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated user question for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      User text:
+      {user_text}
+
+      Return passed=true only if:
+      - The question sounds like a real human asking for information
+      - It does NOT leak exact file paths, document IDs, or tool names
+      - It does NOT contain search terms that would trivially match only the
+        target document (the assistant must figure out effective search terms)
+      - It is specific enough that there IS a correct answer in the corpus
+      - For multi-hop scenarios, the question naturally requires synthesizing
+        information from multiple sources
+
+shared_final_review: &shared_final_review
+  enforce: true
+  gates:
+    - type: field_equals
+      field: environment_passed
+      value: true
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a completed agentic search training example.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Final environment result:
+      {environment_result_json}
+
+      Final assistant response:
+      {assistant_response_json}
+
+      Conversation trace:
+      {conversation_trace_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      If environment_result.passed is true, treat the hard requirements as already
+      satisfied by the programmatic environment validator. Do not override that by
+      re-inferring document contents from earlier tool traces.
+
+      In that case, judge only whether this is a high-quality training example:
+      - The search strategy was reasonable (not brute-force read-everything)
+      - The assistant selected the right documents and skipped distractors
+      - The final answer is grounded in document content with no hallucination
+      - The trajectory is coherent and the tutor feedback is sensible
+      - The ending response is a natural answer to the user question
+
+      If environment_result.passed is false, then passed must be false.
+
+shared_assistant_generation: &shared_assistant_generation
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+scenarios:
+
+  # =========================================================================
+  # SEED: Generate a realistic knowledge base for search scenarios
+  # =========================================================================
+  agentic_search_corpus_seed:
+    type: helper
+    environment_mode: generated
+    system_context:
+      available_workspaces:
+        - id: ws_search_corpus
+          name: Knowledge Base
+          description: A document corpus reused across agentic search workflows
+          root_folder: ""
+      selected_workspace:
+        id: default
+        name: Knowledge Base
+      assistant_instructions: >-
+        This seed corpus should support single-document retrieval, multi-hop
+        retrieval across documents, keyword-based search with distractors,
+        selective reading from mixed results, and grounded answer generation.
+    environment_generation:
+      <<: *shared_environment_generation_review
+      schema: canonical_environment
+      prompt: |
+        Generate one shared knowledge base that will be reused across agentic search scenarios.
+
+        Requirements:
+        - Create 15-20 documents organized across 3-5 topic areas as top-level folders.
+          Example topic areas: Engineering, Operations, Product, Research, Policies.
+          Choose your own realistic topic names and vary them across seeds.
+        - Each document must have realistic multi-paragraph content (3-8 paragraphs).
+          Think internal wiki pages, runbooks, design docs, meeting summaries, or
+          policy documents. Do not generate stubs, placeholder text, or lorem ipsum.
+        - Deliberate DISTRACTORS are critical:
+          - At least 3 documents must share keywords with a target document but
+            cover a different topic. For example, a doc about "rate limiting in
+            the CDN layer" vs. "rate limiting in the payment API" — same keyword
+            "rate limiting", different answers.
+          - At least 2 documents must have similar titles but different content.
+        - MULTI-HOP support:
+          - At least 2 answers must require combining information from 2+ documents.
+            For example, Document A says "the migration deadline is in Q3" and
+            Document B says "Q3 runs July-September" — answering "when is the
+            migration deadline?" requires both.
+          - Cross-references between documents are encouraged (e.g., "see the
+            deployment runbook for details").
+        - Include a mix of document types:
+          - Narrative docs (design docs, postmortems, meeting notes)
+          - Structured docs (runbooks with numbered steps, config references)
+          - Short docs (1-2 paragraphs) and long docs (6-8 paragraphs)
+        - Add 3-5 extra distractor files with plausible but tangential content so
+          different seeds are not clones.
+        - Vary filenames, topics, writing styles, and organizational structure
+          across seeds while preserving the role coverage above.
+        - Return environment.assertions as an empty list.
+        - Put seed-specific metadata under task_context: seed_theme,
+          distractor_paths, multi_hop_pairs, and topic_areas.
+    prompts:
+      user: ""
+      assistant: ""
+
+  # =========================================================================
+  # STAGE 1+2+3: Search, selectively read, and answer from documents
+  # =========================================================================
+  agentic_search_find_and_answer:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: search_and_answer
+      primitives: [search, read]
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        examples:
+          - "What's our policy on handling third-party API outages?"
+          - "How do we handle database failovers in production?"
+          - "What was decided about the authentication redesign?"
+      candidate_selector:
+        target:
+          min_content_length: 200
+          preferred_keywords_from: task_context
+          must_contain_answer: true
+        distractors:
+          share_keywords_with_target: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that can be answered
+        from the knowledge base. Do not mention file names, paths, or tool names.
+        Phrase it the way a colleague would ask over chat.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        First use YOUR_SEARCH_TOOL to find relevant documents, then use YOUR_READ_TOOL
+        to read the most promising results. Skip documents that are clearly irrelevant
+        based on search result summaries. After reading, provide a grounded answer.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response
+
+  # =========================================================================
+  # MULTI-HOP: Answer requires combining info from 2+ documents
+  # =========================================================================
+  agentic_search_multi_hop:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, multi_hop, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_1_path}"
+        - type: file_was_read
+          path: "{task_target_doc_2_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_combined_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+        - type: response_contains_text
+          text: "{task_doc_1_contribution}"
+        - type: response_contains_text
+          text: "{task_doc_2_contribution}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. Some
+        questions require combining information from multiple documents. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: multi_hop_search
+      primitives: [search, read]
+      min_source_docs: 2
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        requires_synthesis: true
+        examples:
+          - "When exactly is the migration deadline and what needs to be done before then?"
+          - "Which team owns the rate limiter and what's their on-call rotation?"
+          - "What's the budget impact of the infrastructure changes planned for next quarter?"
+      candidate_selector:
+        target_pair:
+          doc_1:
+            contains_partial_answer: true
+            preferred_keywords_from: task_context
+          doc_2:
+            contains_complementary_answer: true
+            cross_references_doc_1: preferred
+        distractors:
+          share_keywords_with_targets: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that requires combining
+        information from at least two different documents. The question should sound
+        like a single coherent inquiry, not two separate questions joined together.
+        Do not mention file names, paths, or tool names.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        Use YOUR_SEARCH_TOOL to find relevant documents. You may need multiple searches
+        with different terms. Use YOUR_READ_TOOL to read documents that look relevant.
+        Synthesize information from multiple documents into a single coherent answer.
+        Cite which documents contributed which facts when the answer draws from
+        multiple sources.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response

--- a/.claude/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.claude/skills/case-studies/reference/agentic-search-pipeline.md
@@ -295,8 +295,9 @@ presets:
     tags: [search, grounding, rag]
 ```
 
-### Run Evaluation
+### Two Evaluation Modes
 
+**Static mode** — corpus in the system prompt, quick behavioral check:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
@@ -305,6 +306,21 @@ python -m Evaluator.cli \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
 ```
+
+**Runtime mode** — real files, actual tool execution via agentic loop:
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search_runtime \
+  --env-backend local \
+  --env-tool-schema path/to/your_tool_schema.yaml \
+  --env-exec-config path/to/your_exec_rules.yaml \
+  --output Evaluator/results/agentic_search_runtime_v1.json \
+  --markdown Evaluator/results/agentic_search_runtime_v1.md
+```
+
+> **Do not train to the test.** The runtime eval fixtures (documents and questions) must NOT overlap with your training data. If the model saw these exact docs during SynthChat generation, the eval measures memorization, not capability. Use a held-out document set, or generate fresh questions from the fixture environment with a teacher model. The example fixtures in the template are placeholders — replace them with your own held-out content before trusting results.
 
 ### Key Metrics
 

--- a/.claude/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.claude/skills/case-studies/reference/agentic-search-pipeline.md
@@ -1,0 +1,403 @@
+# Case Study: Agentic Search (RAG Agent) Training Pipeline
+
+A complete walkthrough of how to teach a language model to act as a RAG agent — searching a corpus, selecting relevant documents, and answering questions grounded exclusively in what it found.
+
+---
+
+> **YOUR TOOLS ARE NOT OUR TOOLS**
+>
+> This case study describes a **three-stage pattern**: Search, Select, Answer. The tool names used below (`YOUR_SEARCH_TOOL`, `YOUR_READ_TOOL`, `YOUR_LIST_TOOL`) are **placeholders**. Your system might use `grep`, `ripgrep`, a vector DB query, `cat`, `readFile`, an HTTP API, or something else entirely.
+>
+> **Before you proceed past Stage 1, you must know:**
+> 1. What tool does "search" in your system?
+> 2. What tool does "read" in your system?
+> 3. What tool does "list" in your system?
+>
+> The three-stage behavior is the constant. The tools are variables.
+
+---
+
+## Stage 1: Define the Capability
+
+### What We're Teaching
+
+The model must learn a three-stage behavior loop:
+
+1. **Search** — given a question, generate search terms that would surface target documents in a keyword/grep-style search. The model must reason about vocabulary: what words would the answer contain?
+2. **Selective Read** — from the search results, pick the relevant documents and skip distractors. Not everything returned is useful. The model must show judgment.
+3. **Grounded Answer** — answer using ONLY content from the documents it read. No hallucination. If the docs don't contain the answer, say so.
+
+### How This Differs from the Other Case Studies
+
+| Dimension | Tool Calling | Essay Style | Agentic Search |
+|-----------|-------------|-------------|----------------|
+| Goal | Call the right API | Produce creative output | Find and synthesize from sources |
+| Output | Structured JSON | Structured prose | Grounded prose with citations |
+| Tools are... | The end product | Not involved | The means to an end |
+| Validation | Schema match | Rubric scoring | Retrieval recall + groundedness |
+| Key challenge | Syntax precision | Voice preservation | Search strategy + no hallucination |
+
+Tool calling trains a model to use tools correctly. Agentic search trains a model to use tools *strategically* — the tools are a means to producing a grounded answer.
+
+### Inspiration: Explore, Verify, Extend
+
+The data generation pattern draws from Chroma's Context-1 approach: generate a seed corpus, then create training examples where the model must explore (search), verify (read and confirm), and extend (synthesize an answer). Our corpus is generated per-seed via the environment backend rather than pre-indexed, and evaluation is YAML-driven through the existing Evaluator.
+
+### The Three Rubrics
+
+Quality is governed by three rubrics, one per stage:
+
+| Rubric | Stage | What It Checks |
+|--------|-------|---------------|
+| `search_term_quality` | Search | Are the terms specific enough to retrieve target docs? Do they account for vocabulary mismatch? |
+| `doc_selection` | Select | Did the model read relevant docs and skip distractors? Precision and recall. |
+| `groundedness` | Answer | Is every claim traceable to a document? Does it say "not found" when appropriate? |
+
+---
+
+## Stage 2: Create Training Data
+
+### Prerequisites: Confirm Your Tools
+
+> **STOP.** Before writing any scenarios or generating any data, you must map the three-stage pattern to your actual tools.
+
+Define your tool mapping:
+
+| Stage | Placeholder | Your Tool | Example |
+|-------|------------|-----------|---------|
+| Search | `YOUR_SEARCH_TOOL` | ___________ | `grep`, `searchContent`, `vector_query` |
+| Read | `YOUR_READ_TOOL` | ___________ | `cat`, `read`, `fetchDocument` |
+| List | `YOUR_LIST_TOOL` | ___________ | `ls`, `list`, `listDirectory` |
+
+Once you know your tools, create the tool schema and environment execution config that match your system. The scenario YAML references these tools by name — they must match exactly.
+
+### Corpus Design
+
+The environment backend generates the corpus automatically for each training example. A good corpus has:
+
+- **Varied topics** — not all docs about the same thing
+- **Overlapping vocabulary** — docs sharing keywords but covering different topics (forces precise search)
+- **Deliberate distractors** — docs that look relevant but aren't (forces selective reading)
+- **Multi-hop potential** — answers requiring info from 2+ documents
+
+The seed scenario's `environment_generation.prompt` controls corpus shape. Customize it for your domain. Compare to Context-1's domain-specific corpora (web, SEC, patents, email) — same principle: realistic documents with realistic noise.
+
+### Scenario Types
+
+The scenario file defines three scenario types that build on each other:
+
+**1. Seed scenarios** — generate the corpus and a simple single-doc question:
+```yaml
+scenarios:
+  agentic_search_seed:
+    type: tool
+    environment_mode: generated
+    system_template: mocked_workspace_vault
+    rubrics:
+      response: [search_term_quality, doc_selection, groundedness]
+    environment_generation:
+      prompt: |
+        Generate a workspace with 5-8 documents across 2-3 topics.
+        Include 2 distractors per topic that share vocabulary but
+        cover different aspects. One document must contain the answer
+        to a factual question that requires reading (not guessing).
+```
+
+**2. Find-and-answer scenarios** — question requires searching, reading one doc, answering:
+The model must: search with good terms, pick the right doc from results, answer from its content only.
+
+**3. Multi-hop scenarios** — answer requires info from 2+ documents:
+The model must: search, read doc A, recognize it's incomplete, search again or read doc B, synthesize.
+
+### Running Generation
+
+Copy your scenario file into place and generate:
+
+```bash
+# Copy scenario (after replacing YOUR_SEARCH_TOOL etc. with real tool names)
+cp .skills/case-studies/configs/agentic_search_scenario.yaml \
+   SynthChat/scenarios/agentic_search.yaml
+
+# Dry run — check 3 examples without saving
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --count 3 \
+  --dry-run
+
+# Full generation
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --workers 4 \
+  --output Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Example Training Conversation
+
+Tool names below are placeholders — substitute your own:
+
+```
+system: [workspace context with corpus file listing]
+user:   "What's the maximum retry count for the payment service?"
+assistant:
+  <thinking>I should search for payment service configuration.</thinking>
+  [calls YOUR_SEARCH_TOOL with terms: "payment retry max"]
+tool:   [returns: payment_config.md, payment_overview.md, retry_policy.md]
+assistant:
+  <thinking>payment_config.md and retry_policy.md look relevant.
+  payment_overview.md is a high-level summary — skip it.</thinking>
+  [calls YOUR_READ_TOOL on payment_config.md]
+tool:   [returns file content with "max_retries: 5"]
+assistant:
+  Based on payment_config.md, the maximum retry count for the payment
+  service is **5** (configured via `max_retries: 5` in the service config).
+```
+
+All three stages visible: targeted search terms, selective reading (skipped the overview), grounded answer with citation.
+
+---
+
+## Stage 3: Validate & Improve
+
+### Structural Validation
+
+```bash
+python3 .skills/synethetic-data-generation/scripts/validate_syngen.py \
+  Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Rubric-Based Quality Validation
+
+Copy rubric files into place, then validate:
+
+```bash
+# Copy rubrics (one file per rubric)
+cp .skills/case-studies/configs/agentic_search_rubrics/*.yaml \
+   SynthChat/rubrics/
+
+# Validate a small batch
+python -m SynthChat.run validate \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --start-line 1 --end-line 10
+```
+
+**Search term quality:** Specific to the question? Account for vocabulary mismatch? Would plausibly retrieve the target doc? Not too broad or too narrow?
+
+**Document selection:** Read the doc(s) containing the answer? Skipped distractors? Avoided reading every single result?
+
+**Groundedness:** Every claim traceable to a document? No added information? Says "not found" when docs lack the answer? Citations present?
+
+### Improvement Loop
+
+```bash
+python -m SynthChat.run improve \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --max-iterations 5
+```
+
+### Manual Review
+
+Sample 10-20%: Do search terms feel human? Is reading selective? Can you verify the answer from the cited doc? For multi-hop, does the model actually combine info?
+
+---
+
+## Stage 4: Train
+
+### Training Sequence
+
+```
+SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
+      ↓                        ↓                        ↓
+  Search→Read→Answer     Good vs bad search      Reward = did you find it?
+```
+
+### SFT: Teaching the Search-Read-Answer Loop
+
+**Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
+
+```bash
+cd Trainers/rtx3090_sft
+
+python train_sft.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_sft.jsonl \
+  --num-epochs 3 \
+  --learning-rate 2e-4
+```
+
+**What SFT learns:**
+- The three-stage loop structure (search → select → answer)
+- How to generate effective search terms from a question
+- How to decide which results to read (and which to skip)
+- How to ground answers in document content
+- When to say "I couldn't find that information"
+
+### KTO: Teaching Search Judgment
+
+**Dataset:** Interleaved true/false pairs. Same question, contrasting quality.
+
+Negative examples come naturally from rubric failures during validation:
+- **Bad search terms** (too broad, wrong vocabulary) → `label: false`
+- **Reading everything** instead of selecting → `label: false`
+- **Hallucinated answers** that go beyond what the docs say → `label: false`
+- **Missed answers** where the model says "not found" but the doc was there → `label: false`
+
+```bash
+cd Trainers/rtx3090_kto
+
+python train_kto.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_kto.jsonl \
+  --num-epochs 1 \
+  --learning-rate 1e-6
+```
+
+**What KTO learns:**
+- Prefer specific search terms over generic ones
+- Prefer selective reading over reading everything
+- Prefer grounded answers over hallucinated ones
+- Prefer "not found" over fabricated answers
+
+### GRPO: Optimizing Retrieval Reward (Optional)
+
+GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
+
+```bash
+cd Trainers/rtx3090_grpo
+# Set model.lora_path to KTO checkpoint in configs/config.yaml
+python train_grpo.py
+```
+
+**Reward signal:** Binary retrieval recall. The environment backend re-executes the search and checks whether the target doc appeared. 1.0 if yes, 0.0 if no.
+
+---
+
+## Stage 5: Evaluate
+
+### Setup
+
+Copy evaluation scenarios and add a preset:
+
+```bash
+# Copy eval scenarios
+cp .skills/case-studies/configs/agentic_search_eval.yaml \
+   Evaluator/config/scenarios/agentic_search.yaml
+```
+
+Add the preset to `Evaluator/config/eval_run.yaml`:
+
+```yaml
+presets:
+  agentic_search:
+    scenarios:
+      - agentic_search.yaml
+    tags: [search, grounding, rag]
+```
+
+### Run Evaluation
+
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search \
+  --output Evaluator/results/agentic_search_v1.json \
+  --markdown Evaluator/results/agentic_search_v1.md
+```
+
+### Key Metrics
+
+| Metric | What It Measures | Target |
+|--------|-----------------|--------|
+| Search hit rate | Did the search terms retrieve the target doc? | > 80% |
+| Doc selection precision | Of docs read, how many were relevant? | > 70% |
+| Doc selection recall | Of relevant docs, how many were read? | > 90% |
+| Groundedness score | Are all claims traceable to sources? | > 85% |
+| "Not found" accuracy | When docs lack the answer, does the model say so? | > 75% |
+
+### Status Meanings
+
+| Status | Meaning |
+|--------|---------|
+| **PASS** | Found the right docs AND answered with grounding |
+| **WARN** | Found docs but answer has minor grounding issues (KTO signal) |
+| **FAIL** | Wrong docs, hallucinated answer, or missed available answer |
+
+---
+
+## Stage 6: Iterate
+
+### Common Failure Patterns
+
+| Failure | Root Cause | Fix |
+|---------|-----------|-----|
+| Bad search terms (too generic) | Not enough vocabulary-mismatch training | Add scenarios where the question uses different words than the doc |
+| Reads everything instead of selecting | Not enough distractor-heavy scenarios | Add corpora with 3-4 distractors per relevant doc |
+| Hallucinating beyond docs | Insufficient groundedness training | Add KTO negatives where the answer adds plausible-but-absent facts |
+| Missing multi-hop answers | Too few multi-hop scenarios | Add scenarios requiring info from 2+ docs to form a complete answer |
+| Never says "not found" | All training examples have answers | Add scenarios where the corpus genuinely lacks the answer |
+| Searches when answer is in context | Model always follows the loop mechanically | Add examples where the system prompt already contains enough info |
+
+### The Iteration Loop
+
+```
+Evaluate → Identify weakest metric → Generate targeted data → Retrain → Re-evaluate
+    ↑                                                                         │
+    └─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Priority order for iteration:**
+1. Groundedness (most important — hallucination is the worst failure)
+2. Search hit rate (can't answer if you can't find)
+3. Doc selection (efficiency and precision)
+4. Multi-hop (hardest capability, iterate last)
+
+---
+
+## Comparison to Context-1
+
+| Aspect | Context-1 (Chroma) | This Pipeline |
+|--------|-------------------|---------------|
+| Corpus | Pre-indexed domain corpora (web, SEC, patents, email) | Generated per-seed via environment backend |
+| Data pattern | Explore → verify → extend | Search → select → answer (same idea, different names) |
+| RL reward | Retrieval recall (CISPO) | Retrieval recall via GRPO (same signal) |
+| Context pruning | Trained as a separate capability | Not included (train separately if needed) |
+| Parallel tool calls | Part of training | Not included (train separately if needed) |
+| Evaluation | Custom harness | YAML-driven Evaluator with presets |
+| Simplification | Full production pipeline | Focused on the three-stage core |
+
+**What we borrowed:** The explore-verify-extend pattern for data generation, and verifiable retrieval rewards for RL.
+
+**What we simplified:** No context pruning (separate capability, separate training), no parallel tool calls (train via the tool-calling pipeline first).
+
+**What's different:** Corpus generated fresh per seed (easier to control difficulty/coverage). YAML-driven Evaluator shared with every other capability.
+
+---
+
+## File Map
+
+```
+.skills/case-studies/configs/agentic_search_*.yaml  ← Template configs to copy
+SynthChat/scenarios/agentic_search.yaml             ← Generation scenario (after copy)
+SynthChat/rubrics/search_term_quality.yaml          ← Search quality rubric
+SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
+SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
+Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
+Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
+Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
+Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
+Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+```
+
+---
+
+## Cross-References
+
+| Stage | Skill for CLI Details |
+|-------|----------------------|
+| Scenario authoring | `synethetic-data-generation` |
+| Rubric authoring | `synethetic-data-generation` (rubrics section) |
+| SFT / KTO / GRPO flags | `fine-tuning` |
+| Evaluator presets | `evaluation` |
+| Upload trained model | `upload-deployment` |

--- a/.skills/case-studies/SKILL.md
+++ b/.skills/case-studies/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: case-studies
-description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers two complete worked examples — tool-calling training and essay-style training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
+description: End-to-end case studies showing how to implement the full training pipeline for different skill types. Covers three complete worked examples — tool-calling training, essay-style training, and agentic search (RAG agent) training — demonstrating dataset design, synthetic generation, validation, fine-tuning, evaluation, and iteration. Use when onboarding to the project, understanding how all components fit together, explaining the pipeline to others, or planning a new training capability. This skill is about UNDERSTANDING the system holistically — reference the other skills for specific CLI commands.
 allowed-tools: Read, Bash, Write, Grep, Glob
 ---
 
 # Case Studies: Implementing the Training Pipeline
 
-Two end-to-end worked examples showing how to take a capability from concept to trained model.
+Three end-to-end worked examples showing how to take a capability from concept to trained model.
 
 ## Why Case Studies?
 
@@ -18,16 +18,17 @@ The other skills teach you how to use individual tools:
 
 This skill shows you **how they all connect** — the decisions, the iteration, and the order of operations that turn an idea into a trained capability.
 
-## The Two Case Studies
+## The Three Case Studies
 
 | Case Study | What It Teaches | Reference |
 |-----------|----------------|-----------|
 | **Tool Calling** | Structured output training — teaching a model to call APIs with correct syntax, context objects, and parameters | `reference/tool-calling-pipeline.md` |
 | **Essay Style** | Creative output training — teaching a model to transform messy brainstorms into structured outlines with voice and personality | `reference/essay-style-pipeline.md` |
+| **Agentic Search** | RAG agent training — teaching a model to search a corpus, select relevant documents, and answer grounded in sources | `reference/agentic-search-pipeline.md` |
 
 ## The Universal Pipeline
 
-Both case studies follow the same high-level pipeline, but diverge in dataset design and validation:
+All three case studies follow the same high-level pipeline, but diverge in dataset design and validation:
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -96,7 +97,8 @@ After evaluation, the failure analysis tells you exactly what to generate next. 
 |-----------|-------------|
 | **Tool Calling Pipeline** | Understanding the full tools training journey — from schema to trained model | `reference/tool-calling-pipeline.md` |
 | **Essay Style Pipeline** | Understanding the full essay training journey — from brainstorm to outline model | `reference/essay-style-pipeline.md` |
-| **Pipeline Comparison** | Side-by-side comparison of how the two pipelines differ at each stage | `reference/pipeline-comparison.md` |
+| **Agentic Search Pipeline** | Understanding the full RAG agent training journey — from corpus to grounded-answer model | `reference/agentic-search-pipeline.md` |
+| **Pipeline Comparison** | Side-by-side comparison of how the pipelines differ at each stage | `reference/pipeline-comparison.md` |
 
 ## Cross-References to Other Skills
 
@@ -114,5 +116,6 @@ At each stage of the pipeline, you'll use tools documented in the other skills:
 
 - Read the tool-calling case study first — it's the simpler, more mechanical pipeline
 - The essay case study shows how to adapt the pipeline for creative/subjective outputs
-- Both pipelines use the same trainers, evaluator, and upload tools — only the data differs
+- The agentic search case study shows how to train multi-step reasoning where tools are means to an end
+- All three pipelines use the same trainers, evaluator, and upload tools — only the data differs
 - When planning a new capability, map it to whichever case study is closer, then adapt

--- a/.skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.skills/case-studies/configs/agentic_search_eval.yaml
@@ -2,29 +2,28 @@
 # AGENTIC SEARCH EVALUATION — TEMPLATE
 # ============================================================
 #
-# TOOL-AGNOSTIC: This template uses placeholder tool names.
-# You MUST customize before running:
+# TOOL-AGNOSTIC: Replace YOUR_SEARCH_TOOL / YOUR_READ_TOOL
+# with your actual tools before running.
 #
-#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
-#      (e.g., searchManager_searchContent, rag_search, etc.)
+# TWO EVALUATION MODES:
 #
-#   2. Replace YOUR_READ_TOOL with your actual document-read tool
-#      (e.g., contentManager_read, doc_reader, etc.)
+#   STATIC MODE (no --env-backend flag)
+#     Corpus embedded in system prompt. Tests whether the model
+#     knows HOW to search/read/answer. Quick, no extra setup.
+#     Run: python -m Evaluator.cli --preset agentic_search
 #
-#   3. If using environment-backed evaluation, supply:
-#        --env-tool-schema <path>    (tool JSON schemas)
-#        --env-exec-config <path>    (execution backend config)
-#
-#   4. Adapt the embedded corpus in each system prompt to your
-#      domain if desired. The default corpus is domain-neutral.
-#
-# Each test embeds a small self-contained corpus (3-5 short docs)
-# inside the system prompt so scenarios are portable and do not
-# require an external document store.
+#   RUNTIME MODE (--env-backend local)
+#     Real files in an isolated temp filesystem. Tool calls are
+#     ACTUALLY EXECUTED — search returns real matches, read
+#     returns real content. Tests real search-find-answer ability.
+#     Run: python -m Evaluator.cli --preset agentic_search_runtime \
+#       --env-backend local \
+#       --env-tool-schema path/to/your_tool_schema.yaml \
+#       --env-exec-config path/to/your_exec_config.yaml
 #
 # Tags: agentic_search, search_quality, grounding, multi_hop,
-#        distractor_resistance, no_answer
-# ID convention: AS_<description>
+#        distractor_resistance, no_answer, runtime
+# ID conventions: AS_* (static), ASR_* (runtime)
 # ============================================================
 
 name: Agentic Search Evaluation
@@ -615,38 +614,368 @@ tests:
       Including S3 in the answer is a failure. The s3-deep-dive doc is
       a distractor.
 
+  # ================================================================
+  # RUNTIME MODE TESTS (ASR_*)
+  #
+  # These tests use fixture-based filesystems and agentic loops.
+  # The model's tool calls are ACTUALLY EXECUTED against real files.
+  # The system prompt does NOT contain the corpus — the model must
+  # discover content by searching and reading.
+  #
+  # Requires: --env-backend local --env-tool-schema --env-exec-config
+  # ================================================================
+
+  # ------------------------------------------------------------------
+  # R1. Runtime: Single-doc lookup
+  # ------------------------------------------------------------------
+  - id: ASR_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/config-reference.md
+            body: |
+              # Data Loader Configuration Reference
+              The data loader supports batch sizes from 1 to 512. The default
+              batch size is 32. Set `batch_size` in loader.yaml to override.
+              Larger batch sizes require proportionally more GPU memory.
+          - path: docs/quickstart-guide.md
+            body: |
+              # Quick Start Guide
+              Install dependencies with `pip install -r requirements.txt`.
+              Run `python main.py` to start. See config-reference for tuning.
+          - path: docs/changelog-v2.md
+            body: |
+              # Changelog v2.0
+              Added streaming mode. Fixed memory leak in tokenizer.
+              Bumped minimum Python version to 3.10.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_single_doc_lookup. Model must actually search
+      and read files to find the answer (512). No corpus in system prompt.
+
+  # ------------------------------------------------------------------
+  # R2. Runtime: Multi-hop reasoning
+  # ------------------------------------------------------------------
+  - id: ASR_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-catalog.md
+            body: |
+              # Service Catalog
+              billing-service: Handles invoicing, payment processing, and
+              retry logic for failed transactions. Owner: see team-directory.
+              auth-service: SSO and token management. Owner: Platform team.
+              notification-service: Email and push alerts. Owner: Comms team.
+          - path: docs/team-directory.md
+            body: |
+              # Team Directory
+              Platform team: auth-service, infra-gateway.
+              Payments team: billing-service, refund-engine.
+              Comms team: notification-service, template-renderer.
+          - path: docs/oncall-schedule.md
+            body: |
+              # On-Call Schedule — Q1
+              Week 1: Platform team. Week 2: Payments team.
+              Week 3: Comms team. Week 4: rotate.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_hop_reasoning. Model must search for
+      payment retries → find billing-service → search for team owner →
+      find Payments team. Requires reading 2 documents minimum.
+
+  # ------------------------------------------------------------------
+  # R3. Runtime: Distractor resistance
+  # ------------------------------------------------------------------
+  - id: ASR_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/gateway-config.md
+            body: |
+              # API Gateway Configuration
+              The gateway forwards requests to backend services. Default
+              timeout: 30 seconds. Override with `gateway.timeout_ms` in
+              gateway.yaml. Health-check interval: 10 seconds.
+          - path: docs/client-sdk-timeouts.md
+            body: |
+              # Client SDK — Timeout Settings
+              The Python client SDK has a default request timeout of 60 seconds.
+              Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+              These are CLIENT-SIDE values and do not affect the gateway.
+          - path: docs/database-pool.md
+            body: |
+              # Database Connection Pool
+              Connection timeout: 5 seconds. Query timeout: 15 seconds.
+              Pool size: 20 connections. Idle timeout: 300 seconds.
+          - path: docs/monitoring-alerts.md
+            body: |
+              # Monitoring & Alerts
+              Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+              Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_distractor_resistance. Four files mention
+      "timeout" — model must find gateway-config.md specifically and
+      answer 30 seconds, not confuse with client 60s or DB 5s values.
+
+  # ------------------------------------------------------------------
+  # R4. Runtime: No-answer detection
+  # ------------------------------------------------------------------
+  - id: ASR_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/remote-work-policy.md
+            body: |
+              # Remote Work Policy — Full-Time Employees
+              Full-time employees may work remotely up to 3 days per week.
+              Manager approval required for fully remote arrangements.
+              Equipment stipend: $500/year. VPN required for all remote access.
+          - path: docs/contractor-onboarding.md
+            body: |
+              # Contractor Onboarding Guide
+              Contractors receive a company laptop and badge access.
+              NDA must be signed before day one. Billing cycle: net-30.
+              Contact procurement@company.com for equipment issues.
+          - path: docs/benefits-summary.md
+            body: |
+              # Benefits Summary — 2025
+              Health insurance, 401k match, PTO policy, parental leave.
+              Applies to full-time employees only.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_no_answer_detection. Remote-work policy covers
+      FTEs only. Contractor onboarding doesn't mention remote work. Model
+      should search, read, and conclude the info isn't in the corpus.
+
+  # ------------------------------------------------------------------
+  # R5. Runtime: Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: ASR_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+      - runtime
+    system: |
+      You are a documentation assistant. Search the available documents
+      to answer the user's question. Use your search and read tools to
+      find relevant content. Answer ONLY based on what you find. If the
+      information is not available, say so.
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+    environment:
+      fixture:
+        directories: [docs]
+        notes:
+          - path: docs/service-overview.md
+            body: |
+              # Microservices Overview
+              The platform runs 12 microservices. Each has its own config.
+              Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+              Service-specific vars documented in each service's config doc.
+          - path: docs/email-service-config.md
+            body: |
+              # Email Notification Service — Configuration
+              Required environment variables:
+                SMTP_HOST: Mail server hostname
+                SMTP_PORT: Mail server port (default: 587)
+                SMTP_USER: Authentication username
+                SMTP_PASS: Authentication password
+                FROM_ADDRESS: Default sender address
+                TEMPLATE_DIR: Path to email templates
+              Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+          - path: docs/push-service-config.md
+            body: |
+              # Push Notification Service — Configuration
+              Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+              Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+          - path: docs/sms-service-config.md
+            body: |
+              # SMS Notification Service — Configuration
+              Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+              Optional: MAX_SMS_LENGTH (default: 160).
+          - path: docs/deploy-runbook.md
+            body: |
+              # Deployment Runbook
+              Step 1: Pull latest images. Step 2: Run migrations.
+              Step 3: Set env vars per service config docs. Step 4: Deploy.
+              Rollback: revert to previous image tag.
+      loop:
+        enabled: true
+        mode: agentic
+        max_turns: 6
+        max_tool_steps: 6
+        stop_on_text_response: true
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Runtime variant of AS_multi_step_refinement. Broad search for
+      "environment variables" hits many files. Model should narrow to
+      "email service" or "email notification config" to find the right
+      doc. Answer: SMTP_HOST, SMTP_PORT, SMTP_USER, SMTP_PASS,
+      FROM_ADDRESS, TEMPLATE_DIR (required) + RATE_LIMIT_PER_HOUR.
+
 # ============================================================
 # PRESET CONFIGURATION
 # ============================================================
 #
-# Add the following block to Evaluator/config/eval_run.yaml
-# under the existing `presets:` key:
+# Add these blocks to Evaluator/config/eval_run.yaml under `presets:`:
 #
+#   # Static mode — corpus in system prompt, quick behavioral check
 #   agentic_search:
-#     description: "RAG agent: search -> select -> answer from docs"
+#     description: "RAG agent: search -> select -> answer (static corpus)"
 #     scenarios:
 #       - agentic_search_prompts.yaml
 #     tag_filter:
 #       - agentic_search
+#     exclude_tags:
+#       - runtime
 #     scoring:
 #       pass_threshold: 0.8
 #       weights:
 #         tool_correct: 1.0
 #         behavior_pass: 0.5
 #         response_type_match: 0.3
-#     category_thresholds:
-#       multi_hop: 0.70
-#       distractor_resistance: 0.85
-#       grounding: 0.80
-#       no_answer: 0.90
 #
-# Then copy (or symlink) this scenario file into:
-#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#   # Runtime mode — real filesystem, actual tool execution
+#   agentic_search_runtime:
+#     description: "RAG agent: live search -> read -> answer (runtime env)"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - runtime
+#     scoring:
+#       pass_threshold: 0.8
 #
-# Run with:
-#   python -m Evaluator.cli --preset agentic_search
+# Copy this file to: Evaluator/config/scenarios/agentic_search_prompts.yaml
 #
-# Or with environment backend:
-#   python -m Evaluator.cli --preset agentic_search \
-#     --env-tool-schema <path> --env-exec-config <path>
+# Static:  python -m Evaluator.cli --preset agentic_search
+# Runtime: python -m Evaluator.cli --preset agentic_search_runtime \
+#            --env-backend local \
+#            --env-tool-schema <path> --env-exec-config <path>
 # ============================================================

--- a/.skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.skills/case-studies/configs/agentic_search_eval.yaml
@@ -1,0 +1,652 @@
+# ============================================================
+# AGENTIC SEARCH EVALUATION — TEMPLATE
+# ============================================================
+#
+# TOOL-AGNOSTIC: This template uses placeholder tool names.
+# You MUST customize before running:
+#
+#   1. Replace YOUR_SEARCH_TOOL with your actual search tool
+#      (e.g., searchManager_searchContent, rag_search, etc.)
+#
+#   2. Replace YOUR_READ_TOOL with your actual document-read tool
+#      (e.g., contentManager_read, doc_reader, etc.)
+#
+#   3. If using environment-backed evaluation, supply:
+#        --env-tool-schema <path>    (tool JSON schemas)
+#        --env-exec-config <path>    (execution backend config)
+#
+#   4. Adapt the embedded corpus in each system prompt to your
+#      domain if desired. The default corpus is domain-neutral.
+#
+# Each test embeds a small self-contained corpus (3-5 short docs)
+# inside the system prompt so scenarios are portable and do not
+# require an external document store.
+#
+# Tags: agentic_search, search_quality, grounding, multi_hop,
+#        distractor_resistance, no_answer
+# ID convention: AS_<description>
+# ============================================================
+
+name: Agentic Search Evaluation
+description: >-
+  Tests a model's ability to search a document corpus, select relevant
+  documents, synthesize information, and provide grounded answers. Covers
+  single-doc lookup, multi-hop reasoning, distractor resistance,
+  no-answer detection, term specificity, vocabulary mismatch,
+  multi-step refinement, and grounded citation.
+
+tests:
+
+  # ------------------------------------------------------------------
+  # 1. Simple single-doc search
+  # ------------------------------------------------------------------
+  - id: AS_single_doc_lookup
+    question: "What is the maximum batch size supported by the data loader?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a documentation assistant. Answer the user's question using
+      ONLY the documents available through search. Do not guess.
+
+      <corpus>
+      [doc_id: config-reference]
+      Title: Data Loader Configuration Reference
+      The data loader supports batch sizes from 1 to 512. The default
+      batch size is 32. Set `batch_size` in loader.yaml to override.
+      Larger batch sizes require proportionally more GPU memory.
+
+      [doc_id: quickstart-guide]
+      Title: Quick Start Guide
+      Install dependencies with `pip install -r requirements.txt`.
+      Run `python main.py` to start. See config-reference for tuning.
+
+      [doc_id: changelog-v2]
+      Title: Changelog v2.0
+      Added streaming mode. Fixed memory leak in tokenizer.
+      Bumped minimum Python version to 3.10.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model should search for "batch size" or "data loader", find
+      config-reference, and answer 512. Single search + read is sufficient.
+
+  # ------------------------------------------------------------------
+  # 2. Multi-hop search
+  # ------------------------------------------------------------------
+  - id: AS_multi_hop_reasoning
+    question: "Which team owns the service that handles payment retries?"
+    tags:
+      - agentic_search
+      - multi_hop
+      - grounding
+    system: |
+      You are an internal knowledge-base assistant. Answer using ONLY
+      information retrieved from the available documents.
+
+      <corpus>
+      [doc_id: service-catalog]
+      Title: Service Catalog
+      billing-service: Handles invoicing, payment processing, and
+      retry logic for failed transactions. Owner: see team-directory.
+      auth-service: SSO and token management. Owner: Platform team.
+      notification-service: Email and push alerts. Owner: Comms team.
+
+      [doc_id: team-directory]
+      Title: Team Directory
+      Platform team: auth-service, infra-gateway.
+      Payments team: billing-service, refund-engine.
+      Comms team: notification-service, template-renderer.
+
+      [doc_id: oncall-schedule]
+      Title: On-Call Schedule — Q1
+      Week 1: Platform team. Week 2: Payments team.
+      Week 3: Comms team. Week 4: rotate.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Requires two hops: (1) find that billing-service handles payment
+      retries, (2) find that Payments team owns billing-service. Model
+      must combine information from service-catalog and team-directory.
+
+  # ------------------------------------------------------------------
+  # 3. Distractor resistance
+  # ------------------------------------------------------------------
+  - id: AS_distractor_resistance
+    question: "What is the default timeout for the API gateway?"
+    tags:
+      - agentic_search
+      - distractor_resistance
+      - grounding
+    system: |
+      You are a documentation assistant. Answer using ONLY the documents
+      available through search. If multiple documents mention timeouts,
+      use the one specifically about the API gateway.
+
+      <corpus>
+      [doc_id: gateway-config]
+      Title: API Gateway Configuration
+      The gateway forwards requests to backend services. Default
+      timeout: 30 seconds. Override with `gateway.timeout_ms` in
+      gateway.yaml. Health-check interval: 10 seconds.
+
+      [doc_id: client-sdk-timeouts]
+      Title: Client SDK — Timeout Settings
+      The Python client SDK has a default request timeout of 60 seconds.
+      Set `client_timeout` to adjust. The retry timeout is 120 seconds.
+      These are CLIENT-SIDE values and do not affect the gateway.
+
+      [doc_id: database-pool]
+      Title: Database Connection Pool
+      Connection timeout: 5 seconds. Query timeout: 15 seconds.
+      Pool size: 20 connections. Idle timeout: 300 seconds.
+
+      [doc_id: monitoring-alerts]
+      Title: Monitoring & Alerts
+      Alert on gateway timeout > 30s. Alert on DB timeout > 15s.
+      Alert on client error rate > 5%. Dashboard: /ops/metrics.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Three documents mention "timeout" but only gateway-config has the
+      gateway default. Model must not confuse the client SDK 60s timeout
+      or the DB 5s timeout with the gateway 30s value.
+
+  # ------------------------------------------------------------------
+  # 4. No-answer detection
+  # ------------------------------------------------------------------
+  - id: AS_no_answer_detection
+    question: "What is the company's policy on remote work for contractors?"
+    tags:
+      - agentic_search
+      - no_answer
+      - search_quality
+    system: |
+      You are an HR knowledge assistant. Answer ONLY from the available
+      documents. If the answer is not in the corpus, clearly state that
+      the information was not found.
+
+      <corpus>
+      [doc_id: remote-work-policy]
+      Title: Remote Work Policy — Full-Time Employees
+      Full-time employees may work remotely up to 3 days per week.
+      Manager approval required for fully remote arrangements.
+      Equipment stipend: $500/year. VPN required for all remote access.
+
+      [doc_id: contractor-onboarding]
+      Title: Contractor Onboarding Guide
+      Contractors receive a company laptop and badge access.
+      NDA must be signed before day one. Billing cycle: net-30.
+      Contact procurement@company.com for equipment issues.
+
+      [doc_id: benefits-summary]
+      Title: Benefits Summary — 2025
+      Health insurance, 401k match, PTO policy, parental leave.
+      Applies to full-time employees only.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: text_only
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      The remote-work policy covers full-time employees only. The
+      contractor-onboarding doc does not address remote work. The model
+      should search, read the relevant docs, and conclude that contractor
+      remote-work policy is not documented in the available corpus.
+
+  # ------------------------------------------------------------------
+  # 5. Broad vs narrow search terms
+  # ------------------------------------------------------------------
+  - id: AS_term_specificity
+    question: "How do I enable debug logging for the payment webhook handler?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer documentation assistant. Answer using the
+      available documents. Choose precise search terms.
+
+      <corpus>
+      [doc_id: logging-overview]
+      Title: Logging Overview
+      The system uses structured JSON logging. Log levels: DEBUG, INFO,
+      WARN, ERROR. Global log level set in logging.yaml. Per-module
+      overrides supported via `modules.<name>.level` keys.
+
+      [doc_id: webhook-handler-config]
+      Title: Payment Webhook Handler — Configuration
+      Enable debug logging: set `modules.payment_webhook.level: DEBUG`
+      in logging.yaml. This produces verbose request/response logs
+      including headers and payload bodies. Caution: may log PII.
+
+      [doc_id: webhook-security]
+      Title: Webhook Security
+      All inbound webhooks are verified via HMAC-SHA256 signature.
+      Invalid signatures return 403. Replay protection: 5-minute window.
+
+      [doc_id: payment-processing]
+      Title: Payment Processing Pipeline
+      Payments flow: webhook receipt -> validation -> ledger entry ->
+      notification. Retry on ledger failure: 3 attempts, exponential
+      backoff.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A broad search for "logging" would match logging-overview. A
+      narrow search for "payment webhook" or "webhook handler debug"
+      should find webhook-handler-config directly. The model should
+      select terms specific enough to reach the right document
+      efficiently.
+
+  # ------------------------------------------------------------------
+  # 6. Vocabulary mismatch
+  # ------------------------------------------------------------------
+  - id: AS_vocabulary_mismatch
+    question: "How do I throttle the request rate to avoid getting blocked?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a developer assistant. Answer using ONLY the available
+      documents. The user may use different terminology than the docs.
+
+      <corpus>
+      [doc_id: rate-limiting-guide]
+      Title: Rate Limiting Configuration
+      The API enforces per-client rate limits. Default: 100 requests
+      per minute. Configure via `rate_limit.rpm` in api.yaml. Clients
+      exceeding the limit receive HTTP 429. Implement exponential
+      backoff in your client code. Burst allowance: 20 requests.
+
+      [doc_id: caching-layer]
+      Title: Caching Layer
+      Redis-backed response cache. TTL: 60 seconds for GET endpoints.
+      Cache-Control headers respected. Purge via /admin/cache/clear.
+
+      [doc_id: auth-guide]
+      Title: Authentication Guide
+      API keys issued via /admin/keys. Include in X-API-Key header.
+      Keys rotate quarterly. Revoked keys return 401.
+
+      [doc_id: error-handling]
+      Title: Error Handling Reference
+      400: Bad request. 401: Unauthorized. 403: Forbidden.
+      429: Rate limit exceeded — retry after Retry-After header value.
+      500: Internal server error — contact support.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      User says "throttle" and "getting blocked" — the docs say
+      "rate limiting" and "HTTP 429". The model must translate the
+      user's vocabulary to the corpus terminology to find
+      rate-limiting-guide. May also surface error-handling for the
+      429 reference.
+
+  # ------------------------------------------------------------------
+  # 7. Multi-step refinement
+  # ------------------------------------------------------------------
+  - id: AS_multi_step_refinement
+    question: "What environment variables does the email notification service need?"
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a deployment assistant. Answer from the available
+      documents only. If your first search is too broad, refine it.
+
+      <corpus>
+      [doc_id: service-overview]
+      Title: Microservices Overview
+      The platform runs 12 microservices. Each has its own config.
+      Common env vars: DATABASE_URL, LOG_LEVEL, SERVICE_PORT.
+      Service-specific vars documented in each service's config doc.
+
+      [doc_id: email-service-config]
+      Title: Email Notification Service — Configuration
+      Required environment variables:
+        SMTP_HOST: Mail server hostname
+        SMTP_PORT: Mail server port (default: 587)
+        SMTP_USER: Authentication username
+        SMTP_PASS: Authentication password
+        FROM_ADDRESS: Default sender address
+        TEMPLATE_DIR: Path to email templates
+      Optional: RATE_LIMIT_PER_HOUR (default: 1000).
+
+      [doc_id: push-service-config]
+      Title: Push Notification Service — Configuration
+      Required: FIREBASE_KEY, APNS_CERT_PATH, DEVICE_REGISTRY_URL.
+      Optional: BATCH_SIZE (default: 100), RETRY_COUNT (default: 3).
+
+      [doc_id: sms-service-config]
+      Title: SMS Notification Service — Configuration
+      Required: TWILIO_SID, TWILIO_AUTH, TWILIO_FROM_NUMBER.
+      Optional: MAX_SMS_LENGTH (default: 160).
+
+      [doc_id: deploy-runbook]
+      Title: Deployment Runbook
+      Step 1: Pull latest images. Step 2: Run migrations.
+      Step 3: Set env vars per service config docs. Step 4: Deploy.
+      Rollback: revert to previous image tag.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      A search for "environment variables" hits service-overview (generic)
+      and possibly all service configs. The model should narrow to "email
+      notification" or "email service config" to reach email-service-config.
+      If the first search returns too many results, the model should
+      refine rather than dump all matches.
+
+  # ------------------------------------------------------------------
+  # 8. Grounded citation
+  # ------------------------------------------------------------------
+  - id: AS_grounded_citation
+    question: "Summarize the data retention requirements and cite which document each requirement comes from."
+    tags:
+      - agentic_search
+      - grounding
+      - search_quality
+    system: |
+      You are a compliance assistant. Answer ONLY from the available
+      documents. When stating a fact, cite the source document by name.
+
+      <corpus>
+      [doc_id: data-retention-policy]
+      Title: Data Retention Policy
+      User account data: retained for 7 years after account closure.
+      Transaction logs: retained for 5 years. Audit trails: retained
+      for 10 years. Anonymized analytics data: no retention limit.
+      Review cycle: annual.
+
+      [doc_id: gdpr-compliance]
+      Title: GDPR Compliance Addendum
+      EU user data subject to right-to-erasure. Erasure requests must
+      be fulfilled within 30 days. Retention policy overridden by
+      erasure request except where legal hold applies.
+
+      [doc_id: backup-procedures]
+      Title: Backup Procedures
+      Daily incremental backups retained for 30 days. Weekly full
+      backups retained for 90 days. Disaster recovery backups retained
+      for 1 year. All backups encrypted with AES-256.
+
+      [doc_id: security-overview]
+      Title: Security Overview
+      Encryption at rest and in transit. Access control via RBAC.
+      Penetration testing: quarterly. SOC 2 Type II certified.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must reference specific documents by name in its answer.
+      Expected citations: data-retention-policy for retention periods,
+      gdpr-compliance for erasure override, backup-procedures for
+      backup retention. Answers without citations fail grounding.
+
+  # ------------------------------------------------------------------
+  # 9. Ambiguous query requiring clarification
+  # ------------------------------------------------------------------
+  - id: AS_ambiguous_query_clarification
+    question: "How do I set up the connection?"
+    tags:
+      - agentic_search
+      - search_quality
+    system: |
+      You are a documentation assistant. Answer from the available
+      documents. If the question is too ambiguous to search effectively,
+      ask the user to clarify.
+
+      <corpus>
+      [doc_id: database-setup]
+      Title: Database Connection Setup
+      Install the database driver. Set DATABASE_URL in .env.
+      Run `python manage.py migrate` to initialize schema.
+      Connection pool size: 10 (configurable).
+
+      [doc_id: vpn-setup]
+      Title: VPN Connection Setup
+      Download the VPN client from /tools/vpn. Import the .ovpn
+      config file. Authenticate with your SSO credentials.
+      Required for remote access to staging and production.
+
+      [doc_id: api-client-setup]
+      Title: API Client Connection Setup
+      Install the SDK: `pip install our-client`. Initialize with
+      `Client(api_key="...")`. Set base_url for non-production
+      environments.
+
+      [doc_id: websocket-guide]
+      Title: WebSocket Connection Guide
+      Connect to ws://host:8080/stream. Send auth frame first.
+      Heartbeat interval: 30 seconds. Reconnect on close code 1006.
+      </corpus>
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+      - TEXT_ONLY
+    expected_response_type: clarification
+    behavior_expectations:
+      asks_for_user_input: true
+      explains_choice: true
+    anti_patterns:
+      immediate_tool_call: false
+      assumes_user_choice: true
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      "The connection" is ambiguous — four different connection types
+      exist. The model should either ask which connection type the user
+      means or briefly list the options. Picking one without asking is
+      an anti-pattern.
+
+  # ------------------------------------------------------------------
+  # 10. Search with negation constraint
+  # ------------------------------------------------------------------
+  - id: AS_negation_constraint
+    question: "List all storage backends we support OTHER THAN S3."
+    tags:
+      - agentic_search
+      - search_quality
+      - grounding
+    system: |
+      You are a platform documentation assistant. Answer from the
+      available documents only. Pay attention to constraints in the
+      user's question.
+
+      <corpus>
+      [doc_id: storage-backends]
+      Title: Supported Storage Backends
+      The platform supports four storage backends:
+        1. Amazon S3 — default for production deployments
+        2. Google Cloud Storage (GCS) — set STORAGE_BACKEND=gcs
+        3. Azure Blob Storage — set STORAGE_BACKEND=azure
+        4. Local filesystem — for development only, STORAGE_BACKEND=local
+      All backends implement the StorageProvider interface.
+
+      [doc_id: s3-deep-dive]
+      Title: S3 Configuration Deep Dive
+      Bucket naming conventions, IAM policies, cross-region
+      replication, lifecycle rules. Set AWS_REGION and S3_BUCKET.
+
+      [doc_id: migration-guide]
+      Title: Storage Migration Guide
+      To migrate between backends, run `python migrate_storage.py
+      --from s3 --to gcs`. Supports incremental migration.
+      Estimated time: ~1 hour per 100 GB.
+      </corpus>
+    expected_tools:
+      - YOUR_SEARCH_TOOL
+    acceptable_tools:
+      - YOUR_SEARCH_TOOL
+      - YOUR_READ_TOOL
+    expected_response_type: tool_with_explanation
+    behavior_expectations:
+      explains_choice: true
+      asks_for_user_input: false
+    anti_patterns:
+      immediate_tool_call: false
+    environment:
+      allowed_tools:
+        - YOUR_SEARCH_TOOL
+        - YOUR_READ_TOOL
+      max_steps: 6
+    notes: >-
+      Model must find the storage-backends doc and list GCS, Azure Blob
+      Storage, and local filesystem — excluding S3 as the user requested.
+      Including S3 in the answer is a failure. The s3-deep-dive doc is
+      a distractor.
+
+# ============================================================
+# PRESET CONFIGURATION
+# ============================================================
+#
+# Add the following block to Evaluator/config/eval_run.yaml
+# under the existing `presets:` key:
+#
+#   agentic_search:
+#     description: "RAG agent: search -> select -> answer from docs"
+#     scenarios:
+#       - agentic_search_prompts.yaml
+#     tag_filter:
+#       - agentic_search
+#     scoring:
+#       pass_threshold: 0.8
+#       weights:
+#         tool_correct: 1.0
+#         behavior_pass: 0.5
+#         response_type_match: 0.3
+#     category_thresholds:
+#       multi_hop: 0.70
+#       distractor_resistance: 0.85
+#       grounding: 0.80
+#       no_answer: 0.90
+#
+# Then copy (or symlink) this scenario file into:
+#   Evaluator/config/scenarios/agentic_search_prompts.yaml
+#
+# Run with:
+#   python -m Evaluator.cli --preset agentic_search
+#
+# Or with environment backend:
+#   python -m Evaluator.cli --preset agentic_search \
+#     --env-tool-schema <path> --env-exec-config <path>
+# ============================================================

--- a/.skills/case-studies/configs/agentic_search_eval.yaml
+++ b/.skills/case-studies/configs/agentic_search_eval.yaml
@@ -623,6 +623,22 @@ tests:
   # discover content by searching and reading.
   #
   # Requires: --env-backend local --env-tool-schema --env-exec-config
+  #
+  # ⚠️  DATA CONTAMINATION WARNING
+  #
+  # These fixture documents and questions MUST NOT overlap with your
+  # training data. If the model saw these exact docs or questions
+  # during training, evaluation measures memorization, not capability.
+  #
+  # Best practices:
+  #   - Use a held-out document set that was never in training
+  #   - Or generate fresh questions from the fixture environment
+  #     (e.g., have a teacher model write questions about the fixture
+  #     docs, then use those questions here)
+  #   - Never reuse SynthChat-generated training corpora as eval
+  #     fixtures — write new content or use a different domain
+  #   - The fixture docs below are EXAMPLES — replace them with
+  #     your own held-out content before trusting eval results
   # ================================================================
 
   # ------------------------------------------------------------------

--- a/.skills/case-studies/configs/agentic_search_rubrics.yaml
+++ b/.skills/case-studies/configs/agentic_search_rubrics.yaml
@@ -1,0 +1,463 @@
+# =============================================================================
+# AGENTIC SEARCH RUBRICS — TEMPLATE BUNDLE
+# =============================================================================
+#
+# PURPOSE
+#   Three rubric definitions for evaluating agentic search quality in training
+#   examples where a model must: (1) choose search terms, (2) select documents
+#   to read, and (3) produce a grounded answer from what it read.
+#
+# HOW TO USE
+#   1. Copy the rubric you need into SynthChat/rubrics/<rubric_name>.yaml
+#   2. Customize the judge/improver prompts for your domain and tool schema
+#   3. Run:  python -m SynthChat.services.rubric_runner --list
+#      to confirm your rubric is detected
+#
+# TOOL AGNOSTICISM
+#   These rubrics are intentionally generic. They evaluate BEHAVIOR — what was
+#   searched for, what was opened, what was claimed — not the names or schemas
+#   of specific tools. Whether your pipeline uses searchManager, a RAG
+#   retriever, grep, an MCP tool, or any other search interface, the quality
+#   criteria are the same:
+#
+#     - Did the search terms target the right vocabulary?
+#     - Did the model read the right documents?
+#     - Is the final answer faithful to what the documents actually say?
+#
+#   When you copy a rubric into SynthChat/rubrics/, replace the generic
+#   references (e.g., "search actions", "read actions") with your tool-
+#   specific field names if you want structural validations to fire.
+#
+# AVAILABLE TEMPLATE VARIABLES (for judge/improver prompts)
+#   {current_content}       — The content being evaluated (scoped by rubric scope)
+#   {system_prompt}         — Full system prompt from the training example
+#   {user_request}          — The user's message / question
+#   {assistant_response}    — The assistant's full response
+#   {feedback}              — Judge feedback (improver prompts only)
+#   {thinking_content}      — Thinking block content (if present)
+#   {original_tool_calls}   — Raw tool calls JSON (if present)
+#
+# =============================================================================
+
+
+# =============================================================================
+# RUBRIC 1: search_term_quality
+# =============================================================================
+
+name: Search Term Quality
+description: >
+  Evaluates whether the search terms the model chose would actually surface
+  the target documents in a keyword or grep-style search. Penalizes terms
+  that are too broad, too narrow, or that parrot the user's exact phrasing
+  when the underlying documents use different vocabulary.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating the SEARCH TERMS an assistant chose when answering a
+  user question. The assistant issued one or more search actions before
+  reading documents. Your job is to judge whether those search terms would
+  realistically surface the documents that contain the answer.
+
+  **Tool Calls (containing search actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  # INSTRUCTIONS
+  Examine every search term or query string the assistant used and evaluate
+  along these dimensions:
+
+  1. **Vocabulary match**: Do the search terms use words and phrases that
+     are likely to appear in the target documents? Domain-specific jargon,
+     abbreviations, and canonical names score higher than generic synonyms.
+
+  2. **Specificity**: Are the terms specific enough to filter out irrelevant
+     results? A single common word like "config" is too broad; a phrase like
+     "training learning rate schedule" is appropriately targeted.
+
+  3. **Coverage**: If the answer spans multiple topics or documents, did the
+     assistant issue enough distinct searches to cover the needed ground?
+
+  4. **Avoiding echo**: Did the assistant blindly copy the user's exact
+     question as a search query? Good search reformulates the question into
+     terms the documents are likely to contain. For example, if the user asks
+     "How do I make the model learn faster?" a good search uses terms like
+     "learning_rate" or "lr_scheduler", not "make model learn faster".
+
+  5. **Iteration awareness**: If the first search returned poor results and
+     the assistant searched again, did it adjust terms meaningfully or just
+     repeat the same query?
+
+  # SCORING
+  - **1.0** = Terms are well-chosen: domain-appropriate vocabulary, specific
+    enough to filter noise, cover the needed topics, reformulated from user
+    phrasing into document vocabulary
+  - **0.7-0.9** = Mostly good terms with minor issues (slightly too broad,
+    one redundant search, partial echo of user phrasing)
+  - **0.4-0.6** = Terms are mediocre: overly generic, echo user phrasing
+    without reformulation, or miss an important topic
+  - **0.0-0.3** = Terms are poor: would not surface target docs, completely
+    wrong vocabulary, or no search was performed at all
+
+  # FORMAT
+  Return JSON: {"searchtermquality_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the search terms an assistant used when answering a
+  user question. The judge found issues with the original search terms.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. Search terms use vocabulary that matches the target documents, not the
+     user's exact phrasing
+  2. Terms are specific enough to filter irrelevant results but not so
+     narrow that they miss relevant documents
+  3. Multiple searches cover all topics needed to answer the question
+  4. If the system prompt describes the corpus structure (folders, file
+     names, tags), use that knowledge to craft targeted queries
+
+  Preserve the original tool call structure and format. Only change the
+  search query strings and add/remove search actions as needed.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    searchtermquality_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - searchtermquality_score
+
+validations:
+  # Verify that at least one tool call exists (the model should be searching)
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should issue search actions before answering"
+
+
+# =============================================================================
+# RUBRIC 2: doc_selection
+# =============================================================================
+
+---
+name: Document Selection
+description: >
+  Evaluates whether the model selected the right documents to read after
+  searching. Penalizes reading too few documents (incomplete answer), reading
+  too many (inefficient), skipping relevant results, or falling for distractor
+  documents that match keywords but are irrelevant.
+scope: tool_calls
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating which documents the assistant chose to READ (open, fetch,
+  or retrieve full content) after performing search actions. Your job is to
+  judge whether the selection was appropriate for answering the user's question.
+
+  **Tool Calls (containing search and read actions):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  # INSTRUCTIONS
+  Examine the sequence of tool calls to identify which documents were read
+  (opened, fetched, retrieved) and evaluate along these dimensions:
+
+  1. **Relevance**: Did the assistant read documents that actually contain
+     information needed to answer the question? Cross-reference the user's
+     question, the system prompt's description of available content, and what
+     the assistant ultimately said in its response.
+
+  2. **Distractor avoidance**: Did the assistant skip documents that share
+     keywords with the question but contain irrelevant content? For example,
+     a file called "training_logs.md" might match a search for "training"
+     but be irrelevant if the user asked about training configuration.
+
+  3. **Sufficiency**: Did the assistant read ENOUGH documents to fully answer
+     the question? If the answer requires information from three documents
+     and only one was read, that is insufficient.
+
+  4. **Efficiency**: Did the assistant avoid reading everything blindly? If
+     10 results were returned and only 2 are relevant, reading all 10 is
+     wasteful. Reading 2-3 targeted documents is efficient.
+
+  5. **Progressive narrowing**: If the assistant read one document and then
+     decided to read more, was that decision reasonable based on what the
+     first document contained?
+
+  # SCORING
+  - **1.0** = Read exactly the right documents: all relevant docs included,
+    distractors skipped, efficient selection
+  - **0.7-0.9** = Good selection with minor issues (one unnecessary read,
+    or one mildly relevant doc skipped)
+  - **0.4-0.6** = Mediocre selection: missed an important document, read
+    several distractors, or read everything without filtering
+  - **0.0-0.3** = Poor selection: missed the key document entirely, read
+    only distractors, or did not read any documents at all
+
+  # FORMAT
+  Return JSON: {"docselection_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving the document selection in an assistant's tool call
+  sequence. The judge found issues with which documents were read.
+
+  **Current Tool Calls:**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt (describes available documents/corpus):**
+  ```
+  {system_prompt}
+  ```
+
+  **Assistant Response:**
+  ```
+  {assistant_response}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate improved tool calls where:
+  1. The assistant reads documents that contain information needed to answer
+     the question (check the system prompt for clues about document content)
+  2. Distractor documents with misleading names are skipped
+  3. The selection is sufficient — enough documents are read to fully answer
+     the question
+  4. The selection is efficient — no unnecessary reads of clearly irrelevant
+     documents
+  5. Search actions remain the same (or are only adjusted if the original
+     searches could not have surfaced the right documents)
+
+  Preserve the original tool call structure and format. Add or remove read
+  actions as needed, and reorder if the sequence matters.
+
+  Output ONLY the improved tool calls.
+
+output_schema:
+  type: object
+  properties:
+    docselection_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - docselection_score
+
+validations:
+  # Verify that at least one read/fetch action exists
+  - match: 'tool_calls|function|calls'
+    type: regex
+    error: "No tool calls detected — the assistant should read documents before answering"
+
+
+# =============================================================================
+# RUBRIC 3: groundedness
+# =============================================================================
+
+---
+name: Groundedness
+description: >
+  Evaluates whether the assistant's final answer is faithful to the content
+  of the documents it read. Penalizes fabricated claims, meaning-altering
+  paraphrases, and failure to acknowledge when documents do not cover a topic.
+scope: response
+pass_threshold: 0.8
+
+judge_prompt: |
+  # CONTEXT
+  You are evaluating whether the assistant's response is GROUNDED in the
+  documents it read. Every factual claim in the response should be traceable
+  to a specific passage in the retrieved content. The assistant should not
+  invent information, and should explicitly say when it cannot find something.
+
+  **Assistant Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Thinking Block (if present):**
+  ```
+  {thinking_content}
+  ```
+
+  # INSTRUCTIONS
+  Evaluate the response along these dimensions:
+
+  1. **Traceability**: Can every factual claim (names, numbers, dates,
+     procedures, configurations) be traced back to a specific passage in the
+     documents the assistant read? Claims that appear in the response but not
+     in any read document are hallucinations.
+
+  2. **No added information**: Does the response avoid introducing facts,
+     details, or context not present in the documents? General knowledge
+     framing ("This is a common pattern...") is acceptable; specific claims
+     ("The default learning rate is 2e-4") must come from the documents.
+
+  3. **Faithful paraphrasing**: When the response paraphrases document
+     content rather than quoting it, does the paraphrase preserve the
+     original meaning? Watch for subtle meaning shifts — e.g., changing
+     "recommended" to "required", or "up to 10" to "exactly 10".
+
+  4. **Appropriate uncertainty**: When the documents do not cover part of
+     the user's question, does the response acknowledge this gap? Phrases
+     like "I could not find information about X in the documents" are good.
+     Silently making up an answer is bad. Confidently stating something the
+     documents do not support is the worst case.
+
+  5. **No over-generalization**: Does the response avoid broadening specific
+     claims from the documents? If a document says "Feature X works with
+     model Y," the response should not claim "Feature X works with all
+     models" unless the document supports that.
+
+  # SCORING
+  - **1.0** = Every claim is traceable to the documents, gaps are
+    acknowledged, paraphrasing is faithful, no added information
+  - **0.7-0.9** = Mostly grounded with minor issues (one slightly loose
+    paraphrase, a minor added detail that is broadly correct)
+  - **0.4-0.6** = Several ungrounded claims, or one significant fabrication,
+    or fails to acknowledge a gap in document coverage
+  - **0.0-0.3** = Major fabrications: invents key facts, contradicts the
+    documents, or confidently answers questions the documents do not address
+
+  # FORMAT
+  Return JSON: {"groundedness_score": 0.0-1.0}
+
+improver_prompt: |
+  # CONTEXT
+  You are improving an assistant's response to ensure it is grounded in the
+  documents that were read. The judge found issues with faithfulness.
+
+  **Current Response:**
+  ```
+  {current_content}
+  ```
+
+  **Tool Calls (showing what was searched and read):**
+  ```json
+  {original_tool_calls}
+  ```
+
+  **User Question:**
+  ```
+  {user_request}
+  ```
+
+  **System Prompt:**
+  ```
+  {system_prompt}
+  ```
+
+  **Judge Feedback:**
+  ```
+  {feedback}
+  ```
+
+  # INSTRUCTIONS
+  Generate an improved response where:
+  1. Every factual claim can be traced to a passage in the read documents
+  2. Remove or correct any claims not supported by the documents
+  3. Where the documents do not cover part of the user's question, explicitly
+     state that: "I was not able to find information about [topic] in the
+     available documents"
+  4. Preserve the helpful structure and tone of the original response
+  5. If the original response paraphrased something in a way that changed
+     its meaning, fix the paraphrase to be faithful to the source
+  6. Do not add new information from outside the documents — only use what
+     the assistant actually retrieved
+
+  Output ONLY the improved response text.
+
+output_schema:
+  type: object
+  properties:
+    groundedness_score:
+      type: number
+      min: 0.0
+      max: 1.0
+  required:
+    - groundedness_score
+
+validations:
+  # Verify the response is not empty
+  - match: '\S+'
+    type: regex
+    error: "Response is empty — the assistant must provide an answer after reading documents"

--- a/.skills/case-studies/configs/agentic_search_scenario.yaml
+++ b/.skills/case-studies/configs/agentic_search_scenario.yaml
@@ -1,0 +1,438 @@
+# ╔══════════════════════════════════════════════════════════════════╗
+# ║  AGENTIC SEARCH — Scenario Template                            ║
+# ║                                                                ║
+# ║  BEFORE USING: Replace placeholder tool names with YOUR tools  ║
+# ║                                                                ║
+# ║  Placeholders:                                                 ║
+# ║    YOUR_SEARCH_TOOL  → e.g., grep, ripgrep, searchAPI, etc.   ║
+# ║    YOUR_READ_TOOL    → e.g., cat, readFile, fetchDoc, etc.    ║
+# ║    YOUR_LIST_TOOL    → e.g., ls, listFiles, dirList, etc.     ║
+# ║                                                                ║
+# ║  The three-stage pattern (search → read → answer) is the      ║
+# ║  constant. The actual tools are YOUR choice.                   ║
+# ║                                                                ║
+# ║  Run with --env-tool-schema and --env-exec-config to provide   ║
+# ║  your tool definitions.                                        ║
+# ╚══════════════════════════════════════════════════════════════════╝
+
+# ---------------------------------------------------------------------------
+# Shared anchors — reused across all agentic search scenarios
+# ---------------------------------------------------------------------------
+
+shared_agentic_environment: &shared_agentic_environment
+  loop:
+    enabled: true
+    mode: agentic
+    max_turns: 6
+    max_tool_steps: 6
+    stop_on_text_response: true
+    require_final_text_after_pass: true
+    final_text_prompt: Reply to the user with a concise answer grounded in the documents you read. Do not call tools.
+    continue_on_execution_error: true
+    stuck_repeat_limit: 2
+    no_progress_window: 3
+
+shared_tutored_judge: &shared_tutored_judge
+  in_loop:
+    enabled: true
+    feedback_visible_to_model: true
+    temperature: 0.1
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    prompt: |
+      You are tutoring an agentic search assistant generating high-quality training data.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      Messages so far:
+      {messages_json}
+
+      Latest assistant response:
+      {assistant_response_json}
+
+      Latest environment step:
+      {environment_step_json}
+
+      Tool feedback shown to the model:
+      {tool_feedback}
+
+      Evaluate the assistant on three dimensions:
+      1. SEARCH QUALITY — Did it generate effective search terms that surface the
+         target documents without being so broad that distractors dominate?
+      2. SELECTIVE READ — Did it read the correct documents and skip irrelevant
+         results? Did it avoid reading every result indiscriminately?
+      3. ANSWER GROUNDEDNESS — Is the answer derived from document content only?
+         Flag any claim not traceable to a read document.
+
+      Treat task_context fields as the source of truth for which documents are
+      targets vs. distractors. Do not accept a distractor document as a valid
+      source even if its content seems related.
+
+      Return passed=true only if the hard requirements are already satisfied by
+      the latest assistant action and tool feedback. If any hard requirement is
+      still unmet, return passed=false and explain the next best corrective step.
+
+      Use feedback_to_model for concise tutoring about the next best move.
+      Only ask for a short final text-only answer after the hard requirements
+      are actually satisfied.
+
+shared_environment_generation_review: &shared_environment_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: environment_payload_shape
+      field: value
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated knowledge base environment for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Normalized environment snapshot:
+      {value_json}
+
+      Return passed=true only if the environment:
+      - Contains 15-20 documents across 3-5 distinct topic areas
+      - Has realistic document content (multi-paragraph, not just titles or stubs)
+      - Includes deliberate distractors: documents with overlapping keywords but
+        different topics that could mislead a naive search
+      - Spreads some answers across multiple files to support multi-hop retrieval
+      - Does not make target documents trivially identifiable by filename alone
+      - Is internally consistent (cross-references between docs are valid)
+
+      Penalize environments that are too sparse, have uniform document lengths,
+      or contain documents that are obviously fake (lorem ipsum, placeholder text).
+
+shared_user_generation_review: &shared_user_generation_review
+  enforce: true
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+  gates:
+    - type: non_empty_text
+      field: text
+    - type: plain_text
+      field: text
+    - type: no_tool_names
+      field: text
+    - type: no_exact_paths_from_context
+      field: text
+      sources: [task_context]
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a generated user question for agentic search training.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      User text:
+      {user_text}
+
+      Return passed=true only if:
+      - The question sounds like a real human asking for information
+      - It does NOT leak exact file paths, document IDs, or tool names
+      - It does NOT contain search terms that would trivially match only the
+        target document (the assistant must figure out effective search terms)
+      - It is specific enough that there IS a correct answer in the corpus
+      - For multi-hop scenarios, the question naturally requires synthesizing
+        information from multiple sources
+
+shared_final_review: &shared_final_review
+  enforce: true
+  gates:
+    - type: field_equals
+      field: environment_passed
+      value: true
+  judge:
+    enabled: true
+    max_retries: 3
+    fallback_models:
+      - google/gemini-3.1-flash-lite-preview
+    temperature: 0.1
+    prompt: |
+      You are reviewing a completed agentic search training example.
+
+      Scenario key:
+      {scenario_key}
+
+      Task context:
+      {task_context_json}
+
+      Final environment result:
+      {environment_result_json}
+
+      Final assistant response:
+      {assistant_response_json}
+
+      Conversation trace:
+      {conversation_trace_json}
+
+      Hard requirements:
+      {hard_requirements_json}
+
+      Quality rubric:
+      {quality_rubric_json}
+
+      If environment_result.passed is true, treat the hard requirements as already
+      satisfied by the programmatic environment validator. Do not override that by
+      re-inferring document contents from earlier tool traces.
+
+      In that case, judge only whether this is a high-quality training example:
+      - The search strategy was reasonable (not brute-force read-everything)
+      - The assistant selected the right documents and skipped distractors
+      - The final answer is grounded in document content with no hallucination
+      - The trajectory is coherent and the tutor feedback is sensible
+      - The ending response is a natural answer to the user question
+
+      If environment_result.passed is false, then passed must be false.
+
+shared_assistant_generation: &shared_assistant_generation
+  max_retries: 3
+  fallback_models:
+    - google/gemini-3.1-flash-lite-preview
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+scenarios:
+
+  # =========================================================================
+  # SEED: Generate a realistic knowledge base for search scenarios
+  # =========================================================================
+  agentic_search_corpus_seed:
+    type: helper
+    environment_mode: generated
+    system_context:
+      available_workspaces:
+        - id: ws_search_corpus
+          name: Knowledge Base
+          description: A document corpus reused across agentic search workflows
+          root_folder: ""
+      selected_workspace:
+        id: default
+        name: Knowledge Base
+      assistant_instructions: >-
+        This seed corpus should support single-document retrieval, multi-hop
+        retrieval across documents, keyword-based search with distractors,
+        selective reading from mixed results, and grounded answer generation.
+    environment_generation:
+      <<: *shared_environment_generation_review
+      schema: canonical_environment
+      prompt: |
+        Generate one shared knowledge base that will be reused across agentic search scenarios.
+
+        Requirements:
+        - Create 15-20 documents organized across 3-5 topic areas as top-level folders.
+          Example topic areas: Engineering, Operations, Product, Research, Policies.
+          Choose your own realistic topic names and vary them across seeds.
+        - Each document must have realistic multi-paragraph content (3-8 paragraphs).
+          Think internal wiki pages, runbooks, design docs, meeting summaries, or
+          policy documents. Do not generate stubs, placeholder text, or lorem ipsum.
+        - Deliberate DISTRACTORS are critical:
+          - At least 3 documents must share keywords with a target document but
+            cover a different topic. For example, a doc about "rate limiting in
+            the CDN layer" vs. "rate limiting in the payment API" — same keyword
+            "rate limiting", different answers.
+          - At least 2 documents must have similar titles but different content.
+        - MULTI-HOP support:
+          - At least 2 answers must require combining information from 2+ documents.
+            For example, Document A says "the migration deadline is in Q3" and
+            Document B says "Q3 runs July-September" — answering "when is the
+            migration deadline?" requires both.
+          - Cross-references between documents are encouraged (e.g., "see the
+            deployment runbook for details").
+        - Include a mix of document types:
+          - Narrative docs (design docs, postmortems, meeting notes)
+          - Structured docs (runbooks with numbered steps, config references)
+          - Short docs (1-2 paragraphs) and long docs (6-8 paragraphs)
+        - Add 3-5 extra distractor files with plausible but tangential content so
+          different seeds are not clones.
+        - Vary filenames, topics, writing styles, and organizational structure
+          across seeds while preserving the role coverage above.
+        - Return environment.assertions as an empty list.
+        - Put seed-specific metadata under task_context: seed_theme,
+          distractor_paths, multi_hop_pairs, and topic_areas.
+    prompts:
+      user: ""
+      assistant: ""
+
+  # =========================================================================
+  # STAGE 1+2+3: Search, selectively read, and answer from documents
+  # =========================================================================
+  agentic_search_find_and_answer:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: search_and_answer
+      primitives: [search, read]
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        examples:
+          - "What's our policy on handling third-party API outages?"
+          - "How do we handle database failovers in production?"
+          - "What was decided about the authentication redesign?"
+      candidate_selector:
+        target:
+          min_content_length: 200
+          preferred_keywords_from: task_context
+          must_contain_answer: true
+        distractors:
+          share_keywords_with_target: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that can be answered
+        from the knowledge base. Do not mention file names, paths, or tool names.
+        Phrase it the way a colleague would ask over chat.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        First use YOUR_SEARCH_TOOL to find relevant documents, then use YOUR_READ_TOOL
+        to read the most promising results. Skip documents that are clearly irrelevant
+        based on search result summaries. After reading, provide a grounded answer.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response
+
+  # =========================================================================
+  # MULTI-HOP: Answer requires combining info from 2+ documents
+  # =========================================================================
+  agentic_search_multi_hop:
+    type: tool
+    tool: YOUR_SEARCH_TOOL
+    expected_tools: [YOUR_SEARCH_TOOL, YOUR_READ_TOOL]
+    environment_mode: provided
+    tags: [agentic_search, multi_hop, retrieval, grounding, shared_seed]
+    system_template: mocked_workspace_vault
+    judge: *shared_tutored_judge
+    user_generation: *shared_user_generation_review
+    final_judge: *shared_final_review
+    environment:
+      <<: *shared_agentic_environment
+      assertions:
+        - type: file_was_read
+          path: "{task_target_doc_1_path}"
+        - type: file_was_read
+          path: "{task_target_doc_2_path}"
+        - type: file_not_read
+          path: "{task_primary_distractor_path}"
+        - type: response_contains_text
+          text: "{task_expected_combined_answer_fragment}"
+        - type: response_not_contains_text
+          text: "{task_hallucination_canary}"
+        - type: response_contains_text
+          text: "{task_doc_1_contribution}"
+        - type: response_contains_text
+          text: "{task_doc_2_contribution}"
+    system_context:
+      assistant_instructions: >-
+        You have access to a knowledge base via search and read tools. When the
+        user asks a question, search for relevant documents, read the most
+        promising results, and answer using ONLY the content you read. Some
+        questions require combining information from multiple documents. If the
+        documents do not contain enough information, say so rather than guessing.
+    task_family:
+      kind: multi_hop_search
+      primitives: [search, read]
+      min_source_docs: 2
+      user_request_style:
+        vague_human_request: true
+        avoid_exact_paths: true
+        avoid_search_terms: true
+        reference_mode: natural_question
+        requires_synthesis: true
+        examples:
+          - "When exactly is the migration deadline and what needs to be done before then?"
+          - "Which team owns the rate limiter and what's their on-call rotation?"
+          - "What's the budget impact of the infrastructure changes planned for next quarter?"
+      candidate_selector:
+        target_pair:
+          doc_1:
+            contains_partial_answer: true
+            preferred_keywords_from: task_context
+          doc_2:
+            contains_complementary_answer: true
+            cross_references_doc_1: preferred
+        distractors:
+          share_keywords_with_targets: true
+          different_topic: true
+          min_count: 2
+    prompts:
+      user: |
+        OUTPUT ONLY the user request text.
+
+        Ask a natural question about {task_question_topic} that requires combining
+        information from at least two different documents. The question should sound
+        like a single coherent inquiry, not two separate questions joined together.
+        Do not mention file names, paths, or tool names.
+      assistant: |
+        Generate assistant response as valid JSON text only.
+
+        Return exactly one JSON object with top-level keys "content" and "tool_calls".
+        Use YOUR_SEARCH_TOOL to find relevant documents. You may need multiple searches
+        with different terms. Use YOUR_READ_TOOL to read documents that look relevant.
+        Synthesize information from multiple documents into a single coherent answer.
+        Cite which documents contributed which facts when the answer draws from
+        multiple sources.
+    assistant_generation:
+      <<: *shared_assistant_generation
+      schema: use_tools_response

--- a/.skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.skills/case-studies/reference/agentic-search-pipeline.md
@@ -295,8 +295,9 @@ presets:
     tags: [search, grounding, rag]
 ```
 
-### Run Evaluation
+### Two Evaluation Modes
 
+**Static mode** — corpus in the system prompt, quick behavioral check:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
@@ -305,6 +306,21 @@ python -m Evaluator.cli \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
 ```
+
+**Runtime mode** — real files, actual tool execution via agentic loop:
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search_runtime \
+  --env-backend local \
+  --env-tool-schema path/to/your_tool_schema.yaml \
+  --env-exec-config path/to/your_exec_rules.yaml \
+  --output Evaluator/results/agentic_search_runtime_v1.json \
+  --markdown Evaluator/results/agentic_search_runtime_v1.md
+```
+
+> **Do not train to the test.** The runtime eval fixtures (documents and questions) must NOT overlap with your training data. If the model saw these exact docs during SynthChat generation, the eval measures memorization, not capability. Use a held-out document set, or generate fresh questions from the fixture environment with a teacher model. The example fixtures in the template are placeholders — replace them with your own held-out content before trusting results.
 
 ### Key Metrics
 

--- a/.skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.skills/case-studies/reference/agentic-search-pipeline.md
@@ -1,0 +1,403 @@
+# Case Study: Agentic Search (RAG Agent) Training Pipeline
+
+A complete walkthrough of how to teach a language model to act as a RAG agent — searching a corpus, selecting relevant documents, and answering questions grounded exclusively in what it found.
+
+---
+
+> **YOUR TOOLS ARE NOT OUR TOOLS**
+>
+> This case study describes a **three-stage pattern**: Search, Select, Answer. The tool names used below (`YOUR_SEARCH_TOOL`, `YOUR_READ_TOOL`, `YOUR_LIST_TOOL`) are **placeholders**. Your system might use `grep`, `ripgrep`, a vector DB query, `cat`, `readFile`, an HTTP API, or something else entirely.
+>
+> **Before you proceed past Stage 1, you must know:**
+> 1. What tool does "search" in your system?
+> 2. What tool does "read" in your system?
+> 3. What tool does "list" in your system?
+>
+> The three-stage behavior is the constant. The tools are variables.
+
+---
+
+## Stage 1: Define the Capability
+
+### What We're Teaching
+
+The model must learn a three-stage behavior loop:
+
+1. **Search** — given a question, generate search terms that would surface target documents in a keyword/grep-style search. The model must reason about vocabulary: what words would the answer contain?
+2. **Selective Read** — from the search results, pick the relevant documents and skip distractors. Not everything returned is useful. The model must show judgment.
+3. **Grounded Answer** — answer using ONLY content from the documents it read. No hallucination. If the docs don't contain the answer, say so.
+
+### How This Differs from the Other Case Studies
+
+| Dimension | Tool Calling | Essay Style | Agentic Search |
+|-----------|-------------|-------------|----------------|
+| Goal | Call the right API | Produce creative output | Find and synthesize from sources |
+| Output | Structured JSON | Structured prose | Grounded prose with citations |
+| Tools are... | The end product | Not involved | The means to an end |
+| Validation | Schema match | Rubric scoring | Retrieval recall + groundedness |
+| Key challenge | Syntax precision | Voice preservation | Search strategy + no hallucination |
+
+Tool calling trains a model to use tools correctly. Agentic search trains a model to use tools *strategically* — the tools are a means to producing a grounded answer.
+
+### Inspiration: Explore, Verify, Extend
+
+The data generation pattern draws from Chroma's Context-1 approach: generate a seed corpus, then create training examples where the model must explore (search), verify (read and confirm), and extend (synthesize an answer). Our corpus is generated per-seed via the environment backend rather than pre-indexed, and evaluation is YAML-driven through the existing Evaluator.
+
+### The Three Rubrics
+
+Quality is governed by three rubrics, one per stage:
+
+| Rubric | Stage | What It Checks |
+|--------|-------|---------------|
+| `search_term_quality` | Search | Are the terms specific enough to retrieve target docs? Do they account for vocabulary mismatch? |
+| `doc_selection` | Select | Did the model read relevant docs and skip distractors? Precision and recall. |
+| `groundedness` | Answer | Is every claim traceable to a document? Does it say "not found" when appropriate? |
+
+---
+
+## Stage 2: Create Training Data
+
+### Prerequisites: Confirm Your Tools
+
+> **STOP.** Before writing any scenarios or generating any data, you must map the three-stage pattern to your actual tools.
+
+Define your tool mapping:
+
+| Stage | Placeholder | Your Tool | Example |
+|-------|------------|-----------|---------|
+| Search | `YOUR_SEARCH_TOOL` | ___________ | `grep`, `searchContent`, `vector_query` |
+| Read | `YOUR_READ_TOOL` | ___________ | `cat`, `read`, `fetchDocument` |
+| List | `YOUR_LIST_TOOL` | ___________ | `ls`, `list`, `listDirectory` |
+
+Once you know your tools, create the tool schema and environment execution config that match your system. The scenario YAML references these tools by name — they must match exactly.
+
+### Corpus Design
+
+The environment backend generates the corpus automatically for each training example. A good corpus has:
+
+- **Varied topics** — not all docs about the same thing
+- **Overlapping vocabulary** — docs sharing keywords but covering different topics (forces precise search)
+- **Deliberate distractors** — docs that look relevant but aren't (forces selective reading)
+- **Multi-hop potential** — answers requiring info from 2+ documents
+
+The seed scenario's `environment_generation.prompt` controls corpus shape. Customize it for your domain. Compare to Context-1's domain-specific corpora (web, SEC, patents, email) — same principle: realistic documents with realistic noise.
+
+### Scenario Types
+
+The scenario file defines three scenario types that build on each other:
+
+**1. Seed scenarios** — generate the corpus and a simple single-doc question:
+```yaml
+scenarios:
+  agentic_search_seed:
+    type: tool
+    environment_mode: generated
+    system_template: mocked_workspace_vault
+    rubrics:
+      response: [search_term_quality, doc_selection, groundedness]
+    environment_generation:
+      prompt: |
+        Generate a workspace with 5-8 documents across 2-3 topics.
+        Include 2 distractors per topic that share vocabulary but
+        cover different aspects. One document must contain the answer
+        to a factual question that requires reading (not guessing).
+```
+
+**2. Find-and-answer scenarios** — question requires searching, reading one doc, answering:
+The model must: search with good terms, pick the right doc from results, answer from its content only.
+
+**3. Multi-hop scenarios** — answer requires info from 2+ documents:
+The model must: search, read doc A, recognize it's incomplete, search again or read doc B, synthesize.
+
+### Running Generation
+
+Copy your scenario file into place and generate:
+
+```bash
+# Copy scenario (after replacing YOUR_SEARCH_TOOL etc. with real tool names)
+cp .skills/case-studies/configs/agentic_search_scenario.yaml \
+   SynthChat/scenarios/agentic_search.yaml
+
+# Dry run — check 3 examples without saving
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --count 3 \
+  --dry-run
+
+# Full generation
+python -m SynthChat.run generate \
+  --scenarios agentic_search \
+  --workers 4 \
+  --output Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Example Training Conversation
+
+Tool names below are placeholders — substitute your own:
+
+```
+system: [workspace context with corpus file listing]
+user:   "What's the maximum retry count for the payment service?"
+assistant:
+  <thinking>I should search for payment service configuration.</thinking>
+  [calls YOUR_SEARCH_TOOL with terms: "payment retry max"]
+tool:   [returns: payment_config.md, payment_overview.md, retry_policy.md]
+assistant:
+  <thinking>payment_config.md and retry_policy.md look relevant.
+  payment_overview.md is a high-level summary — skip it.</thinking>
+  [calls YOUR_READ_TOOL on payment_config.md]
+tool:   [returns file content with "max_retries: 5"]
+assistant:
+  Based on payment_config.md, the maximum retry count for the payment
+  service is **5** (configured via `max_retries: 5` in the service config).
+```
+
+All three stages visible: targeted search terms, selective reading (skipped the overview), grounded answer with citation.
+
+---
+
+## Stage 3: Validate & Improve
+
+### Structural Validation
+
+```bash
+python3 .skills/synethetic-data-generation/scripts/validate_syngen.py \
+  Datasets/synthchat/agentic_search_raw.jsonl
+```
+
+### Rubric-Based Quality Validation
+
+Copy rubric files into place, then validate:
+
+```bash
+# Copy rubrics (one file per rubric)
+cp .skills/case-studies/configs/agentic_search_rubrics/*.yaml \
+   SynthChat/rubrics/
+
+# Validate a small batch
+python -m SynthChat.run validate \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --start-line 1 --end-line 10
+```
+
+**Search term quality:** Specific to the question? Account for vocabulary mismatch? Would plausibly retrieve the target doc? Not too broad or too narrow?
+
+**Document selection:** Read the doc(s) containing the answer? Skipped distractors? Avoided reading every single result?
+
+**Groundedness:** Every claim traceable to a document? No added information? Says "not found" when docs lack the answer? Citations present?
+
+### Improvement Loop
+
+```bash
+python -m SynthChat.run improve \
+  -i Datasets/synthchat/agentic_search_raw.jsonl \
+  --rubrics search_term_quality,doc_selection,groundedness \
+  --max-iterations 5
+```
+
+### Manual Review
+
+Sample 10-20%: Do search terms feel human? Is reading selective? Can you verify the answer from the cited doc? For multi-hop, does the model actually combine info?
+
+---
+
+## Stage 4: Train
+
+### Training Sequence
+
+```
+SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
+      ↓                        ↓                        ↓
+  Search→Read→Answer     Good vs bad search      Reward = did you find it?
+```
+
+### SFT: Teaching the Search-Read-Answer Loop
+
+**Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
+
+```bash
+cd Trainers/rtx3090_sft
+
+python train_sft.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_sft.jsonl \
+  --num-epochs 3 \
+  --learning-rate 2e-4
+```
+
+**What SFT learns:**
+- The three-stage loop structure (search → select → answer)
+- How to generate effective search terms from a question
+- How to decide which results to read (and which to skip)
+- How to ground answers in document content
+- When to say "I couldn't find that information"
+
+### KTO: Teaching Search Judgment
+
+**Dataset:** Interleaved true/false pairs. Same question, contrasting quality.
+
+Negative examples come naturally from rubric failures during validation:
+- **Bad search terms** (too broad, wrong vocabulary) → `label: false`
+- **Reading everything** instead of selecting → `label: false`
+- **Hallucinated answers** that go beyond what the docs say → `label: false`
+- **Missed answers** where the model says "not found" but the doc was there → `label: false`
+
+```bash
+cd Trainers/rtx3090_kto
+
+python train_kto.py \
+  --model-size 7b \
+  --local-file ../../Datasets/synthchat/agentic_search_kto.jsonl \
+  --num-epochs 1 \
+  --learning-rate 1e-6
+```
+
+**What KTO learns:**
+- Prefer specific search terms over generic ones
+- Prefer selective reading over reading everything
+- Prefer grounded answers over hallucinated ones
+- Prefer "not found" over fabricated answers
+
+### GRPO: Optimizing Retrieval Reward (Optional)
+
+GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
+
+```bash
+cd Trainers/rtx3090_grpo
+# Set model.lora_path to KTO checkpoint in configs/config.yaml
+python train_grpo.py
+```
+
+**Reward signal:** Binary retrieval recall. The environment backend re-executes the search and checks whether the target doc appeared. 1.0 if yes, 0.0 if no.
+
+---
+
+## Stage 5: Evaluate
+
+### Setup
+
+Copy evaluation scenarios and add a preset:
+
+```bash
+# Copy eval scenarios
+cp .skills/case-studies/configs/agentic_search_eval.yaml \
+   Evaluator/config/scenarios/agentic_search.yaml
+```
+
+Add the preset to `Evaluator/config/eval_run.yaml`:
+
+```yaml
+presets:
+  agentic_search:
+    scenarios:
+      - agentic_search.yaml
+    tags: [search, grounding, rag]
+```
+
+### Run Evaluation
+
+```bash
+python -m Evaluator.cli \
+  --backend unsloth \
+  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --preset agentic_search \
+  --output Evaluator/results/agentic_search_v1.json \
+  --markdown Evaluator/results/agentic_search_v1.md
+```
+
+### Key Metrics
+
+| Metric | What It Measures | Target |
+|--------|-----------------|--------|
+| Search hit rate | Did the search terms retrieve the target doc? | > 80% |
+| Doc selection precision | Of docs read, how many were relevant? | > 70% |
+| Doc selection recall | Of relevant docs, how many were read? | > 90% |
+| Groundedness score | Are all claims traceable to sources? | > 85% |
+| "Not found" accuracy | When docs lack the answer, does the model say so? | > 75% |
+
+### Status Meanings
+
+| Status | Meaning |
+|--------|---------|
+| **PASS** | Found the right docs AND answered with grounding |
+| **WARN** | Found docs but answer has minor grounding issues (KTO signal) |
+| **FAIL** | Wrong docs, hallucinated answer, or missed available answer |
+
+---
+
+## Stage 6: Iterate
+
+### Common Failure Patterns
+
+| Failure | Root Cause | Fix |
+|---------|-----------|-----|
+| Bad search terms (too generic) | Not enough vocabulary-mismatch training | Add scenarios where the question uses different words than the doc |
+| Reads everything instead of selecting | Not enough distractor-heavy scenarios | Add corpora with 3-4 distractors per relevant doc |
+| Hallucinating beyond docs | Insufficient groundedness training | Add KTO negatives where the answer adds plausible-but-absent facts |
+| Missing multi-hop answers | Too few multi-hop scenarios | Add scenarios requiring info from 2+ docs to form a complete answer |
+| Never says "not found" | All training examples have answers | Add scenarios where the corpus genuinely lacks the answer |
+| Searches when answer is in context | Model always follows the loop mechanically | Add examples where the system prompt already contains enough info |
+
+### The Iteration Loop
+
+```
+Evaluate → Identify weakest metric → Generate targeted data → Retrain → Re-evaluate
+    ↑                                                                         │
+    └─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Priority order for iteration:**
+1. Groundedness (most important — hallucination is the worst failure)
+2. Search hit rate (can't answer if you can't find)
+3. Doc selection (efficiency and precision)
+4. Multi-hop (hardest capability, iterate last)
+
+---
+
+## Comparison to Context-1
+
+| Aspect | Context-1 (Chroma) | This Pipeline |
+|--------|-------------------|---------------|
+| Corpus | Pre-indexed domain corpora (web, SEC, patents, email) | Generated per-seed via environment backend |
+| Data pattern | Explore → verify → extend | Search → select → answer (same idea, different names) |
+| RL reward | Retrieval recall (CISPO) | Retrieval recall via GRPO (same signal) |
+| Context pruning | Trained as a separate capability | Not included (train separately if needed) |
+| Parallel tool calls | Part of training | Not included (train separately if needed) |
+| Evaluation | Custom harness | YAML-driven Evaluator with presets |
+| Simplification | Full production pipeline | Focused on the three-stage core |
+
+**What we borrowed:** The explore-verify-extend pattern for data generation, and verifiable retrieval rewards for RL.
+
+**What we simplified:** No context pruning (separate capability, separate training), no parallel tool calls (train via the tool-calling pipeline first).
+
+**What's different:** Corpus generated fresh per seed (easier to control difficulty/coverage). YAML-driven Evaluator shared with every other capability.
+
+---
+
+## File Map
+
+```
+.skills/case-studies/configs/agentic_search_*.yaml  ← Template configs to copy
+SynthChat/scenarios/agentic_search.yaml             ← Generation scenario (after copy)
+SynthChat/rubrics/search_term_quality.yaml          ← Search quality rubric
+SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
+SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
+Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
+Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
+Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
+Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
+Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+```
+
+---
+
+## Cross-References
+
+| Stage | Skill for CLI Details |
+|-------|----------------------|
+| Scenario authoring | `synethetic-data-generation` |
+| Rubric authoring | `synethetic-data-generation` (rubrics section) |
+| SFT / KTO / GRPO flags | `fine-tuning` |
+| Evaluator presets | `evaluation` |
+| Upload trained model | `upload-deployment` |


### PR DESCRIPTION
New preset for training models to search a corpus, select relevant
documents, and produce grounded answers. Inspired by Chroma Context-1's
explore-verify-extend pattern. All templates are tool-agnostic with
placeholder tool names — users must confirm their actual search/read
tools before proceeding.

Deliverables:
- Scenario template (seed corpus + find-and-answer + multi-hop)
- Three rubrics (search_term_quality, doc_selection, groundedness)
- Eval preset with 10 self-contained test cases
- End-to-end case study doc (third alongside tool-calling and essay-style)
- Updated SKILL.md index + synced mirror trees

https://claude.ai/code/session_01TY65D9dzmbD3DaXuRJR8Bo