### PR TITLE
chore(skills+docs): document local-run in skills, normalize LF line endings

### DIFF
--- a/.agents/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.agents/skills/case-studies/reference/agentic-search-pipeline.md
@@ -217,7 +217,7 @@ SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
 **Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -244,7 +244,7 @@ Negative examples come naturally from rubric failures during validation:
 - **Missed answers** where the model says "not found" but the doc was there → `label: false`
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -264,7 +264,7 @@ python train_kto.py \
 GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
 
 ```bash
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 # Set model.lora_path to KTO checkpoint in configs/config.yaml
 python train_grpo.py
 ```
@@ -301,7 +301,7 @@ presets:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
@@ -311,7 +311,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search_runtime \
   --env-backend local \
   --env-tool-schema path/to/your_tool_schema.yaml \
@@ -401,9 +401,9 @@ SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
 SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
 Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
 Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
-Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
-Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
-Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+Trainers/sft/                               ← SFT trainer (same as other pipelines)
+Trainers/kto/                               ← KTO trainer (same as other pipelines)
+Trainers/grpo/                              ← GRPO trainer (same as other pipelines)
 ```
 
 ---

--- a/.agents/skills/case-studies/reference/essay-style-pipeline.md
+++ b/.agents/skills/case-studies/reference/essay-style-pipeline.md
@@ -334,7 +334,7 @@ This creates a preview file like `Datasets/essay_datasets/stage1_thoughts_to_out
 **Dataset:** Validated essay outlines (positive examples only).
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -364,7 +364,7 @@ Unlike tool calling (where bad examples come from high-temperature self-play), e
 2. Using a weaker model to generate outlines (naturally produces lower quality)
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -479,7 +479,7 @@ SynthChat/rubrics/essay_brainstorm_quality/  ← Brainstorm quality rubric
 SynthChat/rubrics/essay_outline_quality/     ← Outline quality rubric
 Datasets/essay_datasets/                     ← Generated essay training data
 Datasets/synthchat/                          ← SynthChat output directory
-Trainers/rtx3090_sft/                        ← SFT trainer (same as tools)
-Trainers/rtx3090_kto/                        ← KTO trainer (same as tools)
+Trainers/sft/                        ← SFT trainer (same as tools)
+Trainers/kto/                        ← KTO trainer (same as tools)
 Evaluator/config/scenarios/                  ← Essay evaluation scenarios
 ```

--- a/.agents/skills/evaluation/SKILL.md
+++ b/.agents/skills/evaluation/SKILL.md
@@ -61,7 +61,7 @@ Load the specific reference you need:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./sft_output/TIMESTAMP/final_model \
   --scenario behavior_prompts.yaml tool_prompts.yaml \
   --output Evaluator/results/my_eval.json \
   --markdown Evaluator/results/my_eval.md

--- a/.agents/skills/evaluation/reference/backends.md
+++ b/.agents/skills/evaluation/reference/backends.md
@@ -26,7 +26,7 @@ Best for evaluating freshly trained LoRA adapters without a server.
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model
 ```
 
 **Requirements:**

--- a/.agents/skills/evaluation/reference/cli-commands.md
+++ b/.agents/skills/evaluation/reference/cli-commands.md
@@ -84,7 +84,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/20250114/final_model \
+  --model ./Trainers/sft/sft_output/20250114/final_model \
   --scenario behavior_prompts.yaml
 ```
 

--- a/.agents/skills/fine-tuning/SKILL.md
+++ b/.agents/skills/fine-tuning/SKILL.md
@@ -13,8 +13,9 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Task | Command |
 |------|---------|
 | Interactive menu | `./run.sh` → Train |
-| SFT training | `cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b` |
-| KTO training | `cd Trainers/rtx3090_kto && python train_kto.py --model-size 7b` |
+| Local Docker config run | `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` |
+| SFT training | `cd Trainers/sft && python train_sft.py --model-size 7b` |
+| KTO training | `cd Trainers/kto && python train_kto.py --model-size 7b` |
 | GRPO training | `cd Trainers/grpo && python train_grpo.py` |
 | Pivot-profile GRPO dataset | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml --pivot-profile-only` |
 | GRPO with pivot filtering | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml` |
@@ -64,9 +65,11 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 
 ## Key Directories
 
-- `Trainers/rtx3090_sft/` — SFT trainer
-- `Trainers/rtx3090_kto/` — KTO trainer
+- `Trainers/sft/` — active SFT trainer
+- `Trainers/local/jobs/` — config-driven local Docker job specs
+- `Trainers/kto/` — KTO trainer
 - `Trainers/grpo/` — GRPO and env-GRPO trainer
+- `Trainers/archive/legacy_rtx3090/` — archived legacy RTX3090 trainer snapshots and outputs; do not use for new runs
 - `Trainers/cloud/jobs/` — checked-in HF Jobs configs
 - `Datasets/` — JSONL training datasets
 - `SynthChat/scenarios/` — synthetic data and environment-backed scenarios
@@ -91,6 +94,9 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - Treat `loss_summary.json` as a supporting artifact, not the canonical final loss metadata file.
 - The ledger should accumulate real model-size / hardware / timing / cost data so future hardware planning can optimize against observed evidence instead of memory.
 - For local trainer iteration, use the checked-in `train_sft.py`, `train_kto.py`, and `train_grpo.py` entrypoints.
+- For repeatable local GPU training, prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` over ad hoc `docker run` commands. Put the model, dataset, Docker image, package overrides, LoRA settings, training knobs, and artifact paths in YAML.
+- For Windows Docker Desktop with GPU, prefer `job.transfer: auto` or `copy` in local-run configs. The runner chooses copy mode on Windows because GPU bind mounts can fail with access denied.
+- Keep newly released model support in local-run `setup.pip` pins or image fields. Do not leave one-off package installs in shell history.
 - For canonical HF experiments, prefer `python tuner.py cloud-pipeline ...` over `cloud-run`.
 - For full train → eval → exact loss → analysis → recommendation runs, prefer `python tuner.py run-experiment ...`.
 - Evolutionary SFT is experimental but now first-class in the cloud experiment path. Prefer a checked-in experiment spec or `cloud-pipeline --train-evolutionary-*` overrides over editing trainer YAMLs by hand.
@@ -114,6 +120,7 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - If `run-experiment` refuses to launch because the tracked worktree is dirty, prefer creating a clean temporary git worktree and launching from there over asking the user to stash or cleaning their checkout.
 - If a cloud run fails before bucket artifacts appear, treat it as a bootstrap/runtime problem first. Inspect `cloud-jobs logs` before changing training hyperparameters.
 - For newly released architectures or day-zero model launches, verify official Docker Hub tags for `unsloth/unsloth` and `vllm/vllm-openai` before trusting the repo's pinned image profiles. As of 2026-04-02, Docker Hub shows `unsloth/unsloth:latest` updated 1 day ago and `vllm/vllm-openai:latest` / `v0.17.1` updated about 17 hours ago.
+- As of 2026-04-22, local `docker pull unsloth/unsloth:latest` resolved to digest `sha256:9be56babef4efc330316cff3a65f9f911b9e7709bce4114fa7817ba3ffd8565d`. That image still reports `transformers 4.57.1`, so Qwen3.5 local runs need config-level package overrides such as `transformers==5.5.0`, `trl==0.22.2`, and current `unsloth` / `unsloth_zoo`.
 - If a named training image profile is broken, prefer an explicit `training.cloud_image` override to a currently verified official image tag over changing unrelated parts of the experiment such as evaluation backend.
 - If a run needs newer package versions but the right base image is otherwise close, use stage-local experiment-spec `pip_packages` pins under `training:`, `evaluation:`, or `loss:` instead of a one-off helper script or a repo-global image pin.
 - For hyperparameter search, use `python tuner.py experiment-loop ...`; this is the built-in LLM + LightGBM surrogate path.
@@ -176,13 +183,22 @@ See `reference/lora-techniques.md` for full details, integration status, and com
 
 **Quick SFT test run:**
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 python train_sft.py --model-size 3b --tier quick --dry-run
 ```
 
+**Config-driven local Docker SFT smoke run:**
+```bash
+python tuner.py local-run \
+  --job-config Trainers/local/jobs/qwen35_2b_sft_smoke.yaml \
+  --yes
+```
+
+For a different local SFT run, copy a job under `Trainers/local/jobs/` and change `model`, `dataset`, `training`, `lora`, `job.image`, and `setup.pip` as needed. Use repo-relative local dataset paths; the runner translates them for the container.
+
 **KTO with local dataset:**
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 python train_kto.py --model-size 7b --local-file ../../Datasets/my_kto_data.jsonl
 ```
 
@@ -427,7 +443,7 @@ RUNPOD_API_KEY=...
 
 Local trainers produce timestamped run directories:
 ```
-{method}_output_rtx3090/YYYYMMDD_HHMMSS/
+{method}_output/YYYYMMDD_HHMMSS/
 ├── checkpoints/
 ├── logs/
 ├── final_model/

--- a/.agents/skills/fine-tuning/reference/grpo-training.md
+++ b/.agents/skills/fine-tuning/reference/grpo-training.md
@@ -14,11 +14,11 @@ GRPO generates multiple completions per prompt, scores them with deterministic r
 
 ## Configuration
 
-GRPO is configured entirely via YAML: `Trainers/rtx3090_grpo/configs/config.yaml`
+GRPO is configured entirely via YAML: `Trainers/grpo/configs/config.yaml`
 
 ```bash
 # Run GRPO training
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 python train_grpo.py
 ```
 
@@ -31,7 +31,7 @@ python train_grpo.py
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/.../checkpoint-1150"  # Optional
+  lora_path: "../sft/sft_output/.../checkpoint-1150"  # Optional
 
 training:
   per_device_train_batch_size: 6
@@ -155,7 +155,7 @@ To start GRPO from an SFT checkpoint:
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/20250114/checkpoint-1150"
+  lora_path: "../sft/sft_output/20250114/checkpoint-1150"
 ```
 
 ---

--- a/.agents/skills/fine-tuning/reference/sft-training.md
+++ b/.agents/skills/fine-tuning/reference/sft-training.md
@@ -92,11 +92,11 @@ When `completion_only_loss: true` (default):
 
 ## Training Workflow
 
-1. **Setup environment**: `bash setup.sh` (creates conda env, installs deps)
+1. **Choose runtime**: prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` for repeatable local Docker runs; use direct `cd Trainers/sft && python train_sft.py ...` for tight trainer iteration.
 2. **Prepare dataset**: JSONL with `conversations` field, positive examples only
-3. **Test setup**: `python train_sft.py --model-size 7b --tier quick --dry-run`
-4. **Quick iteration**: `python train_sft.py --model-size 7b --tier quick` (~5 min)
-5. **Production run**: `python train_sft.py --model-size 7b --tier standard`
+3. **Test setup**: set `run.dry_run: true` in local-run YAML or use `python train_sft.py --model-size 7b --tier quick --dry-run`
+4. **Quick iteration**: cap `training.max_steps` in local-run YAML or use `--tier quick`
+5. **Production run**: remove the step cap and use the intended `training`, `model`, `dataset`, and `lora` settings in YAML
 6. **Monitor**: Watch live dashboard or `tail -f logs/training_latest.jsonl`
 7. **Upload**: `python3 .skills/upload-deployment/scripts/upload_model.py ./final_model user/repo --save-method merged_16bit`
 
@@ -115,7 +115,43 @@ When `completion_only_loss: true` (default):
 
 ## Config File
 
-**Location:** `Trainers/rtx3090_sft/configs/config.yaml`
+**Direct trainer location:** `Trainers/sft/configs/config.yaml`
+
+**Config-driven local Docker location:** `Trainers/local/jobs/*.yaml`
+
+Local Docker job configs keep runtime choices outside shell history:
+
+```yaml
+name: my-sft-run
+provider: local_docker
+job:
+  image: unsloth/unsloth:latest
+  pull_policy: missing
+  transfer: auto
+setup:
+  pip: []
+run:
+  method: sft
+  trainer: Trainers/sft/train_sft.py
+model:
+  name: Qwen/Qwen3.5-2B
+  max_seq_length: 2048
+  load_in_4bit: false
+dataset:
+  local_file: Datasets/my_data.jsonl
+training:
+  batch_size: 2
+  gradient_accumulation: 8
+  learning_rate: 1.0e-4
+  num_epochs: 1
+lora:
+  r: 64
+  alpha: 128
+  target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+artifacts:
+  output_root: toolset-training-artifacts/runs/local_docker/sft/{name}
+  run_timestamp: "{timestamp}"
+```
 
 Key sections:
 - `model` — model name, seq length, quantization

--- a/.agents/skills/upload-deployment/SKILL.md
+++ b/.agents/skills/upload-deployment/SKILL.md
@@ -66,7 +66,7 @@ Load the specific reference you need:
 **Standard upload after SFT:**
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf

--- a/.agents/skills/upload-deployment/reference/model-merging.md
+++ b/.agents/skills/upload-deployment/reference/model-merging.md
@@ -72,10 +72,10 @@ GRPO training requires a merged base to apply new LoRA adapters:
 The GRPO trainer handles this automatically when `lora_path` is set:
 
 ```yaml
-# Trainers/rtx3090_grpo/configs/config.yaml
+# Trainers/grpo/configs/config.yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/TIMESTAMP/checkpoint-1150"
+  lora_path: "../sft/sft_output/TIMESTAMP/checkpoint-1150"
 ```
 
 The trainer:

--- a/.agents/skills/upload-deployment/reference/upload-workflow.md
+++ b/.agents/skills/upload-deployment/reference/upload-workflow.md
@@ -11,7 +11,7 @@ For cloud runs, provider-native storage is the default durable location. Treat H
 ### From SFT Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf
@@ -20,7 +20,7 @@ python3 scripts/upload_model.py \
 ### From KTO Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/kto/kto_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/kto/kto_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit
 ```
@@ -120,7 +120,7 @@ model-name/
 Or manually:
 ```bash
 # 1. Train
-cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b
+cd Trainers/sft && python train_sft.py --model-size 7b
 
 # 2. Upload
 python3 scripts/upload_model.py Trainers/sft/sft_output/LATEST/final_model user/model \

--- a/.claude/skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.claude/skills/case-studies/reference/agentic-search-pipeline.md
@@ -217,7 +217,7 @@ SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
 **Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -244,7 +244,7 @@ Negative examples come naturally from rubric failures during validation:
 - **Missed answers** where the model says "not found" but the doc was there → `label: false`
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -264,7 +264,7 @@ python train_kto.py \
 GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
 
 ```bash
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 # Set model.lora_path to KTO checkpoint in configs/config.yaml
 python train_grpo.py
 ```
@@ -301,7 +301,7 @@ presets:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
@@ -311,7 +311,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search_runtime \
   --env-backend local \
   --env-tool-schema path/to/your_tool_schema.yaml \
@@ -401,9 +401,9 @@ SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
 SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
 Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
 Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
-Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
-Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
-Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+Trainers/sft/                               ← SFT trainer (same as other pipelines)
+Trainers/kto/                               ← KTO trainer (same as other pipelines)
+Trainers/grpo/                              ← GRPO trainer (same as other pipelines)
 ```
 
 ---

--- a/.claude/skills/case-studies/reference/essay-style-pipeline.md
+++ b/.claude/skills/case-studies/reference/essay-style-pipeline.md
@@ -334,7 +334,7 @@ This creates a preview file like `Datasets/essay_datasets/stage1_thoughts_to_out
 **Dataset:** Validated essay outlines (positive examples only).
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -364,7 +364,7 @@ Unlike tool calling (where bad examples come from high-temperature self-play), e
 2. Using a weaker model to generate outlines (naturally produces lower quality)
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -479,7 +479,7 @@ SynthChat/rubrics/essay_brainstorm_quality/  ← Brainstorm quality rubric
 SynthChat/rubrics/essay_outline_quality/     ← Outline quality rubric
 Datasets/essay_datasets/                     ← Generated essay training data
 Datasets/synthchat/                          ← SynthChat output directory
-Trainers/rtx3090_sft/                        ← SFT trainer (same as tools)
-Trainers/rtx3090_kto/                        ← KTO trainer (same as tools)
+Trainers/sft/                        ← SFT trainer (same as tools)
+Trainers/kto/                        ← KTO trainer (same as tools)
 Evaluator/config/scenarios/                  ← Essay evaluation scenarios
 ```

--- a/.claude/skills/evaluation/SKILL.md
+++ b/.claude/skills/evaluation/SKILL.md
@@ -61,7 +61,7 @@ Load the specific reference you need:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./sft_output/TIMESTAMP/final_model \
   --scenario behavior_prompts.yaml tool_prompts.yaml \
   --output Evaluator/results/my_eval.json \
   --markdown Evaluator/results/my_eval.md

--- a/.claude/skills/evaluation/reference/backends.md
+++ b/.claude/skills/evaluation/reference/backends.md
@@ -26,7 +26,7 @@ Best for evaluating freshly trained LoRA adapters without a server.
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model
 ```
 
 **Requirements:**

--- a/.claude/skills/evaluation/reference/cli-commands.md
+++ b/.claude/skills/evaluation/reference/cli-commands.md
@@ -84,7 +84,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/20250114/final_model \
+  --model ./Trainers/sft/sft_output/20250114/final_model \
   --scenario behavior_prompts.yaml
 ```
 

--- a/.claude/skills/fine-tuning/SKILL.md
+++ b/.claude/skills/fine-tuning/SKILL.md
@@ -13,8 +13,9 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Task | Command |
 |------|---------|
 | Interactive menu | `./run.sh` → Train |
-| SFT training | `cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b` |
-| KTO training | `cd Trainers/rtx3090_kto && python train_kto.py --model-size 7b` |
+| Local Docker config run | `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` |
+| SFT training | `cd Trainers/sft && python train_sft.py --model-size 7b` |
+| KTO training | `cd Trainers/kto && python train_kto.py --model-size 7b` |
 | GRPO training | `cd Trainers/grpo && python train_grpo.py` |
 | Pivot-profile GRPO dataset | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml --pivot-profile-only` |
 | GRPO with pivot filtering | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml` |
@@ -64,9 +65,11 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 
 ## Key Directories
 
-- `Trainers/rtx3090_sft/` — SFT trainer
-- `Trainers/rtx3090_kto/` — KTO trainer
+- `Trainers/sft/` — active SFT trainer
+- `Trainers/local/jobs/` — config-driven local Docker job specs
+- `Trainers/kto/` — KTO trainer
 - `Trainers/grpo/` — GRPO and env-GRPO trainer
+- `Trainers/archive/legacy_rtx3090/` — archived legacy RTX3090 trainer snapshots and outputs; do not use for new runs
 - `Trainers/cloud/jobs/` — checked-in HF Jobs configs
 - `Datasets/` — JSONL training datasets
 - `SynthChat/scenarios/` — synthetic data and environment-backed scenarios
@@ -91,6 +94,9 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - Treat `loss_summary.json` as a supporting artifact, not the canonical final loss metadata file.
 - The ledger should accumulate real model-size / hardware / timing / cost data so future hardware planning can optimize against observed evidence instead of memory.
 - For local trainer iteration, use the checked-in `train_sft.py`, `train_kto.py`, and `train_grpo.py` entrypoints.
+- For repeatable local GPU training, prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` over ad hoc `docker run` commands. Put the model, dataset, Docker image, package overrides, LoRA settings, training knobs, and artifact paths in YAML.
+- For Windows Docker Desktop with GPU, prefer `job.transfer: auto` or `copy` in local-run configs. The runner chooses copy mode on Windows because GPU bind mounts can fail with access denied.
+- Keep newly released model support in local-run `setup.pip` pins or image fields. Do not leave one-off package installs in shell history.
 - For canonical HF experiments, prefer `python tuner.py cloud-pipeline ...` over `cloud-run`.
 - For full train → eval → exact loss → analysis → recommendation runs, prefer `python tuner.py run-experiment ...`.
 - Evolutionary SFT is experimental but now first-class in the cloud experiment path. Prefer a checked-in experiment spec or `cloud-pipeline --train-evolutionary-*` overrides over editing trainer YAMLs by hand.
@@ -114,6 +120,7 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - If `run-experiment` refuses to launch because the tracked worktree is dirty, prefer creating a clean temporary git worktree and launching from there over asking the user to stash or cleaning their checkout.
 - If a cloud run fails before bucket artifacts appear, treat it as a bootstrap/runtime problem first. Inspect `cloud-jobs logs` before changing training hyperparameters.
 - For newly released architectures or day-zero model launches, verify official Docker Hub tags for `unsloth/unsloth` and `vllm/vllm-openai` before trusting the repo's pinned image profiles. As of 2026-04-02, Docker Hub shows `unsloth/unsloth:latest` updated 1 day ago and `vllm/vllm-openai:latest` / `v0.17.1` updated about 17 hours ago.
+- As of 2026-04-22, local `docker pull unsloth/unsloth:latest` resolved to digest `sha256:9be56babef4efc330316cff3a65f9f911b9e7709bce4114fa7817ba3ffd8565d`. That image still reports `transformers 4.57.1`, so Qwen3.5 local runs need config-level package overrides such as `transformers==5.5.0`, `trl==0.22.2`, and current `unsloth` / `unsloth_zoo`.
 - If a named training image profile is broken, prefer an explicit `training.cloud_image` override to a currently verified official image tag over changing unrelated parts of the experiment such as evaluation backend.
 - If a run needs newer package versions but the right base image is otherwise close, use stage-local experiment-spec `pip_packages` pins under `training:`, `evaluation:`, or `loss:` instead of a one-off helper script or a repo-global image pin.
 - For hyperparameter search, use `python tuner.py experiment-loop ...`; this is the built-in LLM + LightGBM surrogate path.
@@ -176,13 +183,22 @@ See `reference/lora-techniques.md` for full details, integration status, and com
 
 **Quick SFT test run:**
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 python train_sft.py --model-size 3b --tier quick --dry-run
 ```
 
+**Config-driven local Docker SFT smoke run:**
+```bash
+python tuner.py local-run \
+  --job-config Trainers/local/jobs/qwen35_2b_sft_smoke.yaml \
+  --yes
+```
+
+For a different local SFT run, copy a job under `Trainers/local/jobs/` and change `model`, `dataset`, `training`, `lora`, `job.image`, and `setup.pip` as needed. Use repo-relative local dataset paths; the runner translates them for the container.
+
 **KTO with local dataset:**
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 python train_kto.py --model-size 7b --local-file ../../Datasets/my_kto_data.jsonl
 ```
 
@@ -427,7 +443,7 @@ RUNPOD_API_KEY=...
 
 Local trainers produce timestamped run directories:
 ```
-{method}_output_rtx3090/YYYYMMDD_HHMMSS/
+{method}_output/YYYYMMDD_HHMMSS/
 ├── checkpoints/
 ├── logs/
 ├── final_model/

--- a/.claude/skills/fine-tuning/reference/grpo-training.md
+++ b/.claude/skills/fine-tuning/reference/grpo-training.md
@@ -14,11 +14,11 @@ GRPO generates multiple completions per prompt, scores them with deterministic r
 
 ## Configuration
 
-GRPO is configured entirely via YAML: `Trainers/rtx3090_grpo/configs/config.yaml`
+GRPO is configured entirely via YAML: `Trainers/grpo/configs/config.yaml`
 
 ```bash
 # Run GRPO training
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 python train_grpo.py
 ```
 
@@ -31,7 +31,7 @@ python train_grpo.py
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/.../checkpoint-1150"  # Optional
+  lora_path: "../sft/sft_output/.../checkpoint-1150"  # Optional
 
 training:
   per_device_train_batch_size: 6
@@ -155,7 +155,7 @@ To start GRPO from an SFT checkpoint:
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/20250114/checkpoint-1150"
+  lora_path: "../sft/sft_output/20250114/checkpoint-1150"
 ```
 
 ---

--- a/.claude/skills/fine-tuning/reference/sft-training.md
+++ b/.claude/skills/fine-tuning/reference/sft-training.md
@@ -92,11 +92,11 @@ When `completion_only_loss: true` (default):
 
 ## Training Workflow
 
-1. **Setup environment**: `bash setup.sh` (creates conda env, installs deps)
+1. **Choose runtime**: prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` for repeatable local Docker runs; use direct `cd Trainers/sft && python train_sft.py ...` for tight trainer iteration.
 2. **Prepare dataset**: JSONL with `conversations` field, positive examples only
-3. **Test setup**: `python train_sft.py --model-size 7b --tier quick --dry-run`
-4. **Quick iteration**: `python train_sft.py --model-size 7b --tier quick` (~5 min)
-5. **Production run**: `python train_sft.py --model-size 7b --tier standard`
+3. **Test setup**: set `run.dry_run: true` in local-run YAML or use `python train_sft.py --model-size 7b --tier quick --dry-run`
+4. **Quick iteration**: cap `training.max_steps` in local-run YAML or use `--tier quick`
+5. **Production run**: remove the step cap and use the intended `training`, `model`, `dataset`, and `lora` settings in YAML
 6. **Monitor**: Watch live dashboard or `tail -f logs/training_latest.jsonl`
 7. **Upload**: `python3 .skills/upload-deployment/scripts/upload_model.py ./final_model user/repo --save-method merged_16bit`
 
@@ -115,7 +115,43 @@ When `completion_only_loss: true` (default):
 
 ## Config File
 
-**Location:** `Trainers/rtx3090_sft/configs/config.yaml`
+**Direct trainer location:** `Trainers/sft/configs/config.yaml`
+
+**Config-driven local Docker location:** `Trainers/local/jobs/*.yaml`
+
+Local Docker job configs keep runtime choices outside shell history:
+
+```yaml
+name: my-sft-run
+provider: local_docker
+job:
+  image: unsloth/unsloth:latest
+  pull_policy: missing
+  transfer: auto
+setup:
+  pip: []
+run:
+  method: sft
+  trainer: Trainers/sft/train_sft.py
+model:
+  name: Qwen/Qwen3.5-2B
+  max_seq_length: 2048
+  load_in_4bit: false
+dataset:
+  local_file: Datasets/my_data.jsonl
+training:
+  batch_size: 2
+  gradient_accumulation: 8
+  learning_rate: 1.0e-4
+  num_epochs: 1
+lora:
+  r: 64
+  alpha: 128
+  target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+artifacts:
+  output_root: toolset-training-artifacts/runs/local_docker/sft/{name}
+  run_timestamp: "{timestamp}"
+```
 
 Key sections:
 - `model` — model name, seq length, quantization

--- a/.claude/skills/upload-deployment/SKILL.md
+++ b/.claude/skills/upload-deployment/SKILL.md
@@ -66,7 +66,7 @@ Load the specific reference you need:
 **Standard upload after SFT:**
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf

--- a/.claude/skills/upload-deployment/reference/model-merging.md
+++ b/.claude/skills/upload-deployment/reference/model-merging.md
@@ -72,10 +72,10 @@ GRPO training requires a merged base to apply new LoRA adapters:
 The GRPO trainer handles this automatically when `lora_path` is set:
 
 ```yaml
-# Trainers/rtx3090_grpo/configs/config.yaml
+# Trainers/grpo/configs/config.yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/TIMESTAMP/checkpoint-1150"
+  lora_path: "../sft/sft_output/TIMESTAMP/checkpoint-1150"
 ```
 
 The trainer:

--- a/.claude/skills/upload-deployment/reference/upload-workflow.md
+++ b/.claude/skills/upload-deployment/reference/upload-workflow.md
@@ -11,7 +11,7 @@ For cloud runs, provider-native storage is the default durable location. Treat H
 ### From SFT Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf
@@ -20,7 +20,7 @@ python3 scripts/upload_model.py \
 ### From KTO Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/kto/kto_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/kto/kto_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit
 ```
@@ -120,7 +120,7 @@ model-name/
 Or manually:
 ```bash
 # 1. Train
-cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b
+cd Trainers/sft && python train_sft.py --model-size 7b
 
 # 2. Upload
 python3 scripts/upload_model.py Trainers/sft/sft_output/LATEST/final_model user/model \

--- a/.gitignore
+++ b/.gitignore
@@ -136,7 +136,7 @@ Datasets/synthchat/
 .serena/
 
 # Obvious generated training/test artifacts
-Trainers/rtx3090_grpo/grpo_output_rtx3090/
+Trainers/archive/
 docs/test_*.jsonl
 docs/test_*.review.md
 docs/test_webllm_node.mjs

--- a/.skills/case-studies/reference/agentic-search-pipeline.md
+++ b/.skills/case-studies/reference/agentic-search-pipeline.md
@@ -217,7 +217,7 @@ SFT (learn the loop)  →  KTO (learn judgment)  →  GRPO (optimize retrieval)
 **Dataset:** Positive examples only. The model learns WHEN to search, WHAT to read, and HOW to answer.
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -244,7 +244,7 @@ Negative examples come naturally from rubric failures during validation:
 - **Missed answers** where the model says "not found" but the doc was there → `label: false`
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -264,7 +264,7 @@ python train_kto.py \
 GRPO is well-suited here because the reward is **verifiable**: did the search terms retrieve the target document? This mirrors Context-1's CISPO approach.
 
 ```bash
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 # Set model.lora_path to KTO checkpoint in configs/config.yaml
 python train_grpo.py
 ```
@@ -301,7 +301,7 @@ presets:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search \
   --output Evaluator/results/agentic_search_v1.json \
   --markdown Evaluator/results/agentic_search_v1.md
@@ -311,7 +311,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model \
   --preset agentic_search_runtime \
   --env-backend local \
   --env-tool-schema path/to/your_tool_schema.yaml \
@@ -401,9 +401,9 @@ SynthChat/rubrics/doc_selection.yaml                ← Selection quality rubric
 SynthChat/rubrics/groundedness.yaml                 ← Grounding quality rubric
 Datasets/synthchat/agentic_search_*.jsonl           ← Generated training data
 Evaluator/config/scenarios/agentic_search.yaml      ← Evaluation scenarios
-Trainers/rtx3090_sft/                               ← SFT trainer (same as other pipelines)
-Trainers/rtx3090_kto/                               ← KTO trainer (same as other pipelines)
-Trainers/rtx3090_grpo/                              ← GRPO trainer (same as other pipelines)
+Trainers/sft/                               ← SFT trainer (same as other pipelines)
+Trainers/kto/                               ← KTO trainer (same as other pipelines)
+Trainers/grpo/                              ← GRPO trainer (same as other pipelines)
 ```
 
 ---

--- a/.skills/case-studies/reference/essay-style-pipeline.md
+++ b/.skills/case-studies/reference/essay-style-pipeline.md
@@ -334,7 +334,7 @@ This creates a preview file like `Datasets/essay_datasets/stage1_thoughts_to_out
 **Dataset:** Validated essay outlines (positive examples only).
 
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 
 python train_sft.py \
   --model-size 7b \
@@ -364,7 +364,7 @@ Unlike tool calling (where bad examples come from high-temperature self-play), e
 2. Using a weaker model to generate outlines (naturally produces lower quality)
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -479,7 +479,7 @@ SynthChat/rubrics/essay_brainstorm_quality/  ← Brainstorm quality rubric
 SynthChat/rubrics/essay_outline_quality/     ← Outline quality rubric
 Datasets/essay_datasets/                     ← Generated essay training data
 Datasets/synthchat/                          ← SynthChat output directory
-Trainers/rtx3090_sft/                        ← SFT trainer (same as tools)
-Trainers/rtx3090_kto/                        ← KTO trainer (same as tools)
+Trainers/sft/                        ← SFT trainer (same as tools)
+Trainers/kto/                        ← KTO trainer (same as tools)
 Evaluator/config/scenarios/                  ← Essay evaluation scenarios
 ```

--- a/.skills/evaluation/SKILL.md
+++ b/.skills/evaluation/SKILL.md
@@ -61,7 +61,7 @@ Load the specific reference you need:
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./sft_output_rtx3090/TIMESTAMP/final_model \
+  --model ./sft_output/TIMESTAMP/final_model \
   --scenario behavior_prompts.yaml tool_prompts.yaml \
   --output Evaluator/results/my_eval.json \
   --markdown Evaluator/results/my_eval.md

--- a/.skills/evaluation/reference/backends.md
+++ b/.skills/evaluation/reference/backends.md
@@ -26,7 +26,7 @@ Best for evaluating freshly trained LoRA adapters without a server.
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/TIMESTAMP/final_model
+  --model ./Trainers/sft/sft_output/TIMESTAMP/final_model
 ```
 
 **Requirements:**

--- a/.skills/evaluation/reference/cli-commands.md
+++ b/.skills/evaluation/reference/cli-commands.md
@@ -84,7 +84,7 @@ python -m Evaluator.cli \
 ```bash
 python -m Evaluator.cli \
   --backend unsloth \
-  --model ./Trainers/rtx3090_sft/sft_output_rtx3090/20250114/final_model \
+  --model ./Trainers/sft/sft_output/20250114/final_model \
   --scenario behavior_prompts.yaml
 ```
 

--- a/.skills/fine-tuning/SKILL.md
+++ b/.skills/fine-tuning/SKILL.md
@@ -13,8 +13,9 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Task | Command |
 |------|---------|
 | Interactive menu | `./run.sh` → Train |
-| SFT training | `cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b` |
-| KTO training | `cd Trainers/rtx3090_kto && python train_kto.py --model-size 7b` |
+| Local Docker config run | `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` |
+| SFT training | `cd Trainers/sft && python train_sft.py --model-size 7b` |
+| KTO training | `cd Trainers/kto && python train_kto.py --model-size 7b` |
 | GRPO training | `cd Trainers/grpo && python train_grpo.py` |
 | Pivot-profile GRPO dataset | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml --pivot-profile-only` |
 | GRPO with pivot filtering | `cd Trainers/grpo && python train_grpo.py --config configs/pivot_config.yaml` |
@@ -64,9 +65,11 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 
 ## Key Directories
 
-- `Trainers/rtx3090_sft/` — SFT trainer
-- `Trainers/rtx3090_kto/` — KTO trainer
+- `Trainers/sft/` — active SFT trainer
+- `Trainers/local/jobs/` — config-driven local Docker job specs
+- `Trainers/kto/` — KTO trainer
 - `Trainers/grpo/` — GRPO and env-GRPO trainer
+- `Trainers/archive/legacy_rtx3090/` — archived legacy RTX3090 trainer snapshots and outputs; do not use for new runs
 - `Trainers/cloud/jobs/` — checked-in HF Jobs configs
 - `Datasets/` — JSONL training datasets
 - `SynthChat/scenarios/` — synthetic data and environment-backed scenarios
@@ -91,6 +94,9 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - Treat `loss_summary.json` as a supporting artifact, not the canonical final loss metadata file.
 - The ledger should accumulate real model-size / hardware / timing / cost data so future hardware planning can optimize against observed evidence instead of memory.
 - For local trainer iteration, use the checked-in `train_sft.py`, `train_kto.py`, and `train_grpo.py` entrypoints.
+- For repeatable local GPU training, prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` over ad hoc `docker run` commands. Put the model, dataset, Docker image, package overrides, LoRA settings, training knobs, and artifact paths in YAML.
+- For Windows Docker Desktop with GPU, prefer `job.transfer: auto` or `copy` in local-run configs. The runner chooses copy mode on Windows because GPU bind mounts can fail with access denied.
+- Keep newly released model support in local-run `setup.pip` pins or image fields. Do not leave one-off package installs in shell history.
 - For canonical HF experiments, prefer `python tuner.py cloud-pipeline ...` over `cloud-run`.
 - For full train → eval → exact loss → analysis → recommendation runs, prefer `python tuner.py run-experiment ...`.
 - Evolutionary SFT is experimental but now first-class in the cloud experiment path. Prefer a checked-in experiment spec or `cloud-pipeline --train-evolutionary-*` overrides over editing trainer YAMLs by hand.
@@ -114,6 +120,7 @@ Use `--tier` on the local SFT and KTO trainers when you want a preset instead of
 - If `run-experiment` refuses to launch because the tracked worktree is dirty, prefer creating a clean temporary git worktree and launching from there over asking the user to stash or cleaning their checkout.
 - If a cloud run fails before bucket artifacts appear, treat it as a bootstrap/runtime problem first. Inspect `cloud-jobs logs` before changing training hyperparameters.
 - For newly released architectures or day-zero model launches, verify official Docker Hub tags for `unsloth/unsloth` and `vllm/vllm-openai` before trusting the repo's pinned image profiles. As of 2026-04-02, Docker Hub shows `unsloth/unsloth:latest` updated 1 day ago and `vllm/vllm-openai:latest` / `v0.17.1` updated about 17 hours ago.
+- As of 2026-04-22, local `docker pull unsloth/unsloth:latest` resolved to digest `sha256:9be56babef4efc330316cff3a65f9f911b9e7709bce4114fa7817ba3ffd8565d`. That image still reports `transformers 4.57.1`, so Qwen3.5 local runs need config-level package overrides such as `transformers==5.5.0`, `trl==0.22.2`, and current `unsloth` / `unsloth_zoo`.
 - If a named training image profile is broken, prefer an explicit `training.cloud_image` override to a currently verified official image tag over changing unrelated parts of the experiment such as evaluation backend.
 - If a run needs newer package versions but the right base image is otherwise close, use stage-local experiment-spec `pip_packages` pins under `training:`, `evaluation:`, or `loss:` instead of a one-off helper script or a repo-global image pin.
 - For hyperparameter search, use `python tuner.py experiment-loop ...`; this is the built-in LLM + LightGBM surrogate path.
@@ -176,13 +183,22 @@ See `reference/lora-techniques.md` for full details, integration status, and com
 
 **Quick SFT test run:**
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 python train_sft.py --model-size 3b --tier quick --dry-run
 ```
 
+**Config-driven local Docker SFT smoke run:**
+```bash
+python tuner.py local-run \
+  --job-config Trainers/local/jobs/qwen35_2b_sft_smoke.yaml \
+  --yes
+```
+
+For a different local SFT run, copy a job under `Trainers/local/jobs/` and change `model`, `dataset`, `training`, `lora`, `job.image`, and `setup.pip` as needed. Use repo-relative local dataset paths; the runner translates them for the container.
+
 **KTO with local dataset:**
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 python train_kto.py --model-size 7b --local-file ../../Datasets/my_kto_data.jsonl
 ```
 
@@ -427,7 +443,7 @@ RUNPOD_API_KEY=...
 
 Local trainers produce timestamped run directories:
 ```
-{method}_output_rtx3090/YYYYMMDD_HHMMSS/
+{method}_output/YYYYMMDD_HHMMSS/
 ├── checkpoints/
 ├── logs/
 ├── final_model/

--- a/.skills/fine-tuning/reference/grpo-training.md
+++ b/.skills/fine-tuning/reference/grpo-training.md
@@ -14,11 +14,11 @@ GRPO generates multiple completions per prompt, scores them with deterministic r
 
 ## Configuration
 
-GRPO is configured entirely via YAML: `Trainers/rtx3090_grpo/configs/config.yaml`
+GRPO is configured entirely via YAML: `Trainers/grpo/configs/config.yaml`
 
 ```bash
 # Run GRPO training
-cd Trainers/rtx3090_grpo
+cd Trainers/grpo
 python train_grpo.py
 ```
 
@@ -31,7 +31,7 @@ python train_grpo.py
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/.../checkpoint-1150"  # Optional
+  lora_path: "../sft/sft_output/.../checkpoint-1150"  # Optional
 
 training:
   per_device_train_batch_size: 6
@@ -155,7 +155,7 @@ To start GRPO from an SFT checkpoint:
 ```yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/20250114/checkpoint-1150"
+  lora_path: "../sft/sft_output/20250114/checkpoint-1150"
 ```
 
 ---

--- a/.skills/fine-tuning/reference/sft-training.md
+++ b/.skills/fine-tuning/reference/sft-training.md
@@ -92,11 +92,11 @@ When `completion_only_loss: true` (default):
 
 ## Training Workflow
 
-1. **Setup environment**: `bash setup.sh` (creates conda env, installs deps)
+1. **Choose runtime**: prefer `python tuner.py local-run --job-config Trainers/local/jobs/<job>.yaml --yes` for repeatable local Docker runs; use direct `cd Trainers/sft && python train_sft.py ...` for tight trainer iteration.
 2. **Prepare dataset**: JSONL with `conversations` field, positive examples only
-3. **Test setup**: `python train_sft.py --model-size 7b --tier quick --dry-run`
-4. **Quick iteration**: `python train_sft.py --model-size 7b --tier quick` (~5 min)
-5. **Production run**: `python train_sft.py --model-size 7b --tier standard`
+3. **Test setup**: set `run.dry_run: true` in local-run YAML or use `python train_sft.py --model-size 7b --tier quick --dry-run`
+4. **Quick iteration**: cap `training.max_steps` in local-run YAML or use `--tier quick`
+5. **Production run**: remove the step cap and use the intended `training`, `model`, `dataset`, and `lora` settings in YAML
 6. **Monitor**: Watch live dashboard or `tail -f logs/training_latest.jsonl`
 7. **Upload**: `python3 .skills/upload-deployment/scripts/upload_model.py ./final_model user/repo --save-method merged_16bit`
 
@@ -115,7 +115,43 @@ When `completion_only_loss: true` (default):
 
 ## Config File
 
-**Location:** `Trainers/rtx3090_sft/configs/config.yaml`
+**Direct trainer location:** `Trainers/sft/configs/config.yaml`
+
+**Config-driven local Docker location:** `Trainers/local/jobs/*.yaml`
+
+Local Docker job configs keep runtime choices outside shell history:
+
+```yaml
+name: my-sft-run
+provider: local_docker
+job:
+  image: unsloth/unsloth:latest
+  pull_policy: missing
+  transfer: auto
+setup:
+  pip: []
+run:
+  method: sft
+  trainer: Trainers/sft/train_sft.py
+model:
+  name: Qwen/Qwen3.5-2B
+  max_seq_length: 2048
+  load_in_4bit: false
+dataset:
+  local_file: Datasets/my_data.jsonl
+training:
+  batch_size: 2
+  gradient_accumulation: 8
+  learning_rate: 1.0e-4
+  num_epochs: 1
+lora:
+  r: 64
+  alpha: 128
+  target_modules: [q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj]
+artifacts:
+  output_root: toolset-training-artifacts/runs/local_docker/sft/{name}
+  run_timestamp: "{timestamp}"
+```
 
 Key sections:
 - `model` — model name, seq length, quantization

--- a/.skills/upload-deployment/SKILL.md
+++ b/.skills/upload-deployment/SKILL.md
@@ -66,7 +66,7 @@ Load the specific reference you need:
 **Standard upload after SFT:**
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf

--- a/.skills/upload-deployment/reference/model-merging.md
+++ b/.skills/upload-deployment/reference/model-merging.md
@@ -72,10 +72,10 @@ GRPO training requires a merged base to apply new LoRA adapters:
 The GRPO trainer handles this automatically when `lora_path` is set:
 
 ```yaml
-# Trainers/rtx3090_grpo/configs/config.yaml
+# Trainers/grpo/configs/config.yaml
 model:
   model_name: "unsloth/Qwen3-1.7B-unsloth-bnb-4bit"
-  lora_path: "../rtx3090_sft/sft_output_rtx3090/TIMESTAMP/checkpoint-1150"
+  lora_path: "../sft/sft_output/TIMESTAMP/checkpoint-1150"
 ```
 
 The trainer:

--- a/.skills/upload-deployment/reference/upload-workflow.md
+++ b/.skills/upload-deployment/reference/upload-workflow.md
@@ -11,7 +11,7 @@ For cloud runs, provider-native storage is the default durable location. Treat H
 ### From SFT Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/sft/sft_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/sft/sft_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit \
   --create-gguf
@@ -20,7 +20,7 @@ python3 scripts/upload_model.py \
 ### From KTO Trainer
 ```bash
 python3 scripts/upload_model.py \
-  Trainers/kto/kto_output_rtx3090/TIMESTAMP/final_model \
+  Trainers/kto/kto_output/TIMESTAMP/final_model \
   username/model-name \
   --save-method merged_16bit
 ```
@@ -120,7 +120,7 @@ model-name/
 Or manually:
 ```bash
 # 1. Train
-cd Trainers/rtx3090_sft && python train_sft.py --model-size 7b
+cd Trainers/sft && python train_sft.py --model-size 7b
 
 # 2. Upload
 python3 scripts/upload_model.py Trainers/sft/sft_output/LATEST/final_model user/model \

--- a/Datasets/behavior_datasets/README.md
+++ b/Datasets/behavior_datasets/README.md
@@ -240,4 +240,4 @@ python tools/interleave_dataset.py \
 - **YAML Rubrics:** `../behavior_rubrics/`
 - **Tool Schemas:** `../../tools/tool_schemas.json`
 - **Validator:** `../../tools/validate_syngen.py`
-- **Training Guide:** `../../Trainers/rtx3090_kto/README.md`
+- **Training Guide:** `../../Trainers/kto/README.md`

--- a/Evaluator/README.md
+++ b/Evaluator/README.md
@@ -154,7 +154,7 @@ The CLI will:
 # Basic usage
 python -m Evaluator.cli \
   --backend unsloth \
-  --model Trainers/rtx3090_sft/sft_output/20241215_143022/final_model \
+  --model Trainers/sft/sft_output/20241215_143022/final_model \
   --scenario behavior_prompts.yaml
 
 # Multiple scenarios
@@ -625,7 +625,7 @@ Start the inference server (LM Studio, Ollama) before running evaluation.
 ```
 No LoRA adapters found in training outputs
 ```
-Train a model first - adapters appear in `Trainers/rtx3090_*/*/final_model/`.
+Train a model first - adapters appear in `Trainers/{sft,kto,grpo}/*/final_model/`.
 
 ## Migration from JSON
 

--- a/docs/DATASET_FORMAT_ANALYSIS.md
+++ b/docs/DATASET_FORMAT_ANALYSIS.md
@@ -256,7 +256,7 @@ python tools/convert_to_mcp_format.py \
   Datasets/syngen_tools_sft_11.22.25_mcp.jsonl
 
 # Train on new format
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 ./train.sh --model-size 7b --local-file ../../Datasets/syngen_tools_sft_11.22.25_mcp.jsonl
 
 # Compare results

--- a/docs/EVOLUTIONARY_FINETUNING.md
+++ b/docs/EVOLUTIONARY_FINETUNING.md
@@ -171,7 +171,7 @@ Evaluator/                              ← Clean imports
     # DELETED - now in shared/validation/parsing/
 
 Trainers/                               ← Direct access
-└── rtx3090_sft/
+└── sft/
     from shared.validation import FitnessEvaluator
 ```
 
@@ -567,7 +567,7 @@ class FitnessEvaluator:
 Minimal additions to existing config:
 
 ```yaml
-# Trainers/rtx3090_sft/configs/config.yaml
+# Trainers/sft/configs/config.yaml
 
 model:
   model_name: "unsloth/Qwen2.5-3B-Instruct-bnb-4bit"
@@ -618,7 +618,7 @@ Memory fits easily: ~8.5GB used of 24GB available.
 1. **Enable evolutionary training in config:**
 
 ```yaml
-# Trainers/rtx3090_sft/configs/config.yaml
+# Trainers/sft/configs/config.yaml
 
 evolutionary:
   enabled: true  # Enable evolutionary selection
@@ -637,7 +637,7 @@ evolutionary:
 2. **Create a fitness config (or use the example):**
 
 ```yaml
-# Trainers/rtx3090_sft/configs/fitness/tool_calling.yaml
+# Trainers/sft/configs/fitness/tool_calling.yaml
 
 validations:
   - type: required_field
@@ -858,7 +858,7 @@ shared/evolutionary/
 #### Step 2.3: Integrate into Trainers
 
 ```python
-# Trainers/rtx3090_sft/train_sft.py
+# Trainers/sft/train_sft.py
 if config.evolutionary.enabled:
     from shared.evolutionary import EvolutionaryTrainerWrapper
     trainer = EvolutionaryTrainerWrapper(trainer, config.evolutionary)
@@ -867,7 +867,7 @@ if config.evolutionary.enabled:
 #### Step 2.4: Add fitness config
 
 ```yaml
-# Trainers/rtx3090_sft/configs/fitness/tool_calling.yaml
+# Trainers/sft/configs/fitness/tool_calling.yaml
 # Same format as rubrics!
 ```
 

--- a/docs/INSTALLATION_GUIDE.md
+++ b/docs/INSTALLATION_GUIDE.md
@@ -14,7 +14,7 @@ Complete, tested installation guide for RTX 3090 with dependency troubleshooting
 
 ```bash
 # Clone/navigate to project
-cd rtx3090_kto
+cd kto
 
 # Run setup script
 bash setup.sh

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -32,7 +32,7 @@ Complete production-ready implementation of KTO (Kahneman-Tversky Optimization) 
 ## Project Structure
 
 ```
-rtx3090_kto/
+kto/
 ├── README.md                    # Full documentation
 ├── QUICKSTART.md               # 5-minute setup guide
 ├── PROJECT_OVERVIEW.md         # This file
@@ -78,13 +78,13 @@ python train_kto.py --model-size 13b
 
 ### Inference
 ```bash
-python src/inference.py ./kto_output_rtx3090/final_model
+python src/inference.py ./kto_output/final_model
 ```
 
 ### Upload
 ```bash
 python src/upload_to_hf.py \
-  ./kto_output_rtx3090/final_model \
+  ./kto_output/final_model \
   username/model-name \
   --token YOUR_HF_TOKEN \
   --create-gguf
@@ -194,7 +194,7 @@ python train_kto.py \
 ```bash
 python train_kto.py \
   --model-size 7b \
-  --output-dir ./kto_output_rtx3090 \
+  --output-dir ./kto_output \
   # Training will resume from last checkpoint if found
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -14,7 +14,7 @@ Get up and running with KTO training on RTX 3090 in 5 minutes.
 
 ```bash
 # Clone or navigate to the project
-cd rtx3090_kto
+cd kto
 
 # Run setup script
 bash setup.sh
@@ -91,7 +91,7 @@ This will:
 # venv/bin/python train_kto.py --model-size 7b
 
 # Expected time: 2-3 hours for 1 epoch
-# Output: ./kto_output_rtx3090/
+# Output: ./kto_output/
 ```
 
 ### Option B: Train on Your Dataset
@@ -117,7 +117,7 @@ Then train:
 
 ```bash
 # Interactive chat
-python src/inference.py ./kto_output_rtx3090/final_model
+python src/inference.py ./kto_output/final_model
 
 # You: What is machine learning?
 # Assistant: [model generates response]
@@ -129,7 +129,7 @@ python src/inference.py ./kto_output_rtx3090/final_model
 # Get token from: https://huggingface.co/settings/tokens
 
 python src/upload_to_hf.py \
-  ./kto_output_rtx3090/final_model \
+  ./kto_output/final_model \
   your-username/your-model-name \
   --token YOUR_HF_TOKEN
 ```

--- a/docs/QUICKSTART_FRESH_TERMINAL.md
+++ b/docs/QUICKSTART_FRESH_TERMINAL.md
@@ -9,7 +9,7 @@ Open your WSL terminal (you should be in Windows Terminal with Ubuntu).
 
 ### 2. Navigate to Project Directory
 ```bash
-cd /mnt/c/Users/Joseph/Documents/Code/Toolset-Training/code/rtx3090_kto
+cd /mnt/c/Users/Joseph/Documents/Code/Toolset-Training/code/kto
 ```
 
 ### 3. Activate Conda Environment
@@ -113,7 +113,7 @@ The table updates every 5 steps automatically. Watch for:
 Training automatically saves checkpoints every 50 steps:
 ```
 ----------------------------------------------------------------------------------------------------
->> CHECKPOINT SAVED at step 50 -> ./kto_output_rtx3090/checkpoint-50
+>> CHECKPOINT SAVED at step 50 -> ./kto_output/checkpoint-50
 ----------------------------------------------------------------------------------------------------
 ```
 
@@ -156,7 +156,7 @@ To stop training gracefully:
 ## After Training Completes
 
 Training will automatically:
-1. Save final model to `./kto_output_rtx3090/final_model`
+1. Save final model to `./kto_output/final_model`
 2. Print completion message
 3. Show where model was saved
 
@@ -166,7 +166,7 @@ To upload to HuggingFace:
 from unsloth import FastLanguageModel
 
 model, tokenizer = FastLanguageModel.from_pretrained(
-    model_name="./kto_output_rtx3090/final_model",
+    model_name="./kto_output/final_model",
     max_seq_length=2048,
     dtype=None,
     load_in_4bit=True,
@@ -182,7 +182,7 @@ model.push_to_hub_merged(
 ## Files Created During Training
 
 ```
-kto_output_rtx3090/
+kto_output/
 ├── checkpoint-50/          # First checkpoint
 ├── checkpoint-100/         # Second checkpoint
 ├── checkpoint-145/         # Last checkpoint (if completed)
@@ -197,13 +197,13 @@ kto_output_rtx3090/
 | OOM Error | Use `--batch-size 6 --gradient-accumulation 5` |
 | Training very slow | Check `nvidia-smi` - GPU should be 90-100% |
 | Import errors | Reactivate environment: `conda activate ./venv` |
-| Can't find train_kto.py | Make sure you're in `code/rtx3090_kto` directory |
+| Can't find train_kto.py | Make sure you're in `code/kto` directory |
 
 ## Summary Commands
 
 ```bash
 # Complete fresh start:
-cd /mnt/c/Users/Joseph/Documents/Code/Toolset-Training/code/rtx3090_kto
+cd /mnt/c/Users/Joseph/Documents/Code/Toolset-Training/code/kto
 source ~/miniconda3/etc/profile.d/conda.sh
 conda activate ./venv
 python train_kto.py --model-size 7b --batch-size 8 --gradient-accumulation 4

--- a/docs/SYNTH_CHAT_GENERATION.md
+++ b/docs/SYNTH_CHAT_GENERATION.md
@@ -192,7 +192,7 @@ python tools/validate_syngen.py Datasets/syngen_selfplay_20251204.jsonl
 ### 2. Train with KTO
 
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 
 python train_kto.py \
   --model-size 7b \
@@ -232,11 +232,11 @@ while true; do
     --num-examples 1000
 
   # 2. Train
-  cd Trainers/rtx3090_kto
+  cd Trainers/kto
   python train_kto.py \
     --model-size 7b \
     --local-file "../../Datasets/syngen_selfplay_iter${ITERATION}.jsonl" \
-    --output-dir "kto_output_rtx3090/iter${ITERATION}"
+    --output-dir "kto_output/iter${ITERATION}"
   cd ../..
 
   # 3. Upload

--- a/docs/SYNTH_CHAT_HOW_IT_WORKS.md
+++ b/docs/SYNTH_CHAT_HOW_IT_WORKS.md
@@ -406,7 +406,7 @@ Now that you understand how it works, you can:
 1. **Run it:** `./Tools/run_selfplay.sh --quick`
 2. **Inspect output:** `head -5 Datasets/syngen_selfplay_*.jsonl | jq`
 3. **Check validation:** `python tools/validate_syngen.py Datasets/syngen_selfplay_*.jsonl`
-4. **Train with it:** `cd Trainers/rtx3090_kto && python train_kto.py --local-file ../../Datasets/syngen_selfplay_*.jsonl`
+4. **Train with it:** `cd Trainers/kto && python train_kto.py --local-file ../../Datasets/syngen_selfplay_*.jsonl`
 
 ## Customization Ideas
 

--- a/docs/SYNTH_CHAT_TRUE_VS_GUIDED.md
+++ b/docs/SYNTH_CHAT_TRUE_VS_GUIDED.md
@@ -106,7 +106,7 @@ python Tools/selfplay_generator_v2.py \
 ### Phase 1: Initial Training (SFT)
 Use your existing curated datasets:
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 python train_sft.py --model-size 7b
 ```
 
@@ -137,7 +137,7 @@ cat Datasets/syngen_coverage.jsonl \
     > Datasets/combined_training.jsonl
 
 # Train with KTO
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 python train_kto.py \
   --model-size 7b \
   --local-file ../../Datasets/combined_training.jsonl

--- a/docs/SYNTH_CHAT_V2_COMPLETE.md
+++ b/docs/SYNTH_CHAT_V2_COMPLETE.md
@@ -243,7 +243,7 @@ I'll show you what I find and you can confirm if it's the right project.
 
 ### Phase 1: Initial Training (SFT)
 ```bash
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 python train_sft.py --model-size 7b
 ```
 
@@ -257,7 +257,7 @@ python Tools/selfplay_generator_v2.py \
 
 ### Phase 3: KTO Refinement
 ```bash
-cd Trainers/rtx3090_kto
+cd Trainers/kto
 python train_kto.py \
   --model-size 7b \
   --local-file ../../Datasets/syngen_selfplay_v1.jsonl
@@ -319,7 +319,7 @@ top_p = random.uniform(0.92, 0.98)      # Tighter nucleus
 1. Try it: `python Tools/selfplay_generator_v2.py --model your-model --output test.jsonl --num-examples 100`
 2. Inspect: `head -5 test.jsonl | jq`
 3. Validate: `python tools/validate_syngen.py test.jsonl`
-4. Train: `cd Trainers/rtx3090_kto && python train_kto.py --local-file ../../test.jsonl`
+4. Train: `cd Trainers/kto && python train_kto.py --local-file ../../test.jsonl`
 5. Evaluate: Check if model improves on behavioral tests
 6. Iterate: Generate more data with refined model
 

--- a/docs/WEB_UI_ARCHITECTURE.md
+++ b/docs/WEB_UI_ARCHITECTURE.md
@@ -85,7 +85,7 @@ Utilities to read/write the YAML configuration files used by the trainers.
 ```typescript
 // lib/config-manager.ts
 export async function getTrainingConfig(method: 'sft' | 'kto') {
-  // Reads Trainers/rtx3090_{method}/configs/config.yaml
+  // Reads Trainers/{method}/configs/config.yaml
   // Returns parsed JSON
 }
 

--- a/docs/architecture/gpu-cloud-integration.md
+++ b/docs/architecture/gpu-cloud-integration.md
@@ -298,7 +298,7 @@ CloudTrainHandler.handle()
     |
     +-- backend.load_config(method)
     |     |
-    |     +-- Load Trainers/rtx3090_{method}/configs/config.yaml (training params)
+    |     +-- Load Trainers/{method}/configs/config.yaml (training params)
     |     +-- Load Trainers/cloud/cloud_config.yaml (cloud overlay)
     |     +-- Merge into CloudTrainingConfig
     |
@@ -397,7 +397,7 @@ execute()
 **Code sync strategy**: RunPod pods have internet access. The startup command:
 1. Installs dependencies (`pip install unsloth trl datasets peft`)
 2. Clones the repo (`git clone {repo_url} /workspace/repo`)
-3. Runs the training script (`cd /workspace/repo/Trainers/rtx3090_{method} && python train_{method}.py`)
+3. Runs the training script (`cd /workspace/repo/Trainers/{method} && python train_{method}.py`)
 
 The clone URL can be the user's GitHub repo URL (if public) or use a GitHub token (if private). For private repos, `GH_TOKEN` or a deploy key can be passed as an environment variable.
 
@@ -808,7 +808,7 @@ def _build_startup_command(self, config: CloudTrainingConfig) -> str:
     return (
         f"pip install unsloth trl datasets peft && "
         f"git clone {repo_url} /workspace/repo && "
-        f"cd /workspace/repo/Trainers/rtx3090_{config.method} && "
+        f"cd /workspace/repo/Trainers/{config.method} && "
         f"HF_TOKEN={os.environ.get('HF_TOKEN', '')} "
         f"python train_{config.method}.py"
     )

--- a/docs/architecture/ml-pipeline-foundation.md
+++ b/docs/architecture/ml-pipeline-foundation.md
@@ -202,7 +202,7 @@ config = TrainingConfig(**raw)  # Validates on construction
 - `FeaturesConfig` omits `text` — Phase 2+
 - All fields have sensible defaults; minimal valid config requires only `task`, `data`, `features`
 - `field_validator` on `train_path` gives immediate feedback on missing files
-- The YAML config for SFT uses `yaml.safe_load` + manual `dict_to_dataclass` (see `Trainers/rtx3090_sft/configs/config_loader.py`). Pydantic replaces that entire conversion + validation layer.
+- The YAML config for SFT uses `yaml.safe_load` + manual `dict_to_dataclass` (see `Trainers/sft/configs/config_loader.py`). Pydantic replaces that entire conversion + validation layer.
 
 ---
 
@@ -1093,7 +1093,7 @@ TrainingConfig(**yaml.safe_load(f))    ← Pydantic validates all fields
 
 ### `shared/utilities/paths.py`
 - Provides `get_project_root()`, `get_trainer_root(name)`, `find_training_run(name, id)`
-- **Integration**: `find_training_run` currently hardcodes `sft_output_rtx3090` and `kto_output_rtx3090` patterns. Phase 4 (CLI) will need to extend this or add an ML-specific variant
+- **Integration**: `find_training_run` currently hardcodes `sft_output` and `kto_output` patterns. Phase 4 (CLI) will need to extend this or add an ML-specific variant
 - **Phase 1**: No changes needed. `Trainers/ml/output.py` handles its own directory creation
 
 ### `shared/utilities/env.py`
@@ -1105,7 +1105,7 @@ TrainingConfig(**yaml.safe_load(f))    ← Pydantic validates all fields
 - **Future integration** (Phase 4+): Validation results become features for the quality scorer. The `shared/ml/features.py` module (out of Phase 1 scope) will import from `shared/validation/` to extract schema error counts, tag presence, etc.
 - **Phase 1**: No integration needed
 
-### `Trainers/rtx3090_sft/configs/config_loader.py`
+### `Trainers/sft/configs/config_loader.py`
 - Uses dataclasses + manual `dict_to_dataclass()` conversion
 - **Relationship**: ML config uses Pydantic instead. These are independent — no shared config infrastructure. If the project later wants to unify, SFT/KTO configs could migrate to Pydantic, but that's out of scope
 - **Key difference**: The SFT config loader has no validation beyond type conversion. Pydantic validates constraints (`test_size > 0`, `columns` non-empty, `train_path` exists)
@@ -1172,6 +1172,6 @@ output:
 | Algorithm registry | ABC + `@register_algorithm` decorator + dict | Strategy pattern: enforces interface, enables config-driven lookup, extensible by adding files |
 | Experiment tracking | ABC with LocalTracker fallback | Zero-dependency baseline; MLflow opt-in; tracker swappable without changing training code |
 | Feature engineering | Config -> ColumnTransformer | Leverages sklearn's battle-tested Pipeline/ColumnTransformer; YAML-declarative for common cases |
-| Output structure | Timestamped dirs under `Trainers/ml/ml_output/` | Mirrors SFT pattern (`sft_output_rtx3090/YYYYMMDD_HHMMSS/`); always produces `metrics.json` |
+| Output structure | Timestamped dirs under `Trainers/ml/ml_output/` | Mirrors SFT pattern (`sft_output/YYYYMMDD_HHMMSS/`); always produces `metrics.json` |
 | Import convention | Dotted paths from project root | Matches existing `shared.*`, `Trainers.*` convention |
 | Phase 1 scope | LightGBM only, numeric + categorical only | Smallest vertical slice that proves the architecture end-to-end |

--- a/docs/cloud-training/NEBIUS_INTEGRATION_SUMMARY.md
+++ b/docs/cloud-training/NEBIUS_INTEGRATION_SUMMARY.md
@@ -258,7 +258,7 @@ def trigger_training(model_size="7b", dataset_path="..."):
 
     # Run training
     ssh.exec_command(
-        f"cd ~/Toolset-Training/Trainers/rtx3090_sft && "
+        f"cd ~/Toolset-Training/Trainers/sft && "
         f"./train.sh --model-size {model_size} --local-file {dataset_path}"
     )
 

--- a/docs/cloud-training/NEBIUS_QUICKSTART.md
+++ b/docs/cloud-training/NEBIUS_QUICKSTART.md
@@ -76,7 +76,7 @@ Use `docs/nebius_training_notebook.ipynb` - it includes:
    cd Toolset-Training
 
    # Run setup
-   cd Trainers/rtx3090_sft
+   cd Trainers/sft
    bash setup.sh
 
    # Verify GPU
@@ -89,7 +89,7 @@ Use `docs/nebius_training_notebook.ipynb` - it includes:
    ./train.sh --model-size 7b --wandb --wandb-project nebius-training
 
    # Or KTO training
-   cd ../rtx3090_kto
+   cd ../kto
    ./train.sh --model-size 7b
    ```
 
@@ -97,7 +97,7 @@ Use `docs/nebius_training_notebook.ipynb` - it includes:
    ```bash
    # Start in tmux session
    tmux new-session -s training
-   cd ~/Toolset-Training/Trainers/rtx3090_sft
+   cd ~/Toolset-Training/Trainers/sft
    ./train.sh --model-size 7b
 
    # Detach: Ctrl+B then D
@@ -107,7 +107,7 @@ Use `docs/nebius_training_notebook.ipynb` - it includes:
 5. **Download Results**
    ```bash
    # From your local machine
-   scp -r ubuntu@<vm-ip>:~/Toolset-Training/Trainers/rtx3090_sft/sft_output_rtx3090/ ./
+   scp -r ubuntu@<vm-ip>:~/Toolset-Training/Trainers/sft/sft_output/ ./
    ```
 
 **Cost:** ~$1.50 for full SFT training (45 min) + ~$0.50 for KTO (15 min) = **~$2.00 total**
@@ -229,7 +229,7 @@ sky launch --use-spot docs/nebius_skypilot_config.yaml
 # Use VM approach
 ssh ubuntu@<vm-ip>
 git clone <repo>
-cd Toolset-Training/Trainers/rtx3090_sft
+cd Toolset-Training/Trainers/sft
 bash setup.sh --quick
 ./train.sh --model-size 7b
 ```
@@ -239,11 +239,11 @@ bash setup.sh --quick
 ### 2. Full Pipeline + Upload (1 hour total)
 ```bash
 # SFT + KTO + Upload
-cd Trainers/rtx3090_sft
+cd Trainers/sft
 ./train.sh --model-size 7b
 ./upload_model.sh  # Interactive upload
 
-cd ../rtx3090_kto
+cd ../kto
 ./train.sh --model-size 7b
 ./upload_model.sh
 ```
@@ -273,10 +273,10 @@ nvidia-smi -l 1  # Update every second
 ### View Training Logs
 ```bash
 # Real-time monitoring
-tail -f sft_output_rtx3090/*/logs/training_latest.jsonl
+tail -f sft_output/*/logs/training_latest.jsonl
 
 # Or in notebook
-!tail -f /workspace/Trainers/rtx3090_sft/sft_output_rtx3090/*/logs/training_latest.jsonl
+!tail -f /workspace/Trainers/sft/sft_output/*/logs/training_latest.jsonl
 ```
 
 ### W&B Integration (Recommended)

--- a/docs/cloud-training/nebius-integration-guide.md
+++ b/docs/cloud-training/nebius-integration-guide.md
@@ -45,7 +45,7 @@ Nebius AI Cloud is a GPU cloud platform optimized for AI/ML workloads, offering 
 
    # Import training modules
    import sys
-   sys.path.append('/workspace/Trainers/rtx3090_sft')
+   sys.path.append('/workspace/Trainers/sft')
 
    from configs.training_config import get_7b_config
    from src.model_loader import load_model_and_tokenizer
@@ -126,7 +126,7 @@ Nebius AI Cloud is a GPU cloud platform optimized for AI/ML workloads, offering 
    cd ~/Toolset-Training
 
    # Run setup script (existing setup.sh works!)
-   cd Trainers/rtx3090_sft
+   cd Trainers/sft
    bash setup.sh
 
    # Verify GPU
@@ -138,18 +138,18 @@ Nebius AI Cloud is a GPU cloud platform optimized for AI/ML workloads, offering 
    Use existing training scripts:
    ```bash
    # SFT Training
-   cd ~/Toolset-Training/Trainers/rtx3090_sft
+   cd ~/Toolset-Training/Trainers/sft
    ./train.sh --model-size 7b --wandb --wandb-project nebius-training
 
    # Or KTO Training
-   cd ~/Toolset-Training/Trainers/rtx3090_kto
+   cd ~/Toolset-Training/Trainers/kto
    ./train.sh --model-size 7b
    ```
 
 4. **Monitor with tmux/screen**
    ```bash
    # Start training in detached session
-   tmux new-session -d -s training 'cd ~/Toolset-Training/Trainers/rtx3090_sft && ./train.sh --model-size 7b'
+   tmux new-session -d -s training 'cd ~/Toolset-Training/Trainers/sft && ./train.sh --model-size 7b'
 
    # Attach to monitor
    tmux attach -t training
@@ -215,11 +215,11 @@ Nebius AI Cloud is a GPU cloud platform optimized for AI/ML workloads, offering 
      bash Miniconda3-latest-Linux-x86_64.sh -b
 
      # Setup environment
-     cd /workspace/Trainers/rtx3090_sft
+     cd /workspace/Trainers/sft
      bash setup.sh --quick
 
    run: |
-     cd /workspace/Trainers/rtx3090_sft
+     cd /workspace/Trainers/sft
      source ~/miniconda3/bin/activate unsloth_env
 
      ./train.sh --model-size 7b --wandb --wandb-project nebius-sky
@@ -254,12 +254,12 @@ Nebius AI Cloud is a GPU cloud platform optimized for AI/ML workloads, offering 
 
    setup: |
      # Same as above
-     cd /workspace/Trainers/rtx3090_sft
+     cd /workspace/Trainers/sft
      bash setup.sh --quick
 
    run: |
      # SkyPilot automatically configures distributed training
-     cd /workspace/Trainers/rtx3090_sft
+     cd /workspace/Trainers/sft
      source ~/miniconda3/bin/activate unsloth_env
 
      # Set distributed training env vars (SkyPilot provides these)
@@ -338,7 +338,7 @@ ssh.connect(vm.ip_address, username="ubuntu", key_filename="~/.ssh/id_rsa")
 
 # Execute training
 stdin, stdout, stderr = ssh.exec_command(
-    "cd ~/Toolset-Training/Trainers/rtx3090_sft && ./train.sh --model-size 7b"
+    "cd ~/Toolset-Training/Trainers/sft && ./train.sh --model-size 7b"
 )
 
 # Monitor output
@@ -354,8 +354,8 @@ import sky
 # Define task programmatically
 task = sky.Task(
     name='toolset-training',
-    setup='cd /workspace/Trainers/rtx3090_sft && bash setup.sh --quick',
-    run='cd /workspace/Trainers/rtx3090_sft && ./train.sh --model-size 7b'
+    setup='cd /workspace/Trainers/sft && bash setup.sh --quick',
+    run='cd /workspace/Trainers/sft && ./train.sh --model-size 7b'
 )
 
 # Set resources
@@ -454,7 +454,7 @@ sky.launch(task)
 
 **Issue: "How do I get my model back?"**
 - Solution: Your existing `upload_model.sh` works! Just set HF_TOKEN in `.env`.
-- Or use `scp` to download: `scp -r vm:/workspace/Trainers/rtx3090_sft/sft_output_rtx3090/ ./`
+- Or use `scp` to download: `scp -r vm:/workspace/Trainers/sft/sft_output/ ./`
 
 ---
 

--- a/docs/cloud-training/nebius_skypilot_config.yaml
+++ b/docs/cloud-training/nebius_skypilot_config.yaml
@@ -62,7 +62,7 @@ setup: |
 
   # Setup training environment
   echo "Setting up training environment..."
-  cd /workspace/Trainers/rtx3090_sft
+  cd /workspace/Trainers/sft
 
   # Run the existing setup script (quick mode, no verification)
   bash setup.sh --quick
@@ -81,7 +81,7 @@ run: |
   conda activate unsloth_env
 
   # Navigate to trainer directory
-  cd /workspace/Trainers/rtx3090_sft
+  cd /workspace/Trainers/sft
 
   # Optional: Set environment variables
   export WANDB_PROJECT="nebius-toolset-training"
@@ -105,14 +105,14 @@ run: |
 
   # Show results
   echo "Output directory:"
-  ls -lh sft_output_rtx3090/
+  ls -lh sft_output/
 
   # Show latest logs
   echo "Latest logs:"
-  find sft_output_rtx3090/ -name "training_*.jsonl" -type f -exec tail -20 {} \;
+  find sft_output/ -name "training_*.jsonl" -type f -exec tail -20 {} \;
 
 # Workdir - where commands execute
-workdir: /workspace/Trainers/rtx3090_sft
+workdir: /workspace/Trainers/sft
 
 # Optional: Environment variables
 envs:

--- a/docs/plans/ml-pipeline-expansion-plan.md
+++ b/docs/plans/ml-pipeline-expansion-plan.md
@@ -41,7 +41,7 @@ Expand Toolset-Training from a pure LLM fine-tuning platform into a dual-purpose
 | `shared/influence/` | New module | Per-example loss tracking, TracIn, meta-model |
 | `tuner.py` / CLI | Modify | Add `ml` subcommand tree |
 | `SynthChat/services/rubric_runner.py` | Modify | Quality scorer pre-filter integration |
-| `Trainers/rtx3090_sft/train_sft.py` | Modify | PerExampleLossCallback (opt-in) |
+| `Trainers/sft/train_sft.py` | Modify | PerExampleLossCallback (opt-in) |
 | `Evaluator/` | Extend | ML model evaluation entry point |
 
 #### Design Approach
@@ -223,8 +223,8 @@ ml_output/YYYYMMDD_HHMMSS/
 | `tuner/cli/router.py` | Add MLHandler route |
 | `tuner/handlers/list_handler.py` | Add ML model/config/dataset listing |
 | `SynthChat/services/rubric_runner.py` | Quality scorer pre-filter hook |
-| `Trainers/rtx3090_sft/train_sft.py` | Add PerExampleLossCallback (opt-in) |
-| `Trainers/rtx3090_kto/train_kto.py` | Add PerExampleLossCallback (opt-in) |
+| `Trainers/sft/train_sft.py` | Add PerExampleLossCallback (opt-in) |
+| `Trainers/kto/train_kto.py` | Add PerExampleLossCallback (opt-in) |
 
 #### Implementation Sequence
 See Synthesized Roadmap below.

--- a/docs/plans/unified-experiment-tracking-plan.md
+++ b/docs/plans/unified-experiment-tracking-plan.md
@@ -63,7 +63,7 @@ Unify the 4 disconnected experiment tracking systems (ML trainer, SFT/KTO traine
 | `shared/experiment_tracking/tracker.py` | Modify | Add `log_metadata()` convenience (default no-op); auto-register on `start_run()` exit |
 | `shared/experiment_tracking/local_tracker.py` | Modify | Wire auto-registration to registry on run completion |
 | `shared/experiment_tracking/__init__.py` | Modify | Export new classes, update `create_tracker()` factory |
-| `Trainers/rtx3090_sft/train_sft.py` | Modify | Add post-training tracker hook (~10 lines) |
+| `Trainers/sft/train_sft.py` | Modify | Add post-training tracker hook (~10 lines) |
 | `Trainers/kto/train_kto.py` | Modify | Add post-training tracker hook (~10 lines) |
 | `Trainers/ml/train.py` | Modify | Minor: ensure tracker auto-registration works with existing usage |
 | `Evaluator/cli.py` | Modify | Add `--training-run` flag, register eval runs (~20 lines) |
@@ -216,7 +216,7 @@ class ExperimentTracker(ABC):
 | `shared/experiment_tracking/tracker.py` | Add `log_metadata()` with default no-op |
 | `shared/experiment_tracking/local_tracker.py` | Wire auto-registration to RunRegistry on `start_run()` exit |
 | `shared/experiment_tracking/__init__.py` | Export RunRecord, RunRegistry, RunFilter; update factory |
-| `Trainers/rtx3090_sft/train_sft.py` | Add post-training tracker hook after `save_training_lineage()` (~10 lines, try/except wrapped) |
+| `Trainers/sft/train_sft.py` | Add post-training tracker hook after `save_training_lineage()` (~10 lines, try/except wrapped) |
 | `Trainers/kto/train_kto.py` | Add post-training tracker hook after `save_training_lineage()` (~10 lines, try/except wrapped) |
 | `Trainers/ml/train.py` | Verify auto-registration works; minor wiring if needed |
 | `Evaluator/cli.py` | Add `--training-run` flag; register eval runs with parent linkage |

--- a/docs/preparation/ml-pipeline-expansion-research.md
+++ b/docs/preparation/ml-pipeline-expansion-research.md
@@ -19,7 +19,7 @@ MLflow is the recommended experiment tracking platform for both tracks, as it na
 This research was prompted by the desire to expand beyond pure LLM fine-tuning and leverage the strengths of traditional ML where appropriate. The current pipeline structure (documented in `CLAUDE.md`) centers on:
 
 - **tuner.py / run.sh**: CLI entry point with interactive menus
-- **Trainers/**: SFT (`rtx3090_sft/`) and KTO (`rtx3090_kto/`) training
+- **Trainers/**: SFT (`sft/`) and KTO (`kto/`) training
 - **SynthChat/**: Synthetic data generation and quality improvement (rubric runner)
 - **Evaluator/**: Model evaluation harness
 - **shared/**: LLM client, validation, utilities, judge module
@@ -278,9 +278,9 @@ class ConversationFeatureExtractor:
 ```
 Toolset-Training/
 ├── Trainers/
-│   ├── rtx3090_sft/           # Existing LLM SFT
-│   ├── rtx3090_kto/           # Existing LLM KTO
-│   ├── rtx3090_grpo/          # Existing LLM GRPO
+│   ├── sft/           # Existing LLM SFT
+│   ├── kto/           # Existing LLM KTO
+│   ├── grpo/          # Existing LLM GRPO
 │   │
 │   ├── ml_classifiers/        # NEW: Traditional ML training
 │   │   ├── train_quality_scorer.py
@@ -715,7 +715,7 @@ The following sections cover making traditional ML a first-class training capabi
 
 Mirror the existing LLM training pattern: **YAML config in, trained model out, timestamped run directory with logs and artifacts**.
 
-The existing SFT config (`Trainers/rtx3090_sft/configs/config.yaml`) uses a clean hierarchy: `model:`, `lora:`, `training:`. The ML training config should follow the same pattern with ML-specific sections.
+The existing SFT config (`Trainers/sft/configs/config.yaml`) uses a clean hierarchy: `model:`, `lora:`, `training:`. The ML training config should follow the same pattern with ML-specific sections.
 
 ### Config-Driven Training Design
 
@@ -1401,7 +1401,7 @@ This mirrors the LLM training output pattern:
 
 | LLM Training | ML Training | Purpose |
 |--------------|-------------|---------|
-| `sft_output_rtx3090/YYYYMMDD_HHMMSS/` | `ml_output/YYYYMMDD_HHMMSS/` | Timestamped run dir |
+| `sft_output/YYYYMMDD_HHMMSS/` | `ml_output/YYYYMMDD_HHMMSS/` | Timestamped run dir |
 | `final_model/` | `model.joblib` + `model.onnx` | Trained model |
 | `checkpoints/` | `tuning_history.json` | Intermediate state |
 | `logs/training_latest.jsonl` | `logs/training.log` | Training logs |
@@ -1729,9 +1729,9 @@ output:
 ```
 Toolset-Training/
 ├── Trainers/
-│   ├── rtx3090_sft/              # LLM: Supervised Fine-Tuning
-│   ├── rtx3090_kto/              # LLM: KTO Training
-│   ├── rtx3090_grpo/             # LLM: GRPO Training
+│   ├── sft/              # LLM: Supervised Fine-Tuning
+│   ├── kto/              # LLM: KTO Training
+│   ├── grpo/             # LLM: GRPO Training
 │   │
 │   ├── ml/                       # NEW: Traditional ML Training
 │   │   ├── train.py              # Main training entry point
@@ -1983,7 +1983,7 @@ class PerExampleLossCallback(TrainerCallback):
 
 **Integration with existing SFT training**:
 ```python
-# In Trainers/rtx3090_sft/train_sft.py
+# In Trainers/sft/train_sft.py
 loss_callback = PerExampleLossCallback(
     train_dataset=tokenized_dataset,
     output_dir=run_dir / "influence",
@@ -2244,9 +2244,9 @@ def score_new_dataset(impact_model, new_dataset_path):
 
 ```
 Trainers/
-├── rtx3090_sft/
+├── sft/
 │   ├── train_sft.py                  # Add PerExampleLossCallback
-│   └── sft_output_rtx3090/
+│   └── sft_output/
 │       └── YYYYMMDD_HHMMSS/
 │           ├── checkpoints/           # Existing checkpoints (used by TracIn)
 │           └── influence/             # NEW: Influence analysis output
@@ -2275,8 +2275,8 @@ SynthChat/
 
 | Component | Integration | How |
 |-----------|-------------|-----|
-| `Trainers/rtx3090_sft/train_sft.py` | Add loss callback | Custom TrainerCallback |
-| `Trainers/rtx3090_kto/train_kto.py` | Add loss callback | Same callback pattern |
+| `Trainers/sft/train_sft.py` | Add loss callback | Custom TrainerCallback |
+| `Trainers/kto/train_kto.py` | Add loss callback | Same callback pattern |
 | `shared/influence/` | New module | TracIn + loss tracking + meta-model |
 | `SynthChat/services/rubric_runner.py` | Prioritize by impact | Score examples, process high-impact first |
 | `Trainers/ml/` | Meta-model training | Use standalone ML training config |

--- a/docs/research/karpathy_nanochat_autoresearch.md
+++ b/docs/research/karpathy_nanochat_autoresearch.md
@@ -95,7 +95,7 @@ This would simplify the CLI UX significantly, especially for users who don't kno
 
 **Why it matters**: Training-inference format mismatch degrades quality. Matching formats exactly during SFT ensures the model sees the same token patterns at inference time.
 
-**Applicability to our pipeline**: HIGH. We should verify our SFT training isn't packing/concatenating examples. Each conversation should be padded individually to match inference format. Check `Trainers/rtx3090_sft/train_sft.py` for packing behavior.
+**Applicability to our pipeline**: HIGH. We should verify our SFT training isn't packing/concatenating examples. Each conversation should be padded individually to match inference format. Check `Trainers/sft/train_sft.py` for packing behavior.
 
 ---
 
@@ -921,7 +921,7 @@ python train_sft.py --config config.yaml --eval-checkpoints 5
 
 # Standalone: evaluate checkpoints from a previous run
 python -m shared.checkpoint_eval \
-    --run-dir sft_output_rtx3090/20260321_120000 \
+    --run-dir sft_output/20260321_120000 \
     --last-n 5 \
     --eval-scenario Evaluator/config/scenarios/tool_prompts.yaml
 ```


### PR DESCRIPTION
## Summary
Follow-up to #83. Ships the remaining skill and doc updates for the new `local-run` command, plus line-ending normalization of files that were still stored with CRLF in HEAD (working tree has been LF for a while; `.gitattributes` already specifies `* text=auto`, so this just brings the index into agreement).

**Real content changes (~360 adds / ~204 dels):**
- `.skills/fine-tuning/SKILL.md` — new "Local Docker config run" CLI row, preference note for `python tuner.py local-run --job-config …` over ad-hoc `docker run`, updated directory map (adds `Trainers/local/jobs/` and `Trainers/archive/legacy_rtx3090/`), 2026-04-22 `unsloth/unsloth:latest` digest + `transformers>=5.2.0` pin guidance for Qwen3.5
- `.skills/fine-tuning/reference/sft-training.md` — config-driven local Docker SFT smoke-run example pointing at `Trainers/local/jobs/qwen35_2b_sft_smoke.yaml`
- `.skills/fine-tuning/reference/grpo-training.md`, `.skills/upload-deployment/*` — stale `Trainers/rtx3090_sft` / `kto_output_rtx3090` paths updated to match the canonical `Trainers/sft` / `kto_output` layout
- `docs/QUICKSTART.md`, `docs/INSTALLATION_GUIDE.md`, `docs/PROJECT_OVERVIEW.md`, `docs/EVOLUTIONARY_FINETUNING.md`, `docs/SYNTH_CHAT_*`, `docs/cloud-training/NEBIUS_*`, `docs/plans/ml-pipeline-*`, etc. — same rtx3090 path cleanup

**Line-ending noise (~4725 lines of mechanical CRLF → LF):** everything else in the diff. Reviewing with `git diff --ignore-cr-at-eol` collapses the PR to the ~360/204 real content delta above.

All three skill trees stay in sync — verified with `python3 .skills/scripts/sync_skill_trees.py --check` ("Skill trees are in sync.").

## Test plan
- [x] Skill tree sync check passes
- [x] No code files in this PR — purely docs + skill content + line-ending normalization
- [ ] Reviewers: `git diff --ignore-cr-at-eol origin/main..HEAD` gives the substantive delta; the full diff is mostly mechanical normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)