### PR TITLE
fix(trainers): epoch counter in TUI dashboard + DRY callback refactor

### DIFF
--- a/Trainers/grpo/src/training_callbacks.py
+++ b/Trainers/grpo/src/training_callbacks.py
@@ -33,6 +33,9 @@ class MetricsTableCallback(BaseMetricsCallback):
     print_checkpoint_on_save = False  # GRPO does not print checkpoint lines.
     print_completion_banner = False  # GRPO does not print completion banner in MetricsTable.
     interval_key_name = "interval_seconds"  # GRPO's original schema uses this key.
+    # Pre-refactor GRPO built `entry = dict(logs); entry[k]=v; entry.update(cap)`,
+    # so our fields + capacity override logs on key collisions.
+    fields_win_on_collision = True
 
     def __init__(
         self,

--- a/Trainers/grpo/src/training_callbacks.py
+++ b/Trainers/grpo/src/training_callbacks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Per-trainer GRPO/GSPO callback shims.
+"""Per-trainer GRPO/GSPO concrete callback subclasses and re-exports.
 
 Public symbols `MetricsTableCallback`, `LiveDashboardCallback`,
 `DASHBOARD_AVAILABLE`, `RICH_AVAILABLE` are re-exported at their original
@@ -8,17 +8,13 @@ paths. Shared lifecycle lives in `Trainers.shared.callbacks`.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py.
 from Trainers.shared.callbacks import (
     BaseLiveDashboardCallback,
     BaseMetricsCallback,
     DASHBOARD_AVAILABLE,
-    NoOpHealthChecker,
     RICH_AVAILABLE,
 )
 
@@ -48,7 +44,7 @@ class MetricsTableCallback(BaseMetricsCallback):
             output_dir=output_dir,
             previous_log_entries=previous_log_entries,
         )
-        self.health_checker = NoOpHealthChecker()
+        # health_checker defaults to NoOpHealthChecker in BaseMetricsCallback.__init__.
 
     def _print_header(self):
         print("\n" + "=" * 60)
@@ -89,6 +85,7 @@ class LiveDashboardCallback(BaseLiveDashboardCallback):
     default_title = "GRPO Training"
     training_type_attr = "grpo"
     completion_banner = "GRPO TRAINING COMPLETED"
+    log_write_swallow_errors = True  # GRPO swallows file-write exceptions on dashboard path too.
 
     def _dashboard_metrics(self, logs, capacity_snapshot):
         reward = (

--- a/Trainers/grpo/src/training_callbacks.py
+++ b/Trainers/grpo/src/training_callbacks.py
@@ -1,141 +1,66 @@
 #!/usr/bin/env python3
-"""
-Custom training callbacks for GRPO/GSPO.
-Saves training metrics as JSONL and prints a compact table periodically.
+"""Per-trainer GRPO/GSPO callback shims.
+
+Public symbols `MetricsTableCallback`, `LiveDashboardCallback`,
+`DASHBOARD_AVAILABLE`, `RICH_AVAILABLE` are re-exported at their original
+paths. Shared lifecycle lives in `Trainers.shared.callbacks`.
 """
 
 from __future__ import annotations
 
-import json
 import sys
-import os
-from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
-import torch
-from transformers import TrainerCallback, TrainerControl, TrainerState
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-# Add shared to path for UI components
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
-
-from shared.training_capacity import capture_runtime_capacity_snapshot, reset_capacity_peaks
-
-# Try to import LiveDashboard
-try:
-    from shared.ui import LiveDashboard, RICH_AVAILABLE
-    DASHBOARD_AVAILABLE = True
-except ImportError:
-    DASHBOARD_AVAILABLE = False
-    RICH_AVAILABLE = False
+from Trainers.shared.callbacks import (
+    BaseLiveDashboardCallback,
+    BaseMetricsCallback,
+    DASHBOARD_AVAILABLE,
+    NoOpHealthChecker,
+    RICH_AVAILABLE,
+)
 
 
-def _append_final_training_summary(log_file: Path, *, step: int, total_steps: int, total_epochs: int, elapsed: float) -> None:
-    capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-    entry = {
-        "event": "train_end",
-        "step": int(step),
-        "timestamp": datetime.now().isoformat(),
-        "total_steps": int(total_steps),
-        "total_epochs": int(total_epochs),
-        "train_runtime": round(elapsed, 3),
-        "train_steps_per_second": round((step / elapsed), 3) if elapsed > 0 else 0.0,
-        "train_samples_per_second": None,
-        **capacity_snapshot,
-    }
-    with open(log_file, "a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
+class MetricsTableCallback(BaseMetricsCallback):
+    """GRPO compact table output: step/loss/reward/LR/gpu; silent log-write failures."""
 
+    default_output_dir = "./grpo_output"
+    start_banner = "TRAINING STARTED"
+    log_every_write = True  # Write JSONL every on_log.
+    log_write_swallow_errors = True  # GRPO swallows file-write exceptions.
+    print_checkpoint_on_save = False  # GRPO does not print checkpoint lines.
+    print_completion_banner = False  # GRPO does not print completion banner in MetricsTable.
+    interval_key_name = "interval_seconds"  # GRPO's original schema uses this key.
 
-class MetricsTableCallback(TrainerCallback):
     def __init__(
         self,
         log_every_n_steps: int = 5,
         output_dir: str = "./grpo_output",
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
     ):
-        self.log_every_n_steps = max(1, int(log_every_n_steps))
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        super().__init__(
+            log_every_n_steps=log_every_n_steps,
+            output_dir=output_dir,
+            previous_log_entries=previous_log_entries,
+        )
+        self.health_checker = NoOpHealthChecker()
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
+    def _print_header(self):
+        print("\n" + "=" * 60)
+        print("   Step     |   Loss  | Reward  |    LR     | GPU Mem")
+        print("-" * 60)
 
-        self.start_time: Optional[datetime] = None
-        self.last_log_time: Optional[datetime] = None
-        self.header_printed = False
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        self.start_time = datetime.now()
-        self.last_log_time = self.start_time
-        self.header_printed = False
-        reset_capacity_peaks(torch)
-
-        if self.latest_log.exists():
-            try:
-                self.latest_log.unlink()
-            except Exception:
-                pass
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except Exception:
-            pass
-
-        print("\n" + "=" * 100)
-        print("TRAINING STARTED")
-        print("=" * 100)
-        print(f"Detailed metrics logging to: {self.log_file}")
-        print(f"View in real-time: tail -f {self.log_file}")
-        print(f"Or use latest: tail -f {self.latest_log}")
-        print("=" * 100)
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        if not logs:
-            return
-
-        current_time = datetime.now()
-        interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0.0
-        self.last_log_time = current_time
-        elapsed = (current_time - self.start_time).total_seconds() if self.start_time else 0.0
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
-        samples_per_sec = (
-            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
-        ) / elapsed if elapsed > 0 else 0.0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        cloud_provider = os.environ.get("CLOUD_PROVIDER", "").strip()
-        if cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        entry = dict(logs)
-        entry["step"] = int(state.global_step)
-        entry["timestamp"] = current_time.isoformat()
-        entry["interval_seconds"] = interval_time
-        entry["elapsed_seconds"] = round(elapsed, 3)
-        entry["steps_per_second"] = round(steps_per_sec, 3)
-        entry["samples_per_sec"] = round(samples_per_sec, 3)
-        entry.update(capacity_snapshot)
-
-        try:
-            with open(self.log_file, "a", encoding="utf-8") as f:
-                f.write(json.dumps(entry) + "\n")
-        except Exception:
-            pass
-
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        if not self.header_printed or state.global_step % (self.log_every_n_steps * 20) == 0:
-            self._print_header()
-            self.header_printed = True
-
+    def _print_row(self, *, step, state, args, logs, capacity_snapshot, interval_time, samples_per_sec, eta, progress):
         loss = logs.get("loss")
         lr = logs.get("learning_rate")
-        reward = logs.get("reward") or logs.get("rewards") or logs.get("rewards/mean") or logs.get("mean_reward")
-
+        reward = (
+            logs.get("reward")
+            or logs.get("rewards")
+            or logs.get("rewards/mean")
+            or logs.get("mean_reward")
+        )
         gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
         gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
 
@@ -147,175 +72,54 @@ class MetricsTableCallback(TrainerCallback):
             except Exception:
                 return str(x)
 
+        lr_str = f"{lr:.2e}" if isinstance(lr, (int, float)) else (lr if lr is not None else "-")
         print(
             f"{state.global_step:>10} | {fmt(loss):>7} | {fmt(reward):>7} | "
-            f"{(f'{lr:.2e}' if isinstance(lr, (int, float)) else (lr if lr is not None else '-')):>9} | "
-            f"{gpu_mem:>7}"
-        )
-
-    def _print_header(self):
-        print("\n" + "=" * 60)
-        print("   Step     |   Loss  | Reward  |    LR     | GPU Mem")
-        print("-" * 60)
-
-    def on_train_end(self, args, state, control, **kwargs):
-        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=state.max_steps if state.max_steps > 0 else state.global_step,
-            total_epochs=int(state.epoch or 0),
-            elapsed=elapsed,
+            f"{lr_str:>9} | {gpu_mem:>7}"
         )
 
 
-class LiveDashboardCallback(TrainerCallback):
-    """
-    Training callback that displays a live dashboard with real-time metrics.
-    Specialized for GRPO training - shows rewards, KL penalty, advantages.
-    """
+class LiveDashboardCallback(BaseLiveDashboardCallback):
+    """GRPO live dashboard: reward/reward_std/kl_penalty/advantage with multi-key fallbacks."""
 
-    def __init__(
-        self,
-        log_every_n_steps: int = 5,
-        output_dir: str = "./grpo_output",
-        previous_log_entries: list = None
-    ):
-        self.log_every_n_steps = log_every_n_steps
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
+    default_output_dir = "./grpo_output"
+    default_title = "GRPO Training"
+    training_type_attr = "grpo"
+    completion_banner = "GRPO TRAINING COMPLETED"
 
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
-
-        self.start_time: Optional[datetime] = None
-        self.dashboard: Optional[LiveDashboard] = None
-        self.total_steps = 0
-        self.total_epochs = 1
-
-        if previous_log_entries:
-            self._prepopulate_log(previous_log_entries)
-
-    def _prepopulate_log(self, previous_entries: list):
-        with open(self.log_file, "w") as f:
-            for entry in previous_entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        self.start_time = datetime.now()
-        self.total_steps = state.max_steps if state.max_steps > 0 else 1000
-        self.total_epochs = args.num_train_epochs
-        reset_capacity_peaks(torch)
-
-        if self.latest_log.exists():
-            try:
-                self.latest_log.unlink()
-            except Exception:
-                pass
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except Exception:
-            pass
-
-        if DASHBOARD_AVAILABLE and RICH_AVAILABLE:
-            self.dashboard = LiveDashboard(
-                title="GRPO Training",
-                total_epochs=int(self.total_epochs),
-                total_steps=self.total_steps,
-                training_type="grpo",  # This enables GRPO-specific display
-                show_sparklines=True,
-                log_lines=3,
-            )
-            self.dashboard.__enter__()
-        else:
-            print(f"\n{'=' * 60}")
-            print("GRPO TRAINING STARTED")
-            print(f"{'=' * 60}")
-            print(f"Log file: {self.log_file}")
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        if not logs:
-            return
-
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
-        samples_per_sec = (
-            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
-        ) / elapsed if elapsed > 0 else 0.0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        cloud_provider = os.environ.get("CLOUD_PROVIDER", "").strip()
-        if cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        # Save to log file
-        log_entry = {
-            "step": state.global_step,
-            "timestamp": datetime.now().isoformat(),
-            "total_steps": self.total_steps,
-            "total_epochs": int(self.total_epochs),
-            "elapsed_seconds": round(elapsed, 3),
-            "steps_per_second": round(steps_per_sec, 3),
-            "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs
-        }
-        with open(self.log_file, "a") as f:
-            f.write(json.dumps(log_entry) + "\n")
-
-        # Extract GRPO-specific metrics (handle various key names)
-        reward = logs.get("reward") or logs.get("rewards") or logs.get("rewards/mean") or logs.get("mean_reward") or 0
+    def _dashboard_metrics(self, logs, capacity_snapshot):
+        reward = (
+            logs.get("reward")
+            or logs.get("rewards")
+            or logs.get("rewards/mean")
+            or logs.get("mean_reward")
+            or 0
+        )
         reward_std = logs.get("reward_std") or logs.get("rewards/std") or 0
         kl_penalty = logs.get("kl") or logs.get("kl_penalty") or logs.get("kl_div") or 0
         advantage = logs.get("advantage") or logs.get("advantages/mean") or 0
+        return {
+            "reward": reward,
+            "reward_std": reward_std,
+            "kl_penalty": kl_penalty,
+            "advantage": advantage,
+        }
 
-        # Update dashboard with GRPO-specific metrics
-        if self.dashboard:
-            self.dashboard.update(
-                step=state.global_step,
-                epoch=int(logs.get('epoch', 0)),
-                loss=logs.get('loss'),
-                learning_rate=logs.get('learning_rate'),
-                # GRPO-specific metrics
-                reward=reward,
-                reward_std=reward_std,
-                kl_penalty=kl_penalty,
-                advantage=advantage,
-                gpu_memory_gb=capacity_snapshot.get("gpu_memory_gb"),
-            )
-        else:
-            loss = logs.get('loss', 0)
-            print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | Reward: {reward:.4f}")
-
-    def on_save(self, args, state, control, **kwargs):
-        if self.dashboard:
-            self.dashboard.update(log_message=f"Checkpoint saved at step {state.global_step}")
-        else:
-            print(f"  >> Checkpoint saved at step {state.global_step}")
-
-    def on_train_end(self, args, state, control, **kwargs):
-        if self.dashboard:
-            self.dashboard.__exit__(None, None, None)
-            self.dashboard = None
-
-        elapsed = (datetime.now() - self.start_time).total_seconds()
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=self.total_steps,
-            total_epochs=int(self.total_epochs),
-            elapsed=elapsed,
+    def _fallback_row(self, *, state, logs, capacity_snapshot):
+        loss = logs.get("loss", 0)
+        reward = (
+            logs.get("reward")
+            or logs.get("rewards")
+            or logs.get("rewards/mean")
+            or logs.get("mean_reward")
+            or 0
         )
-        print(f"\n{'=' * 60}")
-        print("GRPO TRAINING COMPLETED")
-        print(f"{'=' * 60}")
-        print(f"Total time: {elapsed // 3600:.0f}h {(elapsed % 3600) // 60:.0f}m {elapsed % 60:.0f}s")
-        print(f"Total steps: {state.global_step:,}")
-        print(f"Log file: {self.log_file}")
+        print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | Reward: {reward:.4f}")
+
+
+__all__ = [
+    "MetricsTableCallback",
+    "LiveDashboardCallback",
+    "DASHBOARD_AVAILABLE",
+    "RICH_AVAILABLE",
+]

--- a/Trainers/kto/src/training_callbacks.py
+++ b/Trainers/kto/src/training_callbacks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Per-trainer KTO callback shims.
+"""Per-trainer KTO concrete callback subclasses and re-exports.
 
 Public symbols `MetricsTableCallback`, `CheckpointMonitorCallback`,
 `LiveDashboardCallback`, `TwoStageLRCallback`, `DASHBOARD_AVAILABLE`,
@@ -9,12 +9,9 @@ lives in `Trainers.shared.callbacks`.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py.
 from Trainers.shared.callbacks import (
     BaseLiveDashboardCallback,
     BaseMetricsCallback,

--- a/Trainers/kto/src/training_callbacks.py
+++ b/Trainers/kto/src/training_callbacks.py
@@ -1,514 +1,101 @@
 #!/usr/bin/env python3
-"""
-Custom training callbacks for KTO fine-tuning.
-Provides real-time metrics tracking and pretty table output.
+"""Per-trainer KTO callback shims.
+
+Public symbols `MetricsTableCallback`, `CheckpointMonitorCallback`,
+`LiveDashboardCallback`, `TwoStageLRCallback`, `DASHBOARD_AVAILABLE`,
+`RICH_AVAILABLE` are re-exported at their original paths. Shared lifecycle
+lives in `Trainers.shared.callbacks`.
 """
 
-from transformers import TrainerCallback, TrainerState, TrainerControl
-import torch
-from datetime import datetime
-from typing import Dict, Any, Optional
-import json
+from __future__ import annotations
+
 import sys
-import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-# Add shared to path for UI components
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from shared.training_capacity import capture_runtime_capacity_snapshot, reset_capacity_peaks
-
-# Try to import LiveDashboard
-try:
-    from shared.ui import LiveDashboard, RICH_AVAILABLE
-    DASHBOARD_AVAILABLE = True
-except ImportError:
-    DASHBOARD_AVAILABLE = False
-    RICH_AVAILABLE = False
-
-
-def _append_final_training_summary(log_file: Path, *, step: int, total_steps: int, total_epochs: int, elapsed: float) -> None:
-    capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-    entry = {
-        "event": "train_end",
-        "step": int(step),
-        "timestamp": datetime.now().isoformat(),
-        "total_steps": int(total_steps),
-        "total_epochs": int(total_epochs),
-        "train_runtime": round(elapsed, 3),
-        "train_steps_per_second": round((step / elapsed), 3) if elapsed > 0 else 0.0,
-        "train_samples_per_second": None,
-        **capacity_snapshot,
-    }
-    with open(log_file, "a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
+from Trainers.shared.callbacks import (
+    BaseLiveDashboardCallback,
+    BaseMetricsCallback,
+    CheckpointMonitorCallback,
+    DASHBOARD_AVAILABLE,
+    KTOHealthChecker,
+    RICH_AVAILABLE,
+    TwoStageLRCallback,
+)
 
 
-class MetricsTableCallback(TrainerCallback):
-    """
-    Custom callback that prints training metrics in a nice table format.
-    Shows metrics every N steps to track training progress.
-    """
+class MetricsTableCallback(BaseMetricsCallback):
+    """KTO table output: loss/LR/chosen/reject/margin/gpu/samples/eta; writes JSONL every on_log."""
 
-    def __init__(self, log_every_n_steps: int = 5, output_dir: str = "./kto_output",
-                 previous_log_entries: list = None):
-        """
-        Args:
-            log_every_n_steps: Print table every N training steps
-            output_dir: Directory to save detailed logs
-            previous_log_entries: Optional list of log entries from a previous run to prepopulate the log
-        """
-        self.log_every_n_steps = log_every_n_steps
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
+    default_output_dir = "./kto_output"
+    start_banner = "TRAINING STARTED"
+    completion_banner = "TRAINING COMPLETED"
+    log_every_write = True  # KTO writes JSONL on every on_log, not only at interval.
 
-        # Create timestamped log file for this training run
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-
-        # Also create a symlink to "latest" for easy access
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
-
-        self.start_time = None
-        self.last_log_time = None
-        self.step_times = []
-        self.header_printed = False
-
-        # Prepopulate log file with previous entries if resuming
-        if previous_log_entries:
-            self._prepopulate_log(previous_log_entries)
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Called at the beginning of training."""
-        self.start_time = datetime.now()
-        self.last_log_time = datetime.now()
-        self.header_printed = False
-        reset_capacity_peaks(torch)
-
-        # Create symlink to latest log for easy access
-        if self.latest_log.exists():
-            self.latest_log.unlink()
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except (OSError, NotImplementedError):
-            # Symlinks might not work on all filesystems (like WSL sometimes)
-            # Just skip the symlink in that case
-            pass
-
-        print("\n" + "=" * 100)
-        print("TRAINING STARTED")
-        print("=" * 100)
-        print(f"Detailed metrics logging to: {self.log_file}")
-        print(f"View in real-time: tail -f {self.log_file}")
-        print(f"Or use latest: tail -f {self.latest_log}")
-        print("=" * 100)
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        """Called when logging occurs."""
-        if logs is None:
-            return
-
-        # Calculate time since last log
-        current_time = datetime.now()
-        interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0
-        self.last_log_time = current_time
-
-        elapsed = (current_time - self.start_time).total_seconds()
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0
-        samples_per_sec = (state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps) / elapsed if elapsed > 0 else 0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        if args.cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", args.cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        # Save full metrics to file (every step) with interval time
-        self._save_metrics_to_file(
-            logs,
-            state.global_step,
-            interval_time,
-            elapsed,
-            steps_per_sec,
-            samples_per_sec,
-            capacity_snapshot,
-        )
-
-        # Check training health and warn if needed
-        self._check_training_health(logs, state.global_step, args.max_grad_norm)
-
-        # Only print table at specified intervals
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        # Print header every 20 rows for readability
-        if not self.header_printed or state.global_step % (self.log_every_n_steps * 20) == 0:
-            self._print_header()
-            self.header_printed = True
-
-        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
-        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
-
-        # Extract metrics from logs
-        loss = logs.get('loss', 0.0)
-        learning_rate = logs.get('learning_rate', 0.0)
-        kto_chosen = logs.get('rewards/chosen', 0.0)
-        kto_rejected = logs.get('rewards/rejected', 0.0)
-        kto_margin = logs.get('rewards/margins', 0.0)
-        kl_div = logs.get('logps/rejected', 0.0)  # KL divergence approximation
-
-        # Calculate ETA
-        if state.max_steps > 0:
-            remaining_steps = state.max_steps - state.global_step
-            eta_seconds = remaining_steps / steps_per_sec if steps_per_sec > 0 else 0
-            eta = self._format_time(eta_seconds)
-            progress = f"{state.global_step}/{state.max_steps}"
-        else:
-            eta = "N/A"
-            progress = f"{state.global_step}"
-
-        # Print table row
-        print(f" {progress:>12} | {loss:>8.4f} | {learning_rate:>9.2e} | "
-              f"{kto_chosen:>6.3f} | {kto_rejected:>6.3f} | {kto_margin:>6.3f} | "
-              f"{gpu_mem:>8} | {interval_time:>7.1f}s | {samples_per_sec:>8.1f} | {eta:>9} ")
-
-    def _save_metrics_to_file(
+    def __init__(
         self,
-        logs: Dict[str, Any],
-        step: int,
-        interval_time: float,
-        elapsed: float,
-        steps_per_sec: float,
-        samples_per_sec: float,
-        capacity_snapshot: Dict[str, Any],
+        log_every_n_steps: int = 5,
+        output_dir: str = "./kto_output",
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
     ):
-        """Save detailed metrics to JSONL file."""
-        log_entry = {
-            "step": step,
-            "timestamp": datetime.now().isoformat(),
-            "interval_time": interval_time,
-            "elapsed_seconds": round(elapsed, 3),
-            "steps_per_second": round(steps_per_sec, 3),
-            "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs
-        }
-
-        with open(self.log_file, "a") as f:
-            f.write(json.dumps(log_entry) + "\n")
-
-    def _prepopulate_log(self, previous_entries: list):
-        """Prepopulate log file with entries from a previous run.
-
-        Args:
-            previous_entries: List of dict entries to write to the log file
-        """
-        print(f"\n✓ Prepopulating log with {len(previous_entries)} entries from previous run")
-
-        with open(self.log_file, "w") as f:
-            for entry in previous_entries:
-                f.write(json.dumps(entry) + "\n")
-
-        print(f"  Log file: {self.log_file}")
-        print(f"  Steps included: 0-{previous_entries[-1]['step'] if previous_entries else 0}\n")
-
-    def _check_training_health(self, logs: Dict[str, Any], step: int, max_grad_norm: float = None):
-        """Check if training metrics are healthy and warn if not."""
-        warnings = []
-
-        # Check for NaN or Inf
-        loss = logs.get('loss', 0.0)
-        if not (0 < loss < 100):  # Loss should be positive and reasonable
-            warnings.append(f"⚠ Unusual loss value: {loss:.4f}")
-
-        # Check KTO margins (should be positive and increasing over time)
-        margin = logs.get('rewards/margins', 0.0)
-        if margin < -1.0:  # Very negative margin is bad
-            warnings.append(f"⚠ Very negative margin: {margin:.4f} (chosen model may be worse than reference)")
-
-        # Check for reward collapse (both chosen and rejected near zero)
-        chosen = logs.get('rewards/chosen', 0.0)
-        rejected = logs.get('rewards/rejected', 0.0)
-        if abs(chosen) < 0.001 and abs(rejected) < 0.001 and step > 10:
-            warnings.append("⚠ Reward collapse detected (both rewards near zero)")
-
-        # Check gradient norm (show both raw and clipped values)
-        grad_norm = logs.get('grad_norm', 0.0)
-        if grad_norm > 100.0:
-            if max_grad_norm is not None:
-                clipped_norm = min(grad_norm, max_grad_norm)
-                warnings.append(
-                    f"⚠ High gradient norm: {grad_norm:.2f} → {clipped_norm:.2f} (clipped)"
-                )
-            else:
-                warnings.append(f"⚠ High gradient norm: {grad_norm:.2f} (may cause instability)")
-
-        # Print warnings if any
-        if warnings:
-            print("\n" + "!" * 100)
-            for warning in warnings:
-                print(f"  {warning}")
-            if max_grad_norm is None or grad_norm > max_grad_norm * 10:
-                print("  Consider: reducing learning rate or using tighter gradient clipping")
-            print("!" * 100 + "\n")
-
-    def on_save(self, args, state, control, **kwargs):
-        """Called when a checkpoint is saved."""
-        print("-" * 100)
-        print(f">> CHECKPOINT SAVED at step {state.global_step:,} -> {args.output_dir}/checkpoint-{state.global_step}")
-        print("-" * 100)
-
-    def on_train_end(self, args, state, control, **kwargs):
-        """Called at the end of training."""
-        print("=" * 100)
-        elapsed = (datetime.now() - self.start_time).total_seconds()
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=state.max_steps if state.max_steps > 0 else state.global_step,
-            total_epochs=int(state.epoch or 0),
-            elapsed=elapsed,
+        super().__init__(
+            log_every_n_steps=log_every_n_steps,
+            output_dir=output_dir,
+            previous_log_entries=previous_log_entries,
         )
-        print("\n" + "=" * 100)
-        print("TRAINING COMPLETED")
-        print("=" * 100)
-        print(f"Total time: {self._format_time(elapsed)}")
-        print(f"Total steps: {state.global_step:,}")
-        print(f"Average speed: {state.global_step / elapsed:.2f} steps/sec")
-        print("=" * 100 + "\n")
+        self.health_checker = KTOHealthChecker()
 
     def _print_header(self):
-        """Print the table header."""
         print("\n" + "=" * 110)
         print(" " * 47 + "TRAINING METRICS")
         print("=" * 110)
         print("   Step      |   Loss   |    LR     | Chosen | Reject | Margin | GPU Mem  | Time/5s | Samp/sec |    ETA    ")
         print("-" * 110)
 
-    def _format_time(self, seconds: float) -> str:
-        """Format seconds into human-readable time."""
-        if seconds < 60:
-            return f"{int(seconds)}s"
-        elif seconds < 3600:
-            return f"{int(seconds // 60)}m {int(seconds % 60)}s"
-        else:
-            hours = int(seconds // 3600)
-            minutes = int((seconds % 3600) // 60)
-            return f"{hours}h {minutes}m"
-
-
-class TwoStageLRCallback(TrainerCallback):
-    """
-    Custom callback that implements a two-stage learning rate schedule.
-
-    This reduces the learning rate at a specified step to prevent optimization
-    instability while maintaining fast early learning.
-
-    Example:
-        Steps 1-50:  LR = 5e-7 (fast early learning)
-        Steps 51+:   LR = 2.5e-7 (reduced to prevent overshoot/instability)
-    """
-
-    def __init__(self, initial_lr: float, reduced_lr: float, reduction_step: int):
-        """
-        Args:
-            initial_lr: Learning rate for early training (e.g., 5e-7)
-            reduced_lr: Reduced learning rate after reduction_step (e.g., 2.5e-7)
-            reduction_step: Step at which to reduce LR (e.g., 50)
-        """
-        self.initial_lr = initial_lr
-        self.reduced_lr = reduced_lr
-        self.reduction_step = reduction_step
-        self.lr_reduced = False
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Display two-stage LR schedule configuration."""
-        print("\n" + "=" * 100)
-        print("TWO-STAGE LEARNING RATE SCHEDULE")
-        print("=" * 100)
-        print(f"  Steps 1-{self.reduction_step}:  LR = {self.initial_lr:.2e} (fast early learning)")
-        print(f"  Steps {self.reduction_step+1}+:     LR = {self.reduced_lr:.2e} ({(self.reduced_lr/self.initial_lr)*100:.0f}% of initial, prevents instability)")
-        print(f"  Reduction ratio: {self.reduced_lr/self.initial_lr:.1%}")
-        print("=" * 100 + "\n")
-
-    def on_step_begin(self, args, state, control, **kwargs):
-        """Check if we need to reduce learning rate at this step."""
-        if state.global_step == self.reduction_step and not self.lr_reduced:
-            # Reduce learning rate for all parameter groups
-            optimizer = kwargs.get('optimizer')
-            if optimizer is not None:
-                for param_group in optimizer.param_groups:
-                    param_group['lr'] = self.reduced_lr
-
-                self.lr_reduced = True
-
-                print("\n" + "!" * 100)
-                print(f"🔧 LEARNING RATE REDUCED at step {state.global_step}")
-                print(f"   {self.initial_lr:.2e} → {self.reduced_lr:.2e} (50% reduction)")
-                print(f"   Reason: Preemptive intervention before step 60 instability zone")
-                print("!" * 100 + "\n")
-
-
-class CheckpointMonitorCallback(TrainerCallback):
-    """
-    Callback to monitor and display checkpoint information.
-    Helps track which checkpoints are being kept/deleted.
-    """
-
-    def on_save(self, args, state, control, **kwargs):
-        """Called when saving a checkpoint."""
-        # This is already handled by MetricsTableCallback
-        # but we keep this for extensibility
-        pass
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Display checkpoint configuration at start."""
-        print(f"\nCheckpoint Configuration:")
-        print(f"  Save every: {args.save_steps} steps")
-        print(f"  Keep last: {args.save_total_limit} checkpoints")
-        print(f"  Output dir: {args.output_dir}")
-        print()
-
-
-class LiveDashboardCallback(TrainerCallback):
-    """
-    Training callback that displays a live dashboard with real-time metrics.
-    Specialized for KTO training - shows margin, KL, and rewards.
-    """
-
-    def __init__(
-        self,
-        log_every_n_steps: int = 5,
-        output_dir: str = "./kto_output",
-        previous_log_entries: list = None
-    ):
-        self.log_every_n_steps = log_every_n_steps
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
-
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
-
-        self.start_time = None
-        self.dashboard: Optional[LiveDashboard] = None
-        self.total_steps = 0
-        self.total_epochs = 1
-
-        if previous_log_entries:
-            self._prepopulate_log(previous_log_entries)
-
-    def _prepopulate_log(self, previous_entries: list):
-        with open(self.log_file, "w") as f:
-            for entry in previous_entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        self.start_time = datetime.now()
-        self.total_steps = state.max_steps if state.max_steps > 0 else 1000
-        self.total_epochs = args.num_train_epochs
-        reset_capacity_peaks(torch)
-
-        if self.latest_log.exists():
-            self.latest_log.unlink()
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except (OSError, NotImplementedError):
-            pass
-
-        if DASHBOARD_AVAILABLE and RICH_AVAILABLE:
-            self.dashboard = LiveDashboard(
-                title="KTO Training",
-                total_epochs=int(self.total_epochs),
-                total_steps=self.total_steps,
-                training_type="kto",  # This enables KTO-specific display
-                show_sparklines=True,
-                log_lines=3,
-            )
-            self.dashboard.__enter__()
-        else:
-            print(f"\n{'=' * 60}")
-            print("KTO TRAINING STARTED")
-            print(f"{'=' * 60}")
-            print(f"Log file: {self.log_file}")
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        if logs is None:
-            return
-
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
-        samples_per_sec = (
-            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
-        ) / elapsed if elapsed > 0 else 0.0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        if args.cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", args.cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        # Save to log file
-        log_entry = {
-            "step": state.global_step,
-            "timestamp": datetime.now().isoformat(),
-            "total_steps": self.total_steps,
-            "total_epochs": int(self.total_epochs),
-            "elapsed_seconds": round(elapsed, 3),
-            "steps_per_second": round(steps_per_sec, 3),
-            "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs
-        }
-        with open(self.log_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(log_entry) + "\n")
-
-        # Update dashboard with KTO-specific metrics
-        if self.dashboard:
-            self.dashboard.update(
-                step=state.global_step,
-                epoch=int(logs.get('epoch', 0)),
-                loss=logs.get('loss'),
-                learning_rate=logs.get('learning_rate'),
-                # KTO-specific metrics
-                kl=logs.get('kl', logs.get('logps/rejected', 0)),  # KL divergence
-                margin=logs.get('rewards/margins'),  # Margin between chosen/rejected
-                gpu_memory_gb=capacity_snapshot.get("gpu_memory_gb"),
-            )
-        else:
-            loss = logs.get('loss', 0)
-            margin = logs.get('rewards/margins', 0)
-            gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
-            gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
-            print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | Margin: {margin:.4f} | GPU: {gpu_mem}")
-
-    def on_save(self, args, state, control, **kwargs):
-        if self.dashboard:
-            self.dashboard.update(log_message=f"Checkpoint saved at step {state.global_step}")
-        else:
-            print(f"  >> Checkpoint saved at step {state.global_step}")
-
-    def on_train_end(self, args, state, control, **kwargs):
-        if self.dashboard:
-            self.dashboard.__exit__(None, None, None)
-            self.dashboard = None
-
-        elapsed = (datetime.now() - self.start_time).total_seconds()
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=self.total_steps,
-            total_epochs=int(self.total_epochs),
-            elapsed=elapsed,
+    def _print_row(self, *, step, state, args, logs, capacity_snapshot, interval_time, samples_per_sec, eta, progress):
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        loss = logs.get("loss", 0.0)
+        learning_rate = logs.get("learning_rate", 0.0)
+        kto_chosen = logs.get("rewards/chosen", 0.0)
+        kto_rejected = logs.get("rewards/rejected", 0.0)
+        kto_margin = logs.get("rewards/margins", 0.0)
+        print(
+            f" {progress:>12} | {loss:>8.4f} | {learning_rate:>9.2e} | "
+            f"{kto_chosen:>6.3f} | {kto_rejected:>6.3f} | {kto_margin:>6.3f} | "
+            f"{gpu_mem:>8} | {interval_time:>7.1f}s | {samples_per_sec:>8.1f} | {eta:>9} "
         )
-        print(f"\n{'=' * 60}")
-        print("KTO TRAINING COMPLETED")
-        print(f"{'=' * 60}")
-        print(f"Total time: {elapsed // 3600:.0f}h {(elapsed % 3600) // 60:.0f}m {elapsed % 60:.0f}s")
-        print(f"Total steps: {state.global_step:,}")
-        print(f"Log file: {self.log_file}")
+
+
+class LiveDashboardCallback(BaseLiveDashboardCallback):
+    """KTO live dashboard: margin + KL-with-logps-fallback."""
+
+    default_output_dir = "./kto_output"
+    default_title = "KTO Training"
+    training_type_attr = "kto"
+    completion_banner = "KTO TRAINING COMPLETED"
+
+    def _dashboard_metrics(self, logs, capacity_snapshot):
+        return {
+            "kl": logs.get("kl", logs.get("logps/rejected", 0)),
+            "margin": logs.get("rewards/margins"),
+        }
+
+    def _fallback_row(self, *, state, logs, capacity_snapshot):
+        loss = logs.get("loss", 0)
+        margin = logs.get("rewards/margins", 0)
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | Margin: {margin:.4f} | GPU: {gpu_mem}")
+
+
+__all__ = [
+    "MetricsTableCallback",
+    "LiveDashboardCallback",
+    "TwoStageLRCallback",
+    "CheckpointMonitorCallback",
+    "DASHBOARD_AVAILABLE",
+    "RICH_AVAILABLE",
+]

--- a/Trainers/sft/src/training_callbacks.py
+++ b/Trainers/sft/src/training_callbacks.py
@@ -1,569 +1,112 @@
 #!/usr/bin/env python3
-"""
-Custom training callbacks for SFT fine-tuning.
-Provides real-time metrics tracking and pretty table output.
+"""Per-trainer SFT callback shims.
+
+Public symbols `MetricsTableCallback`, `CheckpointMonitorCallback`,
+`LiveDashboardCallback`, `TwoStageLRCallback`, `suppress_training_logs`,
+`DASHBOARD_AVAILABLE`, `RICH_AVAILABLE` are re-exported at their original
+paths. Shared lifecycle lives in `Trainers.shared.callbacks`.
 """
 
-from transformers import TrainerCallback, TrainerState, TrainerControl
-import torch
-from datetime import datetime
-from typing import Dict, Any, Optional
-import json
+from __future__ import annotations
+
 import sys
-import logging
-import os
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
-# Add shared to path for UI components
-sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+# Add Toolset-Training/ to path so Trainers.shared.callbacks resolves.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
-from shared.training_capacity import capture_runtime_capacity_snapshot, reset_capacity_peaks
-
-# Try to import LiveDashboard
-try:
-    from shared.ui import LiveDashboard, suppress_logs, RICH_AVAILABLE
-    DASHBOARD_AVAILABLE = True
-except ImportError:
-    DASHBOARD_AVAILABLE = False
-    RICH_AVAILABLE = False
-
-
-def _append_final_training_summary(log_file: Path, *, step: int, total_steps: int, total_epochs: int, elapsed: float) -> None:
-    """Persist a final summary row so bucketed logs retain runtime + peak capacity."""
-    capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-    entry = {
-        "event": "train_end",
-        "step": int(step),
-        "timestamp": datetime.now().isoformat(),
-        "total_steps": int(total_steps),
-        "total_epochs": int(total_epochs),
-        "train_runtime": round(elapsed, 3),
-        "train_steps_per_second": round((step / elapsed), 3) if elapsed > 0 else 0.0,
-        "train_samples_per_second": None,
-        **capacity_snapshot,
-    }
-    with open(log_file, "a", encoding="utf-8") as f:
-        f.write(json.dumps(entry) + "\n")
+from Trainers.shared.callbacks import (
+    BaseLiveDashboardCallback,
+    BaseMetricsCallback,
+    CheckpointMonitorCallback,
+    DASHBOARD_AVAILABLE,
+    RICH_AVAILABLE,
+    SFTHealthChecker,
+    TwoStageLRCallback,
+    format_time,
+    suppress_training_logs,
+)
 
 
-def _resolve_cloud_provider(args: Any) -> Optional[str]:
-    """Resolve cloud provider metadata without assuming trainer args carry custom CLI fields."""
-    cloud_provider = os.environ.get("CLOUD_PROVIDER", "").strip()
-    if cloud_provider:
-        return cloud_provider
-    return getattr(args, "cloud_provider", None)
+class MetricsTableCallback(BaseMetricsCallback):
+    """SFT table output: loss/LR/gradnorm/epoch/gpu/samples/eta."""
 
+    default_output_dir = "./sft_output"
+    start_banner = "TRAINING STARTED"
+    completion_banner = "TRAINING COMPLETED"
+    log_every_write = False  # Write JSONL only at log_every_n_steps boundary.
 
-class MetricsTableCallback(TrainerCallback):
-    """
-    Custom callback that prints training metrics in a nice table format.
-    Shows metrics every N steps to track training progress.
-    """
-
-    def __init__(self, log_every_n_steps: int = 5, output_dir: str = "./sft_output",
-                 previous_log_entries: list = None):
-        """
-        Args:
-            log_every_n_steps: Print table every N training steps
-            output_dir: Directory to save detailed logs
-            previous_log_entries: Optional list of log entries from a previous run to prepopulate the log
-        """
-        self.log_every_n_steps = log_every_n_steps
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
-
-        # Create timestamped log file for this training run
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-
-        # Also create a symlink to "latest" for easy access
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
-
-        self.start_time = None
-        self.last_log_time = None
-        self.step_times = []
-        self.header_printed = False
-
-        # Prepopulate log file with previous entries if resuming
-        if previous_log_entries:
-            self._prepopulate_log(previous_log_entries)
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Called at the beginning of training."""
-        self.start_time = datetime.now()
-        self.last_log_time = datetime.now()
-        self.header_printed = False
-        reset_capacity_peaks(torch)
-
-        # Create symlink to latest log for easy access
-        if self.latest_log.exists():
-            self.latest_log.unlink()
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except (OSError, NotImplementedError):
-            # Symlinks might not work on all filesystems (like WSL sometimes)
-            # Just skip the symlink in that case
-            pass
-
-        print("\n" + "=" * 100)
-        print("TRAINING STARTED")
-        print("=" * 100)
-        print(f"Detailed metrics logging to: {self.log_file}")
-        print(f"View in real-time: tail -f {self.log_file}")
-        print(f"Or use latest: tail -f {self.latest_log}")
-        print("=" * 100)
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        """Called when logging occurs."""
-        if logs is None:
-            return
-
-        # Only log at specified intervals
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        # Calculate time since last log
-        current_time = datetime.now()
-        interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0
-        self.last_log_time = current_time
-
-        elapsed = (current_time - self.start_time).total_seconds()
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0
-        samples_per_sec = (state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps) / elapsed if elapsed > 0 else 0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        cloud_provider = _resolve_cloud_provider(args)
-        if cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        # Save full metrics to file (every log_every_n_steps)
-        self._save_metrics_to_file(
-            logs,
-            state.global_step,
-            interval_time,
-            elapsed,
-            steps_per_sec,
-            samples_per_sec,
-            capacity_snapshot,
-        )
-
-        # Check training health and warn if needed
-        self._check_training_health(logs, state.global_step, args.max_grad_norm)
-
-        # Print header every 20 rows for readability
-        if not self.header_printed or state.global_step % (self.log_every_n_steps * 20) == 0:
-            self._print_header()
-            self.header_printed = True
-
-        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
-        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
-
-        # Extract metrics from logs
-        loss = logs.get('loss', 0.0)
-        learning_rate = logs.get('learning_rate', 0.0)
-        grad_norm = logs.get('grad_norm', 0.0)
-        epoch = logs.get('epoch', 0.0)
-
-        # Calculate ETA
-        if state.max_steps > 0:
-            remaining_steps = state.max_steps - state.global_step
-            eta_seconds = remaining_steps / steps_per_sec if steps_per_sec > 0 else 0
-            eta = self._format_time(eta_seconds)
-            progress = f"{state.global_step}/{state.max_steps}"
-        else:
-            eta = "N/A"
-            progress = f"{state.global_step}"
-
-        # Print table row (SFT-specific metrics)
-        print(f" {progress:>12} | {loss:>8.4f} | {learning_rate:>9.2e} | "
-              f"{grad_norm:>8.3f} | {epoch:>6.2f} | {gpu_mem:>8} | "
-              f"{interval_time:>7.1f}s | {samples_per_sec:>8.1f} | {eta:>9} ")
-
-    def _save_metrics_to_file(
+    def __init__(
         self,
-        logs: Dict[str, Any],
-        step: int,
-        interval_time: float,
-        elapsed: float,
-        steps_per_sec: float,
-        samples_per_sec: float,
-        capacity_snapshot: Dict[str, Any],
+        log_every_n_steps: int = 5,
+        output_dir: str = "./sft_output",
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
     ):
-        """Save detailed metrics to JSONL file."""
-        log_entry = {
-            "step": step,
-            "timestamp": datetime.now().isoformat(),
-            "interval_time": interval_time,
-            "elapsed_seconds": round(elapsed, 3),
-            "steps_per_second": round(steps_per_sec, 3),
-            "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs
-        }
-
-        with open(self.log_file, "a") as f:
-            f.write(json.dumps(log_entry) + "\n")
-
-    def _prepopulate_log(self, previous_entries: list):
-        """Prepopulate log file with entries from a previous run.
-
-        Args:
-            previous_entries: List of dict entries to write to the log file
-        """
-        print(f"\n✓ Prepopulating log with {len(previous_entries)} entries from previous run")
-
-        with open(self.log_file, "w") as f:
-            for entry in previous_entries:
-                f.write(json.dumps(entry) + "\n")
-
-        print(f"  Log file: {self.log_file}")
-        print(f"  Steps included: 0-{previous_entries[-1]['step'] if previous_entries else 0}\n")
-
-    def _check_training_health(self, logs: Dict[str, Any], step: int, max_grad_norm: float = None):
-        """Check if training metrics are healthy and warn if not (SFT-specific checks)."""
-        warnings = []
-
-        # Check for NaN or Inf
-        loss = logs.get('loss', 0.0)
-        if not (0 < loss < 100):  # Loss should be positive and reasonable
-            warnings.append(f"⚠ Unusual loss value: {loss:.4f}")
-
-        # Check gradient norm (show both raw and clipped values)
-        grad_norm = logs.get('grad_norm', 0.0)
-        if grad_norm > 100.0:
-            if max_grad_norm is not None:
-                clipped_norm = min(grad_norm, max_grad_norm)
-                warnings.append(
-                    f"⚠ High gradient norm: {grad_norm:.2f} → {clipped_norm:.2f} (clipped)"
-                )
-            else:
-                warnings.append(f"⚠ High gradient norm: {grad_norm:.2f} (may cause instability)")
-
-        # Check if loss is not decreasing (compare to first few steps)
-        if step > 50:  # After warm-up
-            # This is a basic check - in production you'd track loss history
-            if loss > 2.0:  # Still high after 50 steps
-                warnings.append(f"⚠ Loss remains high after {step} steps: {loss:.4f} (may need longer training or LR adjustment)")
-
-        # Print warnings if any
-        if warnings:
-            print("\n" + "!" * 100)
-            for warning in warnings:
-                print(f"  {warning}")
-            if max_grad_norm is None or grad_norm > max_grad_norm * 10:
-                print("  Consider: reducing learning rate or using tighter gradient clipping")
-            print("!" * 100 + "\n")
-
-    def on_save(self, args, state, control, **kwargs):
-        """Called when a checkpoint is saved."""
-        print("-" * 100)
-        print(f">> CHECKPOINT SAVED at step {state.global_step:,} -> {args.output_dir}/checkpoint-{state.global_step}")
-        print("-" * 100)
-
-    def on_train_end(self, args, state, control, **kwargs):
-        """Called at the end of training."""
-        print("=" * 100)
-        elapsed = (datetime.now() - self.start_time).total_seconds()
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=state.max_steps if state.max_steps > 0 else state.global_step,
-            total_epochs=int(state.epoch or 0),
-            elapsed=elapsed,
+        super().__init__(
+            log_every_n_steps=log_every_n_steps,
+            output_dir=output_dir,
+            previous_log_entries=previous_log_entries,
         )
-        print("\n" + "=" * 100)
-        print("TRAINING COMPLETED")
-        print("=" * 100)
-        print(f"Total time: {self._format_time(elapsed)}")
-        print(f"Total steps: {state.global_step:,}")
-        print(f"Average speed: {state.global_step / elapsed:.2f} steps/sec")
-        print("=" * 100 + "\n")
+        self.health_checker = SFTHealthChecker()
 
     def _print_header(self):
-        """Print the table header."""
         print("\n" + "=" * 110)
         print(" " * 47 + "TRAINING METRICS")
         print("=" * 110)
         print("   Step      |   Loss   |    LR     | GradNorm | Epoch  | GPU Mem  | Time/5s | Samp/sec |    ETA    ")
         print("-" * 110)
 
-    def _format_time(self, seconds: float) -> str:
-        """Format seconds into human-readable time."""
-        if seconds < 60:
-            return f"{int(seconds)}s"
-        elif seconds < 3600:
-            return f"{int(seconds // 60)}m {int(seconds % 60)}s"
-        else:
-            hours = int(seconds // 3600)
-            minutes = int((seconds % 3600) // 60)
-            return f"{hours}h {minutes}m"
+    def _print_row(self, *, step, state, args, logs, capacity_snapshot, interval_time, samples_per_sec, eta, progress):
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        loss = logs.get("loss", 0.0)
+        learning_rate = logs.get("learning_rate", 0.0)
+        grad_norm = logs.get("grad_norm", 0.0)
+        epoch = logs.get("epoch", 0.0)
+        print(
+            f" {progress:>12} | {loss:>8.4f} | {learning_rate:>9.2e} | "
+            f"{grad_norm:>8.3f} | {epoch:>6.2f} | {gpu_mem:>8} | "
+            f"{interval_time:>7.1f}s | {samples_per_sec:>8.1f} | {eta:>9} "
+        )
 
 
-class TwoStageLRCallback(TrainerCallback):
-    """
-    Custom callback that implements a two-stage learning rate schedule.
+class LiveDashboardCallback(BaseLiveDashboardCallback):
+    """SFT live dashboard: loss/LR/kl/margin/gpu; accepts `training_type` param."""
 
-    This reduces the learning rate at a specified step to prevent optimization
-    instability while maintaining fast early learning.
-
-    Example:
-        Steps 1-50:  LR = 5e-7 (fast early learning)
-        Steps 51+:   LR = 2.5e-7 (reduced to prevent overshoot/instability)
-    """
-
-    def __init__(self, initial_lr: float, reduced_lr: float, reduction_step: int):
-        """
-        Args:
-            initial_lr: Learning rate for early training (e.g., 5e-7)
-            reduced_lr: Reduced learning rate after reduction_step (e.g., 2.5e-7)
-            reduction_step: Step at which to reduce LR (e.g., 50)
-        """
-        self.initial_lr = initial_lr
-        self.reduced_lr = reduced_lr
-        self.reduction_step = reduction_step
-        self.lr_reduced = False
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Display two-stage LR schedule configuration."""
-        print("\n" + "=" * 100)
-        print("TWO-STAGE LEARNING RATE SCHEDULE")
-        print("=" * 100)
-        print(f"  Steps 1-{self.reduction_step}:  LR = {self.initial_lr:.2e} (fast early learning)")
-        print(f"  Steps {self.reduction_step+1}+:     LR = {self.reduced_lr:.2e} ({(self.reduced_lr/self.initial_lr)*100:.0f}% of initial, prevents instability)")
-        print(f"  Reduction ratio: {self.reduced_lr/self.initial_lr:.1%}")
-        print("=" * 100 + "\n")
-
-    def on_step_begin(self, args, state, control, **kwargs):
-        """Check if we need to reduce learning rate at this step."""
-        if state.global_step == self.reduction_step and not self.lr_reduced:
-            # Reduce learning rate for all parameter groups
-            optimizer = kwargs.get('optimizer')
-            if optimizer is not None:
-                for param_group in optimizer.param_groups:
-                    param_group['lr'] = self.reduced_lr
-
-                self.lr_reduced = True
-
-                print("\n" + "!" * 100)
-                print(f"🔧 LEARNING RATE REDUCED at step {state.global_step}")
-                print(f"   {self.initial_lr:.2e} → {self.reduced_lr:.2e} (50% reduction)")
-                print(f"   Reason: Preemptive intervention before step 60 instability zone")
-                print("!" * 100 + "\n")
-
-
-class CheckpointMonitorCallback(TrainerCallback):
-    """
-    Callback to monitor and display checkpoint information.
-    Helps track which checkpoints are being kept/deleted.
-    """
-
-    def on_save(self, args, state, control, **kwargs):
-        """Called when saving a checkpoint."""
-        # This is already handled by MetricsTableCallback
-        # but we keep this for extensibility
-        pass
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Display checkpoint configuration at start."""
-        print(f"\nCheckpoint Configuration:")
-        print(f"  Save every: {args.save_steps} steps")
-        print(f"  Keep last: {args.save_total_limit} checkpoints")
-        print(f"  Output dir: {args.output_dir}")
-        print()
-
-
-class LiveDashboardCallback(TrainerCallback):
-    """
-    Training callback that displays a live dashboard with real-time metrics.
-
-    Uses the shared.ui LiveDashboard for a rich, animated display.
-    Falls back to MetricsTableCallback if dashboard is not available.
-    """
+    default_output_dir = "./sft_output"
+    completion_banner = "TRAINING COMPLETED"
 
     def __init__(
         self,
         log_every_n_steps: int = 5,
         output_dir: str = "./sft_output",
         training_type: str = "sft",
-        previous_log_entries: list = None
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
     ):
-        """
-        Args:
-            log_every_n_steps: Update dashboard every N training steps
-            output_dir: Directory to save detailed logs
-            training_type: 'sft' or 'kto' (affects displayed metrics)
-            previous_log_entries: Optional list of log entries from a previous run
-        """
-        self.log_every_n_steps = log_every_n_steps
-        self.output_dir = Path(output_dir)
-        self.logs_dir = self.output_dir / "logs"
-        self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.training_type = training_type
-
-        # Create timestamped log file
-        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
-        self.latest_log = self.logs_dir / "training_latest.jsonl"
-
-        self.start_time = None
-        self.dashboard: Optional[LiveDashboard] = None
-        self.total_steps = 0
-        self.total_epochs = 1
-
-        # Prepopulate if resuming
-        if previous_log_entries:
-            self._prepopulate_log(previous_log_entries)
-
-    def _prepopulate_log(self, previous_entries: list):
-        """Prepopulate log file with entries from a previous run."""
-        with open(self.log_file, "w") as f:
-            for entry in previous_entries:
-                f.write(json.dumps(entry) + "\n")
-
-    def on_train_begin(self, args, state, control, **kwargs):
-        """Start the live dashboard."""
-        self.start_time = datetime.now()
-        self.total_steps = state.max_steps if state.max_steps > 0 else 1000
-        self.total_epochs = args.num_train_epochs
-        reset_capacity_peaks(torch)
-
-        # Create symlink to latest log
-        if self.latest_log.exists():
-            self.latest_log.unlink()
-        try:
-            self.latest_log.symlink_to(self.log_file.name)
-        except (OSError, NotImplementedError):
-            pass
-
-        # Start dashboard if available
-        if DASHBOARD_AVAILABLE and RICH_AVAILABLE:
-            self.dashboard = LiveDashboard(
-                title=f"{self.training_type.upper()} Training",
-                total_epochs=int(self.total_epochs),
-                total_steps=self.total_steps,
-                training_type=self.training_type,
-                show_sparklines=True,
-                log_lines=3,
-            )
-            self.dashboard.__enter__()
-        else:
-            # Fallback: print basic info
-            print(f"\n{'=' * 60}")
-            print(f"TRAINING STARTED - {self.training_type.upper()}")
-            print(f"{'=' * 60}")
-            print(f"Log file: {self.log_file}")
-
-    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
-        """Update the dashboard with new metrics."""
-        if logs is None:
-            return
-
-        # Only update at specified intervals
-        if state.global_step % self.log_every_n_steps != 0:
-            return
-
-        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
-        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
-        samples_per_sec = (
-            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
-        ) / elapsed if elapsed > 0 else 0.0
-        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
-        cloud_provider = _resolve_cloud_provider(args)
-        if cloud_provider:
-            capacity_snapshot.setdefault("cloud_provider", cloud_provider)
-        cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
-        if cloud_gpu_type:
-            capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
-
-        # Save to log file
-        log_entry = {
-            "step": state.global_step,
-            "timestamp": datetime.now().isoformat(),
-            "total_steps": self.total_steps,
-            "total_epochs": int(self.total_epochs),
-            "elapsed_seconds": round(elapsed, 3),
-            "steps_per_second": round(steps_per_sec, 3),
-            "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs
-        }
-        with open(self.log_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(log_entry) + "\n")
-
-        # Update dashboard
-        if self.dashboard:
-            self.dashboard.update(
-                step=state.global_step,
-                epoch=int(logs.get('epoch', 0)),
-                loss=logs.get('loss'),
-                learning_rate=logs.get('learning_rate'),
-                kl=logs.get('kl'),
-                margin=logs.get('rewards/margins'),
-                gpu_memory_gb=capacity_snapshot.get("gpu_memory_gb"),
-            )
-        else:
-            # Fallback: print step info
-            loss = logs.get('loss', 0)
-            lr = logs.get('learning_rate', 0)
-            gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
-            gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
-            print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | LR: {lr:.2e} | GPU: {gpu_mem}")
-
-    def on_save(self, args, state, control, **kwargs):
-        """Log checkpoint save."""
-        if self.dashboard:
-            self.dashboard.update(log_message=f"Checkpoint saved at step {state.global_step}")
-        else:
-            print(f"  >> Checkpoint saved at step {state.global_step}")
-
-    def on_train_end(self, args, state, control, **kwargs):
-        """Stop the dashboard."""
-        if self.dashboard:
-            self.dashboard.__exit__(None, None, None)
-            self.dashboard = None
-
-        elapsed = (datetime.now() - self.start_time).total_seconds()
-        _append_final_training_summary(
-            self.log_file,
-            step=state.global_step,
-            total_steps=self.total_steps,
-            total_epochs=int(self.total_epochs),
-            elapsed=elapsed,
+        self.default_title = f"{training_type.upper()} Training"
+        self.training_type_attr = training_type
+        super().__init__(
+            log_every_n_steps=log_every_n_steps,
+            output_dir=output_dir,
+            previous_log_entries=previous_log_entries,
         )
-        print(f"\n{'=' * 60}")
-        print("TRAINING COMPLETED")
-        print(f"{'=' * 60}")
-        print(f"Total time: {elapsed // 3600:.0f}h {(elapsed % 3600) // 60:.0f}m {elapsed % 60:.0f}s")
-        print(f"Total steps: {state.global_step:,}")
-        print(f"Log file: {self.log_file}")
+
+    def _dashboard_metrics(self, logs, capacity_snapshot):
+        return {
+            "kl": logs.get("kl"),
+            "margin": logs.get("rewards/margins"),
+        }
 
 
-def suppress_training_logs():
-    """
-    Suppress verbose logs from training libraries.
-
-    Call this before importing unsloth/transformers to quiet the output.
-    Returns a context manager that can be used to restore logging.
-    """
-    # Suppress common noisy loggers
-    noisy_loggers = [
-        'unsloth',
-        'transformers',
-        'datasets',
-        'accelerate',
-        'trl',
-        'peft',
-        'bitsandbytes',
-        'torch',
-        'huggingface_hub',
-    ]
-
-    if DASHBOARD_AVAILABLE:
-        return suppress_logs(noisy_loggers, level=logging.WARNING)
-    else:
-        # Return a no-op context manager
-        from contextlib import nullcontext
-        return nullcontext()
+__all__ = [
+    "MetricsTableCallback",
+    "LiveDashboardCallback",
+    "TwoStageLRCallback",
+    "CheckpointMonitorCallback",
+    "suppress_training_logs",
+    "DASHBOARD_AVAILABLE",
+    "RICH_AVAILABLE",
+    "format_time",
+]

--- a/Trainers/sft/src/training_callbacks.py
+++ b/Trainers/sft/src/training_callbacks.py
@@ -36,6 +36,10 @@ class MetricsTableCallback(BaseMetricsCallback):
     start_banner = "TRAINING STARTED"
     completion_banner = "TRAINING COMPLETED"
     log_every_write = False  # Write JSONL only at log_every_n_steps boundary.
+    # Pre-refactor SFT gated the entire on_log body on the interval multiple, so
+    # health_checker.check() and last_log_time update fired only at printed-row cadence.
+    health_check_every_on_log = False
+    interval_time_updates_every_on_log = False
 
     def __init__(
         self,

--- a/Trainers/sft/src/training_callbacks.py
+++ b/Trainers/sft/src/training_callbacks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Per-trainer SFT callback shims.
+"""Per-trainer SFT concrete callback subclasses and re-exports.
 
 Public symbols `MetricsTableCallback`, `CheckpointMonitorCallback`,
 `LiveDashboardCallback`, `TwoStageLRCallback`, `suppress_training_logs`,
@@ -9,13 +9,9 @@ paths. Shared lifecycle lives in `Trainers.shared.callbacks`.
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-# Add Toolset-Training/ to path so Trainers.shared.callbacks resolves.
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py.
 from Trainers.shared.callbacks import (
     BaseLiveDashboardCallback,
     BaseMetricsCallback,

--- a/Trainers/shared/callbacks/__init__.py
+++ b/Trainers/shared/callbacks/__init__.py
@@ -1,0 +1,46 @@
+"""Shared training callback package for sft/kto/grpo trainers.
+
+Per-trainer `Trainers/<trainer>/src/training_callbacks.py` modules subclass
+`BaseMetricsCallback` + `BaseLiveDashboardCallback` and inject strategies
+(HealthChecker, metric extraction, row format). Public symbols — the
+callback classes plus `DASHBOARD_AVAILABLE` / `RICH_AVAILABLE` — are
+re-exported from the per-trainer modules at unchanged paths.
+"""
+
+from __future__ import annotations
+
+from .base import (
+    BaseMetricsCallback,
+    BaseLiveDashboardCallback,
+    append_final_training_summary,
+    resolve_cloud_provider,
+    format_time,
+    DASHBOARD_AVAILABLE,
+    RICH_AVAILABLE,
+)
+from .health_checks import (
+    HealthChecker,
+    SFTHealthChecker,
+    KTOHealthChecker,
+    NoOpHealthChecker,
+)
+from .lr_schedules import TwoStageLRCallback
+from .checkpoints import CheckpointMonitorCallback
+from .log_suppression import suppress_training_logs
+
+__all__ = [
+    "BaseMetricsCallback",
+    "BaseLiveDashboardCallback",
+    "append_final_training_summary",
+    "resolve_cloud_provider",
+    "format_time",
+    "DASHBOARD_AVAILABLE",
+    "RICH_AVAILABLE",
+    "HealthChecker",
+    "SFTHealthChecker",
+    "KTOHealthChecker",
+    "NoOpHealthChecker",
+    "TwoStageLRCallback",
+    "CheckpointMonitorCallback",
+    "suppress_training_logs",
+]

--- a/Trainers/shared/callbacks/__init__.py
+++ b/Trainers/shared/callbacks/__init__.py
@@ -9,6 +9,16 @@ re-exported from the per-trainer modules at unchanged paths.
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+# Single point of sys.path bootstrap for the callback package. Submodules
+# (base.py, log_suppression.py) and per-trainer concrete subclass modules
+# (Trainers/<t>/src/training_callbacks.py) rely on the repo-root being on
+# sys.path to import `shared.*`. Consolidated here so each submodule doesn't
+# repeat the incantation.
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
 from .base import (
     BaseMetricsCallback,
     BaseLiveDashboardCallback,

--- a/Trainers/shared/callbacks/base.py
+++ b/Trainers/shared/callbacks/base.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -18,8 +17,9 @@ from typing import Any, Dict, List, Optional
 import torch
 from transformers import TrainerCallback, TrainerState, TrainerControl
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py
+# so `shared.*` imports below resolve whenever this module is loaded via
+# `from Trainers.shared.callbacks import ...`.
 from shared.training_capacity import (
     capture_runtime_capacity_snapshot,
     reset_capacity_peaks,
@@ -46,6 +46,7 @@ def resolve_cloud_provider(args: Any) -> Optional[str]:
 
 def _annotate_cloud(capacity_snapshot: Dict[str, Any], args: Any) -> None:
     """Add cloud_provider + cloud_gpu_type to the snapshot in-place."""
+    # Invoked from both BaseMetricsCallback.on_log and BaseLiveDashboardCallback.on_log.
     cloud_provider = resolve_cloud_provider(args)
     if cloud_provider:
         capacity_snapshot.setdefault("cloud_provider", cloud_provider)
@@ -300,7 +301,6 @@ class BaseMetricsCallback(TrainerCallback):
         )
         if not self.print_completion_banner:
             return
-        print("=" * 100)
         print("\n" + "=" * 100)
         print(self.completion_banner)
         print("=" * 100)
@@ -346,6 +346,7 @@ class BaseLiveDashboardCallback(TrainerCallback):
     default_title: str = "Training"
     training_type_attr: str = "sft"
     completion_banner: str = "TRAINING COMPLETED"
+    log_write_swallow_errors: bool = False  # GRPO overrides True; mirrors BaseMetricsCallback.
 
     def __init__(
         self,
@@ -365,7 +366,7 @@ class BaseLiveDashboardCallback(TrainerCallback):
         self.start_time: Optional[datetime] = None
         self.dashboard: Optional[Any] = None
         self.total_steps = 0
-        self.total_epochs = 1
+        self.total_epochs = 1  # Sentinel; overwritten by on_train_begin from args.num_train_epochs.
 
         if previous_log_entries:
             _prepopulate_log_file(self.log_file, previous_log_entries)
@@ -418,8 +419,12 @@ class BaseLiveDashboardCallback(TrainerCallback):
             **capacity_snapshot,
             **logs,
         }
-        with open(self.log_file, "a", encoding="utf-8") as f:
-            f.write(json.dumps(log_entry) + "\n")
+        try:
+            with open(self.log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(log_entry) + "\n")
+        except Exception:
+            if not self.log_write_swallow_errors:
+                raise
 
         if self.dashboard:
             epoch = float(logs.get("epoch", 0.0) or 0.0)

--- a/Trainers/shared/callbacks/base.py
+++ b/Trainers/shared/callbacks/base.py
@@ -127,6 +127,16 @@ class BaseMetricsCallback(TrainerCallback):
     print_checkpoint_on_save: bool = True
     print_completion_banner: bool = True
     interval_key_name: str = "interval_time"  # GRPO overrides to "interval_seconds"
+    # Pre-refactor SFT gated the ENTIRE on_log body on the interval multiple, so the
+    # health-check and last_log_time update fired only at printed-row cadence. KTO/GRPO
+    # fired them every on_log call. Default True matches KTO/GRPO; SFT overrides to False.
+    health_check_every_on_log: bool = True
+    interval_time_updates_every_on_log: bool = True
+    # Pre-refactor GRPO built the JSONL entry as `dict(logs); entry[k]=v; entry.update(cap)`,
+    # where our fields + capacity won over `logs` on key collisions. Pre-refactor SFT and
+    # KTO built `{**our_fields, **capacity, **logs}`, where `logs` won. Default False
+    # preserves SFT/KTO; GRPO overrides to True.
+    fields_win_on_collision: bool = False
 
     def __init__(
         self,
@@ -178,7 +188,12 @@ class BaseMetricsCallback(TrainerCallback):
 
         current_time = datetime.now()
         interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0.0
-        self.last_log_time = current_time
+        on_interval = state.global_step % self.log_every_n_steps == 0
+        # SFT (override False) only updates last_log_time at interval multiples, so
+        # the printed `Time/5s` column measures row-to-row gaps, not on_log-to-on_log.
+        # KTO/GRPO (default True) update every call — matches their pre-refactor behavior.
+        if self.interval_time_updates_every_on_log or on_interval:
+            self.last_log_time = current_time
         elapsed = (current_time - self.start_time).total_seconds() if self.start_time else 0.0
         steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
         samples_per_sec = (
@@ -187,7 +202,7 @@ class BaseMetricsCallback(TrainerCallback):
         capacity_snapshot = capture_runtime_capacity_snapshot(torch)
         _annotate_cloud(capacity_snapshot, args)
 
-        should_write_jsonl = self.log_every_write or (state.global_step % self.log_every_n_steps == 0)
+        should_write_jsonl = self.log_every_write or on_interval
         if should_write_jsonl:
             self._write_log_row(
                 logs=logs,
@@ -200,9 +215,12 @@ class BaseMetricsCallback(TrainerCallback):
                 current_time=current_time,
             )
 
-        self.health_checker.check(logs, state.global_step, args.max_grad_norm)
+        # SFT (override False) only runs health checks at interval multiples — matches
+        # pre-refactor top-of-on_log early return. KTO/GRPO (default True) every call.
+        if self.health_check_every_on_log or on_interval:
+            self.health_checker.check(logs, state.global_step, args.max_grad_norm)
 
-        if state.global_step % self.log_every_n_steps != 0:
+        if not on_interval:
             return
 
         if not self.header_printed or state.global_step % (self.log_every_n_steps * 20) == 0:
@@ -234,16 +252,22 @@ class BaseMetricsCallback(TrainerCallback):
         capacity_snapshot: Dict[str, Any],
         current_time: datetime,
     ):
-        entry = {
+        our_fields = {
             "step": int(step),
             "timestamp": current_time.isoformat(),
             self.interval_key_name: interval_time,
             "elapsed_seconds": round(elapsed, 3),
             "steps_per_second": round(steps_per_sec, 3),
             "samples_per_sec": round(samples_per_sec, 3),
-            **capacity_snapshot,
-            **logs,
         }
+        # GRPO (override True): logs is the base, our fields + capacity override — matches
+        # pre-refactor `entry = dict(logs); entry[k]=v; entry.update(cap)`.
+        # SFT/KTO (default False): our fields first, logs wins on collision — matches
+        # pre-refactor `{..our_fields, **capacity, **logs}`.
+        if self.fields_win_on_collision:
+            entry = {**logs, **our_fields, **capacity_snapshot}
+        else:
+            entry = {**our_fields, **capacity_snapshot, **logs}
         try:
             with open(self.log_file, "a", encoding="utf-8") as f:
                 f.write(json.dumps(entry) + "\n")

--- a/Trainers/shared/callbacks/base.py
+++ b/Trainers/shared/callbacks/base.py
@@ -1,0 +1,452 @@
+"""Shared base callbacks for sft/kto/grpo trainers.
+
+`BaseMetricsCallback` owns the table-output + JSONL-logging lifecycle.
+`BaseLiveDashboardCallback` wraps `shared.ui.LiveDashboard` lifecycle.
+Per-trainer subclasses inject strategies (HealthChecker, metric extraction,
+row formatting) without overriding `on_train_begin` / `on_train_end`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import torch
+from transformers import TrainerCallback, TrainerState, TrainerControl
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from shared.training_capacity import (
+    capture_runtime_capacity_snapshot,
+    reset_capacity_peaks,
+)
+
+try:
+    from shared.ui import LiveDashboard, RICH_AVAILABLE
+    DASHBOARD_AVAILABLE = True
+except ImportError:
+    LiveDashboard = None  # type: ignore[assignment]
+    DASHBOARD_AVAILABLE = False
+    RICH_AVAILABLE = False
+
+from .health_checks import HealthChecker, NoOpHealthChecker
+
+
+def resolve_cloud_provider(args: Any) -> Optional[str]:
+    """Resolve cloud provider metadata: env first, then args attribute."""
+    cloud_provider = os.environ.get("CLOUD_PROVIDER", "").strip()
+    if cloud_provider:
+        return cloud_provider
+    return getattr(args, "cloud_provider", None)
+
+
+def _annotate_cloud(capacity_snapshot: Dict[str, Any], args: Any) -> None:
+    """Add cloud_provider + cloud_gpu_type to the snapshot in-place."""
+    cloud_provider = resolve_cloud_provider(args)
+    if cloud_provider:
+        capacity_snapshot.setdefault("cloud_provider", cloud_provider)
+    cloud_gpu_type = os.environ.get("CLOUD_GPU_TYPE", "").strip()
+    if cloud_gpu_type:
+        capacity_snapshot.setdefault("cloud_gpu_type", cloud_gpu_type)
+
+
+def append_final_training_summary(
+    log_file: Path,
+    *,
+    step: int,
+    total_steps: int,
+    total_epochs: int,
+    elapsed: float,
+) -> None:
+    """Persist a final summary row so bucketed logs retain runtime + peak capacity."""
+    capacity_snapshot = capture_runtime_capacity_snapshot(torch)
+    entry = {
+        "event": "train_end",
+        "step": int(step),
+        "timestamp": datetime.now().isoformat(),
+        "total_steps": int(total_steps),
+        "total_epochs": int(total_epochs),
+        "train_runtime": round(elapsed, 3),
+        "train_steps_per_second": round((step / elapsed), 3) if elapsed > 0 else 0.0,
+        "train_samples_per_second": None,
+        **capacity_snapshot,
+    }
+    with open(log_file, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def format_time(seconds: float) -> str:
+    """Human-readable duration used by SFT/KTO table footers."""
+    if seconds < 60:
+        return f"{int(seconds)}s"
+    if seconds < 3600:
+        return f"{int(seconds // 60)}m {int(seconds % 60)}s"
+    hours = int(seconds // 3600)
+    minutes = int((seconds % 3600) // 60)
+    return f"{hours}h {minutes}m"
+
+
+def _setup_latest_symlink(latest_log: Path, log_file_name: str) -> None:
+    """Recreate the training_latest.jsonl symlink; swallow WSL/fs errors."""
+    if latest_log.exists():
+        try:
+            latest_log.unlink()
+        except Exception:
+            pass
+    try:
+        latest_log.symlink_to(log_file_name)
+    except (OSError, NotImplementedError):
+        pass
+
+
+def _prepopulate_log_file(log_file: Path, previous_entries: List[Dict[str, Any]]) -> None:
+    with open(log_file, "w") as f:
+        for entry in previous_entries:
+            f.write(json.dumps(entry) + "\n")
+
+
+class BaseMetricsCallback(TrainerCallback):
+    """Table-output + JSONL-logging lifecycle. Subclasses inject row format & health strategy.
+
+    Subclass contract:
+      - set `default_output_dir`, `training_type_label`, optionally
+        `log_every_write`, `log_write_swallow_errors`.
+      - set `self.health_checker` in `__init__` (default: NoOpHealthChecker).
+      - override `_print_header()` and `_print_row(...)`.
+    """
+
+    default_output_dir: str = "./output"
+    start_banner: str = "TRAINING STARTED"
+    completion_banner: str = "TRAINING COMPLETED"
+    log_every_write: bool = False
+    log_write_swallow_errors: bool = False
+    print_checkpoint_on_save: bool = True
+    print_completion_banner: bool = True
+    interval_key_name: str = "interval_time"  # GRPO overrides to "interval_seconds"
+
+    def __init__(
+        self,
+        log_every_n_steps: int = 5,
+        output_dir: Optional[str] = None,
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self.log_every_n_steps = max(1, int(log_every_n_steps))
+        self.output_dir = Path(output_dir if output_dir is not None else self.default_output_dir)
+        self.logs_dir = self.output_dir / "logs"
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
+        self.latest_log = self.logs_dir / "training_latest.jsonl"
+
+        self.start_time: Optional[datetime] = None
+        self.last_log_time: Optional[datetime] = None
+        self.header_printed = False
+        self.health_checker: HealthChecker = NoOpHealthChecker()
+
+        if previous_log_entries:
+            self._prepopulate_log(previous_log_entries)
+
+    def _prepopulate_log(self, previous_entries: List[Dict[str, Any]]):
+        print(f"\n✓ Prepopulating log with {len(previous_entries)} entries from previous run")
+        _prepopulate_log_file(self.log_file, previous_entries)
+        print(f"  Log file: {self.log_file}")
+        print(f"  Steps included: 0-{previous_entries[-1]['step'] if previous_entries else 0}\n")
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        self.start_time = datetime.now()
+        self.last_log_time = self.start_time
+        self.header_printed = False
+        reset_capacity_peaks(torch)
+        _setup_latest_symlink(self.latest_log, self.log_file.name)
+
+        print("\n" + "=" * 100)
+        print(self.start_banner)
+        print("=" * 100)
+        print(f"Detailed metrics logging to: {self.log_file}")
+        print(f"View in real-time: tail -f {self.log_file}")
+        print(f"Or use latest: tail -f {self.latest_log}")
+        print("=" * 100)
+
+    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
+        if not logs:
+            return
+
+        current_time = datetime.now()
+        interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0.0
+        self.last_log_time = current_time
+        elapsed = (current_time - self.start_time).total_seconds() if self.start_time else 0.0
+        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
+        samples_per_sec = (
+            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
+        ) / elapsed if elapsed > 0 else 0.0
+        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
+        _annotate_cloud(capacity_snapshot, args)
+
+        should_write_jsonl = self.log_every_write or (state.global_step % self.log_every_n_steps == 0)
+        if should_write_jsonl:
+            self._write_log_row(
+                logs=logs,
+                step=state.global_step,
+                interval_time=interval_time,
+                elapsed=elapsed,
+                steps_per_sec=steps_per_sec,
+                samples_per_sec=samples_per_sec,
+                capacity_snapshot=capacity_snapshot,
+                current_time=current_time,
+            )
+
+        self.health_checker.check(logs, state.global_step, args.max_grad_norm)
+
+        if state.global_step % self.log_every_n_steps != 0:
+            return
+
+        if not self.header_printed or state.global_step % (self.log_every_n_steps * 20) == 0:
+            self._print_header()
+            self.header_printed = True
+
+        eta, progress = self._compute_eta_progress(state, steps_per_sec)
+        self._print_row(
+            step=state.global_step,
+            state=state,
+            args=args,
+            logs=logs,
+            capacity_snapshot=capacity_snapshot,
+            interval_time=interval_time,
+            samples_per_sec=samples_per_sec,
+            eta=eta,
+            progress=progress,
+        )
+
+    def _write_log_row(
+        self,
+        *,
+        logs: Dict[str, Any],
+        step: int,
+        interval_time: float,
+        elapsed: float,
+        steps_per_sec: float,
+        samples_per_sec: float,
+        capacity_snapshot: Dict[str, Any],
+        current_time: datetime,
+    ):
+        entry = {
+            "step": int(step),
+            "timestamp": current_time.isoformat(),
+            self.interval_key_name: interval_time,
+            "elapsed_seconds": round(elapsed, 3),
+            "steps_per_second": round(steps_per_sec, 3),
+            "samples_per_sec": round(samples_per_sec, 3),
+            **capacity_snapshot,
+            **logs,
+        }
+        try:
+            with open(self.log_file, "a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception:
+            if not self.log_write_swallow_errors:
+                raise
+
+    def _compute_eta_progress(self, state, steps_per_sec):
+        if state.max_steps > 0:
+            remaining_steps = state.max_steps - state.global_step
+            eta_seconds = remaining_steps / steps_per_sec if steps_per_sec > 0 else 0
+            return format_time(eta_seconds), f"{state.global_step}/{state.max_steps}"
+        return "N/A", f"{state.global_step}"
+
+    def on_save(self, args, state, control, **kwargs):
+        if not self.print_checkpoint_on_save:
+            return
+        print("-" * 100)
+        print(f">> CHECKPOINT SAVED at step {state.global_step:,} -> {args.output_dir}/checkpoint-{state.global_step}")
+        print("-" * 100)
+
+    def on_train_end(self, args, state, control, **kwargs):
+        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
+        append_final_training_summary(
+            self.log_file,
+            step=state.global_step,
+            total_steps=state.max_steps if state.max_steps > 0 else state.global_step,
+            total_epochs=int(state.epoch or 0),
+            elapsed=elapsed,
+        )
+        if not self.print_completion_banner:
+            return
+        print("=" * 100)
+        print("\n" + "=" * 100)
+        print(self.completion_banner)
+        print("=" * 100)
+        print(f"Total time: {format_time(elapsed)}")
+        print(f"Total steps: {state.global_step:,}")
+        if elapsed > 0:
+            print(f"Average speed: {state.global_step / elapsed:.2f} steps/sec")
+        print("=" * 100 + "\n")
+
+    # Subclass hooks ---------------------------------------------------
+
+    def _print_header(self):  # pragma: no cover - abstract-ish
+        raise NotImplementedError
+
+    def _print_row(
+        self,
+        *,
+        step: int,
+        state: TrainerState,
+        args: Any,
+        logs: Dict[str, Any],
+        capacity_snapshot: Dict[str, Any],
+        interval_time: float,
+        samples_per_sec: float,
+        eta: str,
+        progress: str,
+    ):  # pragma: no cover - abstract-ish
+        raise NotImplementedError
+
+
+class BaseLiveDashboardCallback(TrainerCallback):
+    """Wraps `shared.ui.LiveDashboard`; subclasses inject per-trainer metric extraction.
+
+    Subclass contract:
+      - set `default_output_dir`, `default_title`, `training_type_attr`,
+        `completion_banner`.
+      - override `_dashboard_metrics(logs, capacity_snapshot)` to return kwargs
+        for `dashboard.update(...)`.
+      - override `_fallback_row(...)` to print when the dashboard is unavailable.
+    """
+
+    default_output_dir: str = "./output"
+    default_title: str = "Training"
+    training_type_attr: str = "sft"
+    completion_banner: str = "TRAINING COMPLETED"
+
+    def __init__(
+        self,
+        log_every_n_steps: int = 5,
+        output_dir: Optional[str] = None,
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
+    ):
+        self.log_every_n_steps = log_every_n_steps
+        self.output_dir = Path(output_dir if output_dir is not None else self.default_output_dir)
+        self.logs_dir = self.output_dir / "logs"
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.log_file = self.logs_dir / f"training_{timestamp}.jsonl"
+        self.latest_log = self.logs_dir / "training_latest.jsonl"
+
+        self.start_time: Optional[datetime] = None
+        self.dashboard: Optional[Any] = None
+        self.total_steps = 0
+        self.total_epochs = 1
+
+        if previous_log_entries:
+            _prepopulate_log_file(self.log_file, previous_log_entries)
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        self.start_time = datetime.now()
+        self.total_steps = state.max_steps if state.max_steps > 0 else 1000
+        self.total_epochs = args.num_train_epochs
+        reset_capacity_peaks(torch)
+        _setup_latest_symlink(self.latest_log, self.log_file.name)
+
+        if DASHBOARD_AVAILABLE and RICH_AVAILABLE:
+            self.dashboard = LiveDashboard(
+                title=self.default_title,
+                total_epochs=int(self.total_epochs),
+                total_steps=self.total_steps,
+                training_type=self.training_type_attr,
+                show_sparklines=True,
+                log_lines=3,
+            )
+            self.dashboard.__enter__()
+        else:
+            print(f"\n{'=' * 60}")
+            print(f"{self.training_type_attr.upper()} TRAINING STARTED")
+            print(f"{'=' * 60}")
+            print(f"Log file: {self.log_file}")
+
+    def on_log(self, args, state: TrainerState, control: TrainerControl, logs: Dict[str, Any] = None, **kwargs):
+        if logs is None:
+            return
+        if state.global_step % self.log_every_n_steps != 0:
+            return
+
+        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
+        steps_per_sec = state.global_step / elapsed if elapsed > 0 else 0.0
+        samples_per_sec = (
+            state.global_step * args.per_device_train_batch_size * args.gradient_accumulation_steps
+        ) / elapsed if elapsed > 0 else 0.0
+        capacity_snapshot = capture_runtime_capacity_snapshot(torch)
+        _annotate_cloud(capacity_snapshot, args)
+
+        log_entry = {
+            "step": state.global_step,
+            "timestamp": datetime.now().isoformat(),
+            "total_steps": self.total_steps,
+            "total_epochs": int(self.total_epochs),
+            "elapsed_seconds": round(elapsed, 3),
+            "steps_per_second": round(steps_per_sec, 3),
+            "samples_per_sec": round(samples_per_sec, 3),
+            **capacity_snapshot,
+            **logs,
+        }
+        with open(self.log_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(log_entry) + "\n")
+
+        if self.dashboard:
+            epoch = float(logs.get("epoch", 0.0) or 0.0)
+            metrics = self._dashboard_metrics(logs, capacity_snapshot)
+            self.dashboard.update(
+                step=state.global_step,
+                epoch=epoch,
+                loss=logs.get("loss"),
+                learning_rate=logs.get("learning_rate"),
+                gpu_memory_gb=capacity_snapshot.get("gpu_memory_gb"),
+                **metrics,
+            )
+        else:
+            self._fallback_row(state=state, logs=logs, capacity_snapshot=capacity_snapshot)
+
+    def on_save(self, args, state, control, **kwargs):
+        if self.dashboard:
+            self.dashboard.update(log_message=f"Checkpoint saved at step {state.global_step}")
+        else:
+            print(f"  >> Checkpoint saved at step {state.global_step}")
+
+    def on_train_end(self, args, state, control, **kwargs):
+        if self.dashboard:
+            self.dashboard.__exit__(None, None, None)
+            self.dashboard = None
+
+        elapsed = (datetime.now() - self.start_time).total_seconds() if self.start_time else 0.0
+        append_final_training_summary(
+            self.log_file,
+            step=state.global_step,
+            total_steps=self.total_steps,
+            total_epochs=int(self.total_epochs),
+            elapsed=elapsed,
+        )
+        print(f"\n{'=' * 60}")
+        print(self.completion_banner)
+        print(f"{'=' * 60}")
+        print(f"Total time: {elapsed // 3600:.0f}h {(elapsed % 3600) // 60:.0f}m {elapsed % 60:.0f}s")
+        print(f"Total steps: {state.global_step:,}")
+        print(f"Log file: {self.log_file}")
+
+    # Subclass hooks ---------------------------------------------------
+
+    def _dashboard_metrics(self, logs: Dict[str, Any], capacity_snapshot: Dict[str, Any]) -> Dict[str, Any]:
+        """Return extra kwargs for `dashboard.update(...)` (step/epoch/loss/lr/gpu are always passed)."""
+        return {}
+
+    def _fallback_row(self, *, state: TrainerState, logs: Dict[str, Any], capacity_snapshot: Dict[str, Any]):
+        """Print a single-line fallback when the rich dashboard is unavailable."""
+        loss = logs.get("loss", 0)
+        lr = logs.get("learning_rate", 0)
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | LR: {lr:.2e} | GPU: {gpu_mem}")

--- a/Trainers/shared/callbacks/checkpoints.py
+++ b/Trainers/shared/callbacks/checkpoints.py
@@ -1,0 +1,19 @@
+"""Checkpoint configuration banner, hoisted from sft + kto (byte-identical)."""
+
+from __future__ import annotations
+
+from transformers import TrainerCallback
+
+
+class CheckpointMonitorCallback(TrainerCallback):
+    """Display checkpoint configuration at start; kept for extensibility."""
+
+    def on_save(self, args, state, control, **kwargs):
+        pass
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        print(f"\nCheckpoint Configuration:")
+        print(f"  Save every: {args.save_steps} steps")
+        print(f"  Keep last: {args.save_total_limit} checkpoints")
+        print(f"  Output dir: {args.output_dir}")
+        print()

--- a/Trainers/shared/callbacks/checkpoints.py
+++ b/Trainers/shared/callbacks/checkpoints.py
@@ -6,10 +6,7 @@ from transformers import TrainerCallback
 
 
 class CheckpointMonitorCallback(TrainerCallback):
-    """Display checkpoint configuration at start; kept for extensibility."""
-
-    def on_save(self, args, state, control, **kwargs):
-        pass
+    """Display checkpoint configuration at start."""
 
     def on_train_begin(self, args, state, control, **kwargs):
         print(f"\nCheckpoint Configuration:")

--- a/Trainers/shared/callbacks/health_checks.py
+++ b/Trainers/shared/callbacks/health_checks.py
@@ -85,4 +85,4 @@ class NoOpHealthChecker(HealthChecker):
     """GRPO: no health checks today."""
 
     def check(self, logs, step, max_grad_norm):
-        return
+        pass

--- a/Trainers/shared/callbacks/health_checks.py
+++ b/Trainers/shared/callbacks/health_checks.py
@@ -1,0 +1,88 @@
+"""Per-trainer health-check strategies.
+
+Each concrete class prints identical-format warning blocks (100-char bracket
+lines + "Consider:" footer) matching the exact output each trainer produces
+today. Preserving this format is a non-goal for elegance but a hard
+requirement for zero-behavior-change.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+
+
+def _grad_norm_warning(logs: Dict[str, Any], max_grad_norm: Optional[float]) -> Optional[str]:
+    """Shared grad-norm warning formatter used by SFT + KTO checkers."""
+    grad_norm = logs.get("grad_norm", 0.0)
+    if grad_norm <= 100.0:
+        return None
+    if max_grad_norm is not None:
+        clipped_norm = min(grad_norm, max_grad_norm)
+        return f"⚠ High gradient norm: {grad_norm:.2f} → {clipped_norm:.2f} (clipped)"
+    return f"⚠ High gradient norm: {grad_norm:.2f} (may cause instability)"
+
+
+def _print_warnings(warnings, max_grad_norm, grad_norm):
+    """Shared footer logic — prints bracketed block with 'Consider:' hint."""
+    if not warnings:
+        return
+    print("\n" + "!" * 100)
+    for w in warnings:
+        print(f"  {w}")
+    if max_grad_norm is None or grad_norm > max_grad_norm * 10:
+        print("  Consider: reducing learning rate or using tighter gradient clipping")
+    print("!" * 100 + "\n")
+
+
+class HealthChecker(ABC):
+    @abstractmethod
+    def check(self, logs: Dict[str, Any], step: int, max_grad_norm: Optional[float]) -> None: ...
+
+
+class SFTHealthChecker(HealthChecker):
+    """SFT: loss-range, grad-norm-clip, loss-still-high-after-50-steps."""
+
+    def check(self, logs, step, max_grad_norm):
+        warnings = []
+        loss = logs.get("loss", 0.0)
+        if not (0 < loss < 100):
+            warnings.append(f"⚠ Unusual loss value: {loss:.4f}")
+        grad_warning = _grad_norm_warning(logs, max_grad_norm)
+        if grad_warning:
+            warnings.append(grad_warning)
+        if step > 50 and loss > 2.0:
+            warnings.append(
+                f"⚠ Loss remains high after {step} steps: {loss:.4f} (may need longer training or LR adjustment)"
+            )
+        _print_warnings(warnings, max_grad_norm, logs.get("grad_norm", 0.0))
+
+
+class KTOHealthChecker(HealthChecker):
+    """KTO: loss-range, margin < -1.0, reward-collapse, grad-norm-clip."""
+
+    def check(self, logs, step, max_grad_norm):
+        warnings = []
+        loss = logs.get("loss", 0.0)
+        if not (0 < loss < 100):
+            warnings.append(f"⚠ Unusual loss value: {loss:.4f}")
+        margin = logs.get("rewards/margins", 0.0)
+        if margin < -1.0:
+            warnings.append(
+                f"⚠ Very negative margin: {margin:.4f} (chosen model may be worse than reference)"
+            )
+        chosen = logs.get("rewards/chosen", 0.0)
+        rejected = logs.get("rewards/rejected", 0.0)
+        if abs(chosen) < 0.001 and abs(rejected) < 0.001 and step > 10:
+            warnings.append("⚠ Reward collapse detected (both rewards near zero)")
+        grad_warning = _grad_norm_warning(logs, max_grad_norm)
+        if grad_warning:
+            warnings.append(grad_warning)
+        _print_warnings(warnings, max_grad_norm, logs.get("grad_norm", 0.0))
+
+
+class NoOpHealthChecker(HealthChecker):
+    """GRPO: no health checks today."""
+
+    def check(self, logs, step, max_grad_norm):
+        return

--- a/Trainers/shared/callbacks/log_suppression.py
+++ b/Trainers/shared/callbacks/log_suppression.py
@@ -1,0 +1,36 @@
+"""Noisy-logger suppression helper shared by trainers (currently used by SFT)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+try:
+    from shared.ui import suppress_logs
+    _SUPPRESS_AVAILABLE = True
+except ImportError:
+    _SUPPRESS_AVAILABLE = False
+
+
+_NOISY_LOGGERS = [
+    "unsloth",
+    "transformers",
+    "datasets",
+    "accelerate",
+    "trl",
+    "peft",
+    "bitsandbytes",
+    "torch",
+    "huggingface_hub",
+]
+
+
+def suppress_training_logs():
+    """Context manager that quiets common noisy training loggers; no-op if unavailable."""
+    if _SUPPRESS_AVAILABLE:
+        return suppress_logs(_NOISY_LOGGERS, level=logging.WARNING)
+    return nullcontext()

--- a/Trainers/shared/callbacks/log_suppression.py
+++ b/Trainers/shared/callbacks/log_suppression.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import logging
-import sys
 from contextlib import nullcontext
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
-
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py.
 try:
     from shared.ui import suppress_logs
     _SUPPRESS_AVAILABLE = True

--- a/Trainers/shared/callbacks/lr_schedules.py
+++ b/Trainers/shared/callbacks/lr_schedules.py
@@ -1,0 +1,42 @@
+"""Two-stage LR reduction callback, hoisted from sft + kto (byte-identical)."""
+
+from __future__ import annotations
+
+from transformers import TrainerCallback
+
+
+class TwoStageLRCallback(TrainerCallback):
+    """Reduce LR at a specified step to prevent optimization instability.
+
+    Example:
+        Steps 1-50:  LR = 5e-7 (fast early learning)
+        Steps 51+:   LR = 2.5e-7 (reduced to prevent overshoot/instability)
+    """
+
+    def __init__(self, initial_lr: float, reduced_lr: float, reduction_step: int):
+        self.initial_lr = initial_lr
+        self.reduced_lr = reduced_lr
+        self.reduction_step = reduction_step
+        self.lr_reduced = False
+
+    def on_train_begin(self, args, state, control, **kwargs):
+        print("\n" + "=" * 100)
+        print("TWO-STAGE LEARNING RATE SCHEDULE")
+        print("=" * 100)
+        print(f"  Steps 1-{self.reduction_step}:  LR = {self.initial_lr:.2e} (fast early learning)")
+        print(f"  Steps {self.reduction_step + 1}+:     LR = {self.reduced_lr:.2e} ({(self.reduced_lr / self.initial_lr) * 100:.0f}% of initial, prevents instability)")
+        print(f"  Reduction ratio: {self.reduced_lr / self.initial_lr:.1%}")
+        print("=" * 100 + "\n")
+
+    def on_step_begin(self, args, state, control, **kwargs):
+        if state.global_step == self.reduction_step and not self.lr_reduced:
+            optimizer = kwargs.get("optimizer")
+            if optimizer is not None:
+                for param_group in optimizer.param_groups:
+                    param_group["lr"] = self.reduced_lr
+                self.lr_reduced = True
+                print("\n" + "!" * 100)
+                print(f"🔧 LEARNING RATE REDUCED at step {state.global_step}")
+                print(f"   {self.initial_lr:.2e} → {self.reduced_lr:.2e} (50% reduction)")
+                print(f"   Reason: Preemptive intervention before step 60 instability zone")
+                print("!" * 100 + "\n")

--- a/docs/architecture/training-callbacks-refactor.md
+++ b/docs/architecture/training-callbacks-refactor.md
@@ -150,6 +150,58 @@ converge on it.
   have the attribute — `getattr(..., None)` default makes this safe).
   Strictly an improvement in metadata completeness, no control-flow change.
 
+### 6a. JSONL dict-merge precedence — preserved per-trainer (correction note)
+
+> **Correction to the coder's original HANDOFF.** An earlier handoff
+> note said the refactor would "unify on SFT/KTO style
+> `{...our_fields, **logs}` (logs wins)" for all three trainers. That
+> was based on a misread of GRPO's pre-refactor code. Pre-refactor
+> GRPO's `on_log` built the JSONL row as
+> `entry = dict(logs); entry[k] = v; entry.update(capacity)` — i.e.,
+> logs is the base dict and **our fields + capacity override logs on
+> key collisions** (fields-win). Pre-refactor SFT and KTO built the
+> dict as `{**our_fields, **capacity, **logs}` — logs-win. Flipping
+> base to a single unified precedence would have regressed whichever
+> two trainers were on the other side.
+>
+> **Resolution**: per-trainer class attr
+> `BaseMetricsCallback.fields_win_on_collision: bool = False` (default
+> matches SFT/KTO majority). GRPO's `MetricsTableCallback` overrides
+> to `True`. `_write_log_row` branches on the attr and emits the
+> corresponding spread order. All three trainers now preserve their
+> pre-refactor JSONL row content byte-exact.
+>
+> Practical blast radius of either direction is small — HF Trainer's
+> standard emitted log keys (`loss`, `learning_rate`, `epoch`,
+> `grad_norm`) don't collide with our field names (`step`,
+> `timestamp`, `interval_time` / `interval_seconds`,
+> `elapsed_seconds`, `steps_per_second`, `samples_per_sec`,
+> `gpu_memory_gb`). But custom trainers or future TRL key additions
+> could collide, so preservation matters.
+
+### 6b. SFT cadence — interval gate restored via class attrs (correction note)
+
+> **Correction to the coder's original implementation.** The first cut
+> of `BaseMetricsCallback.on_log` unconditionally updated
+> `self.last_log_time` and called
+> `self.health_checker.check(...)` on every `on_log` invocation. This
+> matches KTO and GRPO's pre-refactor behavior but regresses SFT,
+> which gated the entire `on_log` body on
+> `state.global_step % log_every_n_steps != 0` (early return at the
+> top of the function). As a result, in the first cut: SFT's
+> printed-row `Time/5s` column silently redefined from "time between
+> printed rows" to "time between on_log calls", and SFT health-check
+> warnings fired more often than before.
+>
+> **Resolution**: two per-trainer class attrs
+> `BaseMetricsCallback.health_check_every_on_log: bool = True` and
+> `BaseMetricsCallback.interval_time_updates_every_on_log: bool = True`
+> (defaults match KTO/GRPO). SFT's `MetricsTableCallback` overrides
+> both to `False`. `on_log` gates the two lines on
+> `(attr or on_interval)` so SFT only fires them at interval
+> multiples — matching its pre-refactor early-return behavior —
+> while KTO/GRPO retain every-call behavior.
+
 ## 7. No-Public-API-Change Confirmation
 
 Callers import from the **per-trainer module**, not from a shared package:

--- a/docs/architecture/training-callbacks-refactor.md
+++ b/docs/architecture/training-callbacks-refactor.md
@@ -1,0 +1,246 @@
+# Training Callbacks DRY Refactor — Architecture
+
+Pure code-organization refactor of the three per-trainer `training_callbacks.py`
+modules (sft, kto, grpo) into a shared base + per-trainer strategies.
+
+- **Non-negotiable**: zero behavior change. No public API change on the four
+  callback classes or the `DASHBOARD_AVAILABLE` / `RICH_AVAILABLE` /
+  `suppress_training_logs` symbols. Existing call sites in
+  `Trainers/{sft,kto,grpo}/train_*.py` import unchanged.
+- **Scope**: `Trainers/{sft,kto,grpo}/src/training_callbacks.py` + new
+  `Trainers/shared/callbacks/` package.
+- **Out of scope**: `shared/ui/dashboard.py`, `Trainers/shared/ui/training_progress.py`.
+
+## 1. Target Package Layout
+
+| Module | Responsibility / Exports |
+|---|---|
+| `Trainers/shared/callbacks/__init__.py` | Public re-exports + `DASHBOARD_AVAILABLE` / `RICH_AVAILABLE` |
+| `base.py` | Lifecycle skeleton (shared timing/capacity/cloud-provider capture, JSONL writing, symlink mgmt, final-summary footer). Exports `BaseMetricsCallback`, `BaseLiveDashboardCallback`, `append_final_training_summary`, `resolve_cloud_provider`, `build_log_entry` |
+| `health_checks.py` | `HealthChecker` ABC + `SFTHealthChecker` / `KTOHealthChecker` / `NoOpHealthChecker` |
+| `lr_schedules.py` | `TwoStageLRCallback` (hoisted, byte-identical across sft + kto) |
+| `checkpoints.py` | `CheckpointMonitorCallback` (hoisted, byte-identical) |
+| `log_suppression.py` | `suppress_training_logs` (currently sft-only) |
+
+Each `Trainers/<trainer>/src/training_callbacks.py` shrinks to:
+- 2 thin concrete subclasses (`MetricsTableCallback`, `LiveDashboardCallback`) binding per-trainer strategies.
+- Re-exports of hoisted classes/symbols under existing names (see §7).
+
+## 2. `BaseMetricsCallback` Contract
+
+Shared `TrainerCallback` subclass owning the table-output and JSONL-logging
+lifecycle. Per-trainer classes subclass it and inject strategies — they do
+**not** override `on_train_begin` / `on_train_end`.
+
+**Class attributes (overridable)**: `default_output_dir: str` (e.g. `"./sft_output"`),
+`log_every_write: bool` (kto/grpo: True; sft: False), `training_type_label: str`
+(header/banner name), `log_write_swallow_errors: bool` (grpo: True; others: False).
+
+**Constructor**: `(log_every_n_steps=5, output_dir=None, previous_log_entries=None)`.
+`previous_log_entries` is accepted by all trainers; GRPO currently omits it, base
+adds uniformly (default `None` no-ops — no behavior change).
+
+**Lifecycle (base-owned, subclasses must not override)**:
+
+- `on_train_begin`: set `start_time` / `last_log_time`; `reset_capacity_peaks(torch)`;
+  recreate `training_latest.jsonl` symlink (swallow OSError/NotImplementedError);
+  print start banner using `training_type_label`.
+- `on_log`: compute elapsed / steps-per-sec / samples-per-sec / interval_time;
+  build capacity_snapshot via `capture_runtime_capacity_snapshot(torch)`; annotate
+  with `resolve_cloud_provider(args)` + `CLOUD_GPU_TYPE` env. Then delegate:
+  (1) `_write_log_row(entry)` gated by `log_every_write` vs. interval;
+  (2) `self.health_checker.check(logs, step, args.max_grad_norm)`;
+  (3) every Nth step: `_print_row(...)` (subclass hook).
+- `on_save`: print checkpoint line (identical across trainers).
+- `on_train_end`: `append_final_training_summary(...)`; print completion banner.
+
+**Subclass hooks**: `_print_header(self)`, `_print_row(self, *, step, state, logs,
+capacity_snapshot, interval_time, samples_per_sec, eta)`, `health_checker: HealthChecker`
+(set by subclass `__init__`).
+
+## 3. `BaseLiveDashboardCallback` Contract
+
+Wraps `shared.ui.LiveDashboard` (when available) with the same lifecycle shape.
+Subclass provides `training_type` and a `_dashboard_metrics(logs, capacity_snapshot)`
+method returning the kwargs passed to `self.dashboard.update(...)`.
+
+| Hook | SFT | KTO | GRPO |
+|---|---|---|---|
+| `training_type` | `self.training_type` (ctor param, defaults `"sft"`) | `"kto"` | `"grpo"` |
+| `_dashboard_metrics` | `loss`, `learning_rate`, `kl`, `margin` (rewards/margins), `gpu_memory_gb` | same + `kl` falls back to `logps/rejected` | `reward`/`reward_std`/`kl_penalty`/`advantage` (with multi-key fallbacks) |
+| `_fallback_row` | prints step/loss/lr/gpu | step/loss/margin/gpu | step/loss/reward |
+
+SFT keeps its `training_type` constructor arg (currently `"sft"`/`"kto"`); base exposes
+it via subclass default, preserving the signature.
+
+## 4. `HealthChecker` Strategy
+
+```python
+class HealthChecker(ABC):
+    @abstractmethod
+    def check(self, logs: dict, step: int, max_grad_norm: float | None) -> None: ...
+```
+
+Concrete classes print identical-format warning blocks (`"!" * 100` bracket lines +
+`"Consider: ..."` footer), preserving exact output today:
+
+- `SFTHealthChecker`: loss-range, grad-norm-clip, loss-high-after-50-steps.
+- `KTOHealthChecker`: loss-range, KTO margin < −1.0, reward-collapse (both ≈0 after
+  step 10), grad-norm-clip.
+- `NoOpHealthChecker`: GRPO — no checks today.
+
+Grad-norm-clip logic lives in a shared `_grad_norm_warning(logs, max_grad_norm)`
+helper in `health_checks.py` used by both SFT and KTO checkers.
+
+## 5. Divergence Matrix — Stays Per-Trainer vs. Moves to Base
+
+**Moves to base** (identical today across ≥2 trainers): start banner + JSONL
+symlink-to-latest (swallow OSError/NotImplementedError); elapsed/steps-per-sec/
+samples-per-sec calc; `capture_runtime_capacity_snapshot` + cloud-provider +
+cloud-gpu-type annotation; `append_final_training_summary` helper (byte-identical
+in all three); `_format_time` helper (identical sft + kto); completion banner
+shape; `on_save` checkpoint-line print; `TwoStageLRCallback` + `CheckpointMonitorCallback`
+(both byte-identical sft + kto; grpo doesn't use them — unchanged).
+
+**Stays per-trainer** (concrete subclass / strategy / class attr):
+
+- Table header + row format (SFT: loss/LR/gradnorm/epoch/gpu/samples/eta;
+  KTO: loss/LR/chosen/reject/margin/gpu/samples/eta; GRPO: compact loss/reward/LR/gpu).
+- Dashboard metric extraction (`rewards/margins` vs. `reward`/`kl_penalty`/`advantage`
+  multi-key lookups).
+- Health-check rules (via strategy, §4).
+- `default_output_dir` and completion banner label (per-trainer class attrs).
+- **JSONL write cadence**: KTO + GRPO write every `on_log` (`log_every_write=True`);
+  SFT writes only at `log_every_n_steps` boundary (`log_every_write=False`).
+  Preserved via class attr — single knob, grep-visible.
+
+## 6. Cloud-Provider Resolution — Unify on SFT's Helper
+
+**Current divergence**:
+
+| Trainer | Source |
+|---|---|
+| sft | `_resolve_cloud_provider(args)` — env `CLOUD_PROVIDER` then `getattr(args, "cloud_provider", None)` |
+| kto | `args.cloud_provider` directly |
+| grpo | `os.environ.get("CLOUD_PROVIDER")` only (no args fallback) |
+
+**Decision**: base uses sft's helper (`resolve_cloud_provider(args)` —
+env-first, then `getattr(args, "cloud_provider", None)`). All three trainers
+converge on it.
+
+> **Intentional, additive behavior change — not an accidental diff.** Kto
+> and grpo gain a fallback path they did not have before. This is called out
+> explicitly so PR reviewers do not treat it as an unintended regression.
+> Precedence is fixed: env-first, args fallback (via `getattr(..., None)`).
+> `cloud_provider` is metadata attached to JSONL log rows for downstream
+> experiment tracking — never a control-flow input.
+
+**Behavior-change audit**:
+- **sft**: unchanged — helper originates here.
+- **kto**: *additive* — previously `args.cloud_provider` only; now env-first,
+  args fallback. In practice `CLOUD_PROVIDER` env is set by HF-Jobs + local
+  docker runners that also set `args.cloud_provider`; env and args are
+  expected to agree. If they ever disagreed, env now wins — same-or-stricter
+  since `cloud_provider` is metadata, not control flow. **Flag for test
+  engineer**: add a kto test asserting env-wins-over-args-when-set.
+- **grpo**: *additive* — previously `os.environ.get("CLOUD_PROVIDER")` only;
+  now gains `getattr(args, "cloud_provider", None)` fallback when env is
+  unset. Current behavior: None when env unset. New behavior: None unless
+  args carries it (GRPO's `args` is TRL `GRPOConfig` which may or may not
+  have the attribute — `getattr(..., None)` default makes this safe).
+  Strictly an improvement in metadata completeness, no control-flow change.
+
+## 7. No-Public-API-Change Confirmation
+
+Callers import from the **per-trainer module**, not from a shared package:
+
+- `Trainers/sft/train_sft.py:51–54` →
+  `from src.training_callbacks import MetricsTableCallback, CheckpointMonitorCallback, LiveDashboardCallback`
+- `Trainers/kto/train_kto.py:50` →
+  `from src.training_callbacks import LiveDashboardCallback, MetricsTableCallback, CheckpointMonitorCallback, TwoStageLRCallback, DASHBOARD_AVAILABLE, RICH_AVAILABLE`
+- `Trainers/grpo/train_grpo.py:62` + `Trainers/grpo/train_env_grpo.py:34` →
+  `from src.training_callbacks import LiveDashboardCallback, MetricsTableCallback, DASHBOARD_AVAILABLE, RICH_AVAILABLE`
+
+> **Critical — per-trainer re-export required.** A package-level
+> `Trainers/shared/callbacks/__init__.py` re-export is **not sufficient**.
+> Every name these callers reference must be importable from
+> `Trainers/<trainer>/src/training_callbacks` at its original path. Coder
+> **must not** delete or empty `Trainers/{sft,kto,grpo}/src/training_callbacks.py`
+> or merely point to the shared package from callers. The per-trainer module
+> stays; it becomes thin.
+
+This is not a "backward-compat shim" (which CLAUDE.md forbids). The per-trainer
+module is the *canonical* home for these class names: sft's `MetricsTableCallback`
+is a different class from kto's (different health checker, different row format).
+The shared package provides the base machinery; the per-trainer module is where
+the concrete, trainer-specific class lives.
+
+After refactor, each `Trainers/<trainer>/src/training_callbacks.py`:
+
+1. **Defines** (subclasses `BaseMetricsCallback` / `BaseLiveDashboardCallback`,
+   wiring in the trainer's `HealthChecker`, `default_output_dir`, `log_every_write`,
+   `training_type_label`, `_print_header` / `_print_row`, and `_dashboard_metrics` /
+   `_fallback_row`):
+   `MetricsTableCallback`, `LiveDashboardCallback`.
+2. **Re-exports from the shared package** (so per-trainer import path is preserved):
+   `TwoStageLRCallback` (sft + kto), `CheckpointMonitorCallback` (sft + kto),
+   `DASHBOARD_AVAILABLE`, `RICH_AVAILABLE`, and `suppress_training_logs` (sft only).
+
+The result: every symbol in each caller's import line still resolves from
+`Trainers/<trainer>/src/training_callbacks` at unchanged signatures, with no
+changes to the train_*.py files.
+
+## 8. Migration Sequence
+
+Each step is independently testable; later steps are gated by the previous
+step's tests being green.
+
+1. **Land base package, no imports yet.** Create
+   `Trainers/shared/callbacks/{__init__.py,base.py,health_checks.py,lr_schedules.py,checkpoints.py,log_suppression.py}`.
+   Base classes compile; strategies compile; nothing imports them yet. Gate:
+   package imports cleanly under `python -c "from Trainers.shared.callbacks import *"`.
+2. **Port SFT first — sft's behavior is unchanged by the refactor.** SFT is the
+   richest file, and since the cloud-provider helper originated in sft, porting
+   it first exercises the full base-class surface with zero behavior-change risk
+   (any regression must be a refactoring bug, not the intentional additive
+   change from §6). Replace `Trainers/sft/src/training_callbacks.py` body with
+   thin subclasses + re-exports (per §7 — do **not** empty the module). Gate:
+   `train_sft.py` imports succeed; smoke-run a 5-step SFT training; verify log
+   file + symlink + banner + health-warning output match pre-refactor.
+3. **Port KTO — introduces the additive cloud-provider change.** Gate: kto
+   smoke-run; verify JSONL-every-on_log cadence preserved (diff pre/post sample
+   log files on same 5-step run); verify `CLOUD_PROVIDER` env value appears in
+   JSONL rows when env is set (new behavior per §6).
+4. **Port GRPO — introduces the additive args fallback.** Gate: `train_grpo.py`
+   + `train_env_grpo.py` imports succeed; grpo smoke-run; verify no health-check
+   output (`NoOpHealthChecker`); verify `cloud_provider` appears when only args
+   (not env) carries it (new behavior per §6).
+5. **Delete duplicated helpers.** The per-trainer `_append_final_training_summary`
+   / `_resolve_cloud_provider` (sft only) / `_format_time` are now dead. Gate:
+   grep confirms zero callers outside the shared package.
+
+Rollback unit: each step is one or two files; `git revert` restores behavior.
+
+## 9. Risk Matrix
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Import path breakage — callers use `from src.training_callbacks import …` | Low | High | Per-trainer module must define concrete subclasses + re-export hoisted names (see §7 — package-level `__init__.py` alone is insufficient); verified 4 call sites, all use same-file imports |
+| Symlink-behavior regression on WSL | Low | Low | Base preserves identical try/except OSError+NotImplementedError pattern; test step 2 checks symlink on WSL |
+| Dashboard callback sequence (on_log vs on_save order with LiveDashboard) | Low | Medium | Base does not reorder hooks; pure extraction. Test engineer: run dashboard side-by-side diff on same training_latest.jsonl |
+| KTO health-check output format drift (spaces, punctuation) | Medium | Low | `HealthChecker.check` prints identical bracket lines + "Consider:" footer; snapshot-test output |
+| Cloud-provider resolution: KTO gains env-first fallback (**intentional additive change**, guarded by args precedence, §6) | Low | Low | Called out explicitly so PR reviewers do not flag as accidental; test engineer adds env-wins-over-args assertion |
+| Cloud-provider resolution: GRPO gains args fallback (**intentional additive change**, guarded by args precedence, §6) | Low | Low | Called out explicitly; previously `None` when env unset, now `getattr(args, "cloud_provider", None)`; improvement-only for metadata completeness |
+| JSONL-write cadence silently flipped for a trainer | Low | High | `log_every_write` class attr is the single knob; step-2/3/4 gates diff log files before/after |
+| `previous_log_entries` semantics for GRPO (new param) | Low | Low | Default `None` is a no-op; preserves current behavior |
+| `suppress_training_logs` only lived in sft — don't accidentally break kto/grpo | Low | Low | Hoist to `log_suppression.py`; sft re-exports; kto/grpo don't import it, no-op for them |
+| `CLOUD_GPU_TYPE` env read — currently in all three files | Low | Low | Move to base alongside cloud-provider capture — identical code |
+
+## 10. Open Questions (for Coder)
+
+- GRPO's `MetricsTableCallback` swallows all log-write exceptions (`try/except Exception: pass`);
+  SFT + KTO raise. Preserve via `log_write_swallow_errors` class attr (default False;
+  GRPO overrides True) — **recommendation: preserve**, zero behavior change.
+- SFT's `LiveDashboardCallback` `training_type="sft"` ctor param is actually used
+  to switch dashboard rendering mode. Keep on sft's subclass only; don't propagate
+  to kto/grpo subclasses — **recommendation: keep as-is**.

--- a/docs/review/pr-85-architect.md
+++ b/docs/review/pr-85-architect.md
@@ -1,0 +1,247 @@
+# PR #85 — Architect Review
+
+**Scope**: Design-conformance review of the DRY callback refactor against
+`docs/architecture/training-callbacks-refactor.md`. Implementation review
+and test coverage are the sibling reviewers' charge.
+
+**Commit**: `d1cd904 fix(trainers): epoch counter in TUI dashboard + DRY callback refactor`
+
+**Verdict**: **Blocking** — two real SFT behavior changes slipped past the
+"zero behavior change" non-negotiable. One fix is a two-line reorder; the
+other is a one-class-attribute addition. Refactor shape is otherwise clean
+and matches the design doc.
+
+---
+
+## Findings
+
+### BLOCKING-1 — SFT health check now fires on every on_log (was Nth)
+
+**Location**: `Trainers/shared/callbacks/base.py:175-206`
+
+**What changed**: The original SFT `on_log` (see `git show main:Trainers/sft/src/training_callbacks.py`, lines 117-124) early-returned at
+`if state.global_step % self.log_every_n_steps != 0: return` **before**
+`_check_training_health` and `_save_metrics_to_file`. The new
+`BaseMetricsCallback.on_log` computes the capacity snapshot, writes JSONL
+(now gated via `should_write_jsonl`), calls
+`self.health_checker.check(...)` at line 203, and **only then** checks the
+modulo for the print-row gate at line 205.
+
+For SFT, `log_every_write = False`, so JSONL cadence is preserved (modulo
+still gates `should_write_jsonl`). But `SFTHealthChecker.check` now runs
+on **every** HF Trainer log callback instead of every Nth, producing
+N× more grad-norm / loss-still-high / reward-collapse warnings.
+
+**Why this is blocking**: Design doc §7 ("No-Public-API-Change
+Confirmation") and the dispatch non-negotiable ("zero behavior change")
+both required preserving observable behavior. SFT health-warning
+frequency is observable and used by the operator during training.
+
+**Fix**: Move the health-check call below the modulo gate, OR gate it on
+the same modulo:
+
+```python
+# replace lines 203-206 with:
+if state.global_step % self.log_every_n_steps != 0:
+    return
+self.health_checker.check(logs, state.global_step, args.max_grad_norm)
+```
+
+This preserves SFT behavior exactly. For KTO it also matches the
+original (original KTO called `_check_training_health` before the modulo
+gate — so KTO's health check *should* remain pre-gate). Resolution: make
+the gating configurable, e.g. class attr `health_check_every_on_log: bool`
+(KTO/GRPO: True; SFT: False, or absent since NoOp). Simpler alternative:
+keep pre-gate for all trainers and move SFT's rule into
+`SFTHealthChecker` with an internal modulo guard — but that leaks the
+log_every_n_steps knob into the health checker. The class-attr approach
+is cleaner and consistent with the design doc's divergence-via-class-attrs
+pattern.
+
+---
+
+### BLOCKING-2 — SFT `last_log_time` / `interval_time` semantics changed
+
+**Location**: `Trainers/shared/callbacks/base.py:180-181`
+
+**What changed**: Original SFT assigned `self.last_log_time = current_time`
+**after** the modulo early-return (line 129 in the old file), so
+`interval_time` measured time between **logged rows**. New base.py
+assigns `self.last_log_time = current_time` on every on_log (line 181),
+before the modulo gate. Consequence for SFT: the `interval_time` /
+`Time/5s` column and the `interval_time` JSONL field now reflect time
+since the **previous on_log callback**, not since the previous logged
+row. On the N-1 off-boundary steps the value is silently reset.
+
+Net effect: printed `Time/5s` and JSONL `interval_time` for SFT become
+meaningless (effectively zero-ish or very small), because the previous
+on_log tick happened 1 training step ago, not `log_every_n_steps` steps
+ago.
+
+KTO's original also updated `last_log_time` unconditionally — so KTO
+semantics are preserved. GRPO same. This is SFT-only.
+
+**Why this is blocking**: silently breaks an operator-facing metric
+(interval time and samples-per-5s). Small code change, meaningful
+display regression.
+
+**Fix**: Gate the `last_log_time` reassignment on the same `should_write_jsonl`
+or print-modulo that SFT previously used. Cleanest: make it track the
+print-row cadence (modulo), so `interval_time` always reflects
+row-to-row wall time. Example:
+
+```python
+current_time = datetime.now()
+interval_time = (current_time - self.last_log_time).total_seconds() if self.last_log_time else 0.0
+# (do NOT reassign last_log_time here yet)
+elapsed = ...
+...
+should_write_jsonl = self.log_every_write or (state.global_step % self.log_every_n_steps == 0)
+if should_write_jsonl:
+    self._write_log_row(..., interval_time=interval_time, ...)
+if state.global_step % self.log_every_n_steps != 0:
+    return
+self.last_log_time = current_time  # moved: only update at print boundary
+# ...print row...
+```
+
+Caveat: KTO/GRPO write JSONL every on_log (`log_every_write=True`), so
+their `interval_time` value *does* need to update every on_log to stay
+meaningful. Two options: (a) a second class attr
+`interval_time_updates_every_on_log: bool` (KTO/GRPO True, SFT False),
+or (b) update `last_log_time` inside `_write_log_row` when
+`log_every_write` is True, and at the print-row boundary when False.
+Option (a) is more explicit and matches the design doc's pattern.
+
+---
+
+### MINOR-1 — `BaseMetricsCallback.on_train_end` double-banner preserved
+
+**Location**: `Trainers/shared/callbacks/base.py:279-280`
+
+```python
+print("=" * 100)
+print("\n" + "=" * 100)
+```
+
+Preserved byte-identically from original SFT (which had the same bug).
+Not introduced by the refactor but now visible as shared code. Safe to
+leave for this PR (strict byte parity on that path was an implicit goal);
+flag for a follow-up cleanup.
+
+---
+
+### MINOR-2 — `BaseLiveDashboardCallback` no-dashboard start banner format drift
+
+**Location**: `Trainers/shared/callbacks/base.py:367-368`
+
+Original SFT (dashboard fallback) printed `"SFT TRAINING STARTED"` by
+concatenating `training_type.upper() + " TRAINING STARTED"`. New base
+does the same — **but** for GRPO the original printed `"GRPO TRAINING STARTED"`
+via the same template, so parity holds. I'm flagging this only because
+the original KTO LiveDashboard no-fallback path (original
+`Trainers/kto/src/training_callbacks.py:206` region) prints
+`"KTO TRAINING STARTED"` — verify in the coder-review that KTO parity is
+intact. Not blocking unless that check fails.
+
+---
+
+### MINOR-3 — `on_train_end` elapsed-time format inconsistency between base classes
+
+**Location**: `Trainers/shared/callbacks/base.py:283` vs `:436`
+
+`BaseMetricsCallback.on_train_end` uses `format_time(elapsed)`.
+`BaseLiveDashboardCallback.on_train_end` uses an inline
+`elapsed // 3600 ... % 60` expression. Both are preserved from originals,
+but the sibling-base inconsistency is a DRY smell. Follow-up: point both
+at `format_time()`.
+
+---
+
+### MINOR-4 — `BaseLiveDashboardCallback` JSONL write lacks `log_write_swallow_errors`
+
+**Location**: `Trainers/shared/callbacks/base.py:397-398`
+
+```python
+with open(self.log_file, "a", encoding="utf-8") as f:
+    f.write(json.dumps(log_entry) + "\n")
+```
+
+No try/except. Original per-trainer LiveDashboard callbacks also had no
+try/except here, so byte-parity holds. Design inconsistency only: the
+sibling `_write_log_row` on `BaseMetricsCallback` respects
+`log_write_swallow_errors`; this path does not. If GRPO LiveDashboard
+is ever invoked in a read-only FS / quota-exhausted environment, it will
+crash where GRPO's `MetricsTableCallback` would have silently swallowed.
+Safe to defer; flag for a follow-up unification.
+
+---
+
+### MINOR-5 — Per-trainer module docstrings call themselves "shims"
+
+**Location**: `Trainers/{sft,kto,grpo}/src/training_callbacks.py:1-7`
+
+Docstrings say "Per-trainer [SFT|KTO|GRPO] callback shims." CLAUDE.md
+rule: **"No backward-compat shims — This codebase has no external
+consumers..."** These are NOT backward-compat shims — they are the
+canonical concrete-class home (per design doc §7). Rename docstring to
+something like "Per-trainer concrete subclasses and re-exports" to avoid
+confusing future readers who may grep for "shim" during cleanup.
+
+---
+
+### FUTURE-1 — `sys.path.insert(...)` repeated in 4 files
+
+`base.py:21`, `log_suppression.py`, and the three per-trainer modules
+all do `sys.path.insert(0, str(Path(__file__).resolve().parents[N]))`.
+Consistent with the repo's existing convention, but worth consolidating
+via a single bootstrap module or a proper `pyproject.toml` package entry
+in a future refactor. Not in scope for this PR.
+
+---
+
+### FUTURE-2 — HealthChecker strategy is good; consider a no-op subclass sentinel
+
+The `NoOpHealthChecker` is used as both the default (in
+`BaseMetricsCallback.__init__`) and the explicit GRPO assignment. If the
+default covers GRPO, the explicit assignment in the GRPO module can go.
+Purely stylistic; leave as-is for clarity of intent.
+
+---
+
+## Design-Doc Conformance — PASS items
+
+- **§1 Package Layout**: `Trainers/shared/callbacks/{base,health_checks,lr_schedules,checkpoints,log_suppression,__init__}.py` — matches exactly.
+- **§3 Class-attr divergence knobs**: `log_every_write`, `log_write_swallow_errors`, `interval_key_name`, `default_output_dir`, `start_banner`, `completion_banner`, `print_checkpoint_on_save`, `print_completion_banner` — all present on `BaseMetricsCallback` and used correctly by the three subclasses.
+- **§4 HealthChecker Strategy**: ABC with single `check(logs, step, max_grad_norm)` method, three concrete subclasses (`SFTHealthChecker`, `KTOHealthChecker`, `NoOpHealthChecker`), shared `_grad_norm_warning` helper. Minimal and clean.
+- **§6 Cloud-provider resolution**: Unified on env-first + `getattr(args, "cloud_provider", None)` fallback via `resolve_cloud_provider()`. Matches the design-doc callout; KTO and GRPO correctly inherit the additive env-first behavior that the design-doc §6 flagged as an intentional minor behavior change.
+- **§7 No-public-API-change**: Per-trainer concrete classes and re-exports preserved at `Trainers/{sft,kto,grpo}/src/training_callbacks`. The four documented call sites (`train_sft.py`, `train_kto.py`, `train_grpo.py`, `train_env_grpo.py`) can continue importing by existing paths.
+- **§8 Migration sequence**: SFT-first / KTO-second / GRPO-third order evident; each per-trainer shim is thin and byte-faithful on its specific divergence axes (modulo the two BLOCKING findings above).
+
+---
+
+## Summary for Team Lead
+
+- 5 non-blocking design smells, 2 future cleanups.
+- **2 blocking SFT behavior regressions** that the refactor introduced
+  by "unifying" what was actually divergent between SFT and KTO/GRPO.
+  Both are small local fixes on `base.py`.
+- Recommended remediation: add one or two class attributes
+  (`health_check_every_on_log`, `interval_time_updates_every_on_log`) —
+  consistent with the class-attr-divergence pattern already used in the
+  refactor — and move the two statements below the appropriate gates.
+  Coder's lift is small; tests should grow to cover the SFT Nth-step
+  health-check and interval-time cadence so this regression doesn't
+  recur.
+
+---
+
+## Open Questions for Team Lead
+
+1. Accept BLOCKING-1 and BLOCKING-2 as must-fix-before-merge? (My
+   recommendation: yes, both. Each is a ~5-line fix plus a test.)
+2. MINOR-1 (double-banner bug preserved from original): fix in this PR
+   or leave for follow-up? Byte-parity goal suggests leave; hygiene
+   suggests fix while the code is open.
+3. MINOR-5 (docstrings say "shim"): rename in this PR or leave?
+   Low-risk one-liner per file.

--- a/docs/review/pr-85-backend.md
+++ b/docs/review/pr-85-backend.md
@@ -1,0 +1,381 @@
+# PR #85 — Backend Implementation Review
+
+**Reviewer**: backend-coder-reviewer
+**Scope**: `Trainers/shared/callbacks/` package + three per-trainer shims
+(`Trainers/{sft,kto,grpo}/src/training_callbacks.py`).
+**Commit under review**: `d1cd904`
+**Mode**: Review-only. No code changes.
+
+## Verdict
+
+Close to mergeable. Two blocking concerns around **undocumented behavior
+drift in SFT** (health-check cadence + interval_time semantics) and **a
+silent precedence flip in GRPO's JSONL row** that the architect doc
+names but the risk matrix doesn't surface as a diff risk. Everything
+else is minor/cosmetic.
+
+---
+
+## Blocking
+
+### B1. SFT: health-check cadence + `interval_time` semantics silently shifted
+
+**What changed.** Old `Trainers/sft/src/training_callbacks.py`
+(pre-refactor) gated the **entire** `on_log` body on
+`state.global_step % self.log_every_n_steps != 0` (old
+`training_callbacks.py:123-124`). That early return meant:
+
+- `self.last_log_time = current_time` was updated only at interval
+  multiples, so `interval_time` = wall-clock gap between **printed
+  rows** (which the row label `Time/5s` advertises).
+- `_check_training_health(...)` was called only at interval multiples,
+  so SFT warnings were throttled to 1-per-N-steps.
+
+The new `BaseMetricsCallback.on_log`
+(`Trainers/shared/callbacks/base.py:175-223`) is structured differently:
+
+- `self.last_log_time = current_time` updates on **every** `on_log`
+  (line 181) — before the interval gate.
+- `self.health_checker.check(...)` fires on **every** `on_log`
+  (line 203) — before the interval gate at line 205.
+
+For KTO + GRPO this matches old behavior (they already updated every
+call). For **SFT this is a behavior change**:
+
+- `interval_time` now measures on_log-to-on_log deltas, not
+  row-to-row deltas. Since HF Trainer's `logging_steps` and this
+  callback's `log_every_n_steps` are independent knobs, when
+  `logging_steps < log_every_n_steps` the printed `Time/5s` column
+  will drop to small values. Users reading the column by its label
+  will be misled.
+- SFT warnings (unusual loss, high grad norm, loss-still-high-after-50)
+  print more often than before. In the worst case — HF Trainer logging
+  per step — warnings become per-step noise rather than per-5-step.
+
+The architect design doc (§5 *Divergence Matrix*) lists
+"elapsed/steps-per-sec/samples-per-sec calc" as moved-to-base but is
+silent on these two cadence changes. The risk matrix (§9) does not
+mention SFT-specific health-check cadence or `interval_time`
+redefinition.
+
+**Recommendation.** Either:
+
+1. Gate both `self.last_log_time = current_time` and
+   `self.health_checker.check(...)` on `should_write_jsonl` (i.e.,
+   `log_every_write=True OR on interval`) so SFT keeps its old
+   interval-only semantics while KTO/GRPO still update every call
+   (they set `log_every_write=True`). This is the least-diff fix and
+   preserves both trainers' prior behavior exactly.
+2. Or: explicitly document this as an intentional additive change, add
+   a risk-matrix entry, and add a test asserting SFT warnings fire at
+   expected cadence.
+
+Option 1 is preferred — no behavior change is the stated
+non-negotiable (design doc §1).
+
+**Evidence**: pre-refactor `Trainers/sft/src/training_callbacks.py:117-124`
+(early return at top of on_log) vs `Trainers/shared/callbacks/base.py:175-206`
+(gate only at line 205 after `last_log_time` and `health_checker.check`).
+
+---
+
+### B2. GRPO JSONL: dict-merge precedence flipped from "ours wins" to "logs wins"
+
+**What changed.** Pre-refactor GRPO `on_log`
+(old `training_callbacks.py:113-120`) built the JSONL row as:
+
+```python
+entry = dict(logs)                    # logs is the base dict
+entry["step"] = int(state.global_step)
+entry["timestamp"] = current_time.isoformat()
+entry["interval_seconds"] = interval_time
+entry["elapsed_seconds"] = ...
+entry["steps_per_second"] = ...
+entry["samples_per_sec"] = ...
+entry.update(capacity_snapshot)        # capacity overrides
+```
+
+Precedence: `{...logs, ...our_timing (overrides), ...capacity (overrides)}`.
+**Our fields win over logs.**
+
+New `BaseMetricsCallback._write_log_row`
+(`Trainers/shared/callbacks/base.py:237-246`):
+
+```python
+entry = {
+    "step": int(step),
+    "timestamp": current_time.isoformat(),
+    self.interval_key_name: interval_time,
+    "elapsed_seconds": ...,
+    "steps_per_second": ...,
+    "samples_per_sec": ...,
+    **capacity_snapshot,
+    **logs,
+}
+```
+
+Precedence: `{...our_fields, ...capacity, ...logs}`.
+**Logs wins over our fields.**
+
+For SFT and KTO this matches their previous `{...ours, **logs}`
+pattern, so no change. For **GRPO this flips precedence** on any key
+that appears in both our fields and HF Trainer's `logs`.
+
+**In practice the blast radius is small.** HF Trainer's standard
+emitted log keys (`loss`, `learning_rate`, `epoch`, `grad_norm`) don't
+collide with our field names (`step`, `timestamp`, `interval_seconds`,
+`elapsed_seconds`, `steps_per_second`, `samples_per_sec`, or capacity
+keys like `gpu_memory_gb`). So in the default GRPO training path no
+row content actually changes.
+
+**However**: this is a silent precedence flip on the exact format the
+PR description asks reviewers to verify byte-exact
+(`interval_seconds`). If a downstream consumer — or a custom
+`GRPOTrainer` subclass, or TRL's own eval logs — ever puts `step`,
+`timestamp`, or a capacity key into `logs`, GRPO's behavior changes
+without warning. The architect doc §5 claims "moves to base …
+`_append_final_training_summary` helper (byte-identical in all three)"
+— which is true for the final-summary row — but doesn't surface that
+the per-step row's merge precedence has changed for GRPO.
+
+**Recommendation.** Either:
+
+1. Keep the new unified `{...ours, **logs}` precedence (matches the
+   architect's stated unification), but document it explicitly in the
+   PR description + §9 risk matrix with an explicit "GRPO: per-row
+   dict-merge precedence flipped from ours-wins to logs-wins; no
+   current HF Trainer log key collides, so no observed diff in
+   default training, but any custom trainer emitting `step` /
+   `timestamp` / capacity-shaped keys in `logs` would now see those
+   values land in JSONL instead of our computed ones."
+2. Or: change base to preserve GRPO's old precedence with
+   `{..logs, **our_fields, **capacity}` — but this would break
+   SFT/KTO's prior `{...ours, **logs}` semantics.
+
+Option 1 is the correct direction. The PR just needs to own the
+change explicitly.
+
+**Evidence**: old `Trainers/grpo/src/training_callbacks.py:113-120`
+vs new `Trainers/shared/callbacks/base.py:237-246`.
+
+---
+
+## Minor
+
+### M1. SFT `on_train_end` drops one leading `=` * 100 decorator line
+
+Old SFT `on_train_end` printed a leading `"=" * 100` line before the
+`train_end` JSONL write (old `training_callbacks.py:268`), then
+`"\n" + "=" * 100` + banner. New `BaseMetricsCallback.on_train_end`
+(`base.py:268-287`) writes the JSONL row first then goes straight to
+`"\n" + "=" * 100`. Visual output now missing one row of `=` dashes
+before the banner. Cosmetic.
+
+### M2. SFT `LiveDashboardCallback` fallback banner reshape
+
+Old SFT no-dashboard fallback banner:
+`"TRAINING STARTED - {training_type.upper()}"`
+(old `training_callbacks.py:455`).
+
+New `BaseLiveDashboardCallback.on_train_begin` fallback banner:
+`"{training_type_attr.upper()} TRAINING STARTED"` (`base.py:368`).
+
+Text order flipped. Low-impact (fallback path only, no rich
+dashboard). Call out if the design goal is byte-exact output
+preservation.
+
+### M3. Four modules each call `sys.path.insert(0, <repo-root>)` at import
+
+`Trainers/shared/callbacks/base.py:21`,
+`Trainers/shared/callbacks/log_suppression.py:10`, and all three
+`Trainers/<trainer>/src/training_callbacks.py` shims (line 17 each)
+mutate global `sys.path` at import time. Pre-refactor files did the
+same (old `training_callbacks.py:18`), so no regression, but it's four
+copies of the same hack in the new layout where a single package-level
+`__init__.py` injection would have sufficed. Consider consolidating
+into one place (e.g., `Trainers/shared/callbacks/__init__.py`).
+
+### M4. `resolve_cloud_provider` + `CLOUD_GPU_TYPE` env lookup: not DRY
+
+`_annotate_cloud` (`base.py:47-54`) wraps `resolve_cloud_provider` +
+`CLOUD_GPU_TYPE` env read into one helper — good. But the helper is
+called from **two** places (`BaseMetricsCallback.on_log:188` and
+`BaseLiveDashboardCallback.on_log:384`) and the logic inside is only
+two `setdefault` calls. Fine as-is, but worth a comment that both
+callbacks must call it — easy to forget when adding a third callback
+type.
+
+### M5. `BaseLiveDashboardCallback.on_log` has no `log_write_swallow_errors` switch
+
+`BaseMetricsCallback._write_log_row` (`base.py:247-252`) honors
+`log_write_swallow_errors`. `BaseLiveDashboardCallback.on_log`
+writes JSONL (`base.py:397-398`) with no such gate. Pre-refactor,
+neither `LiveDashboardCallback` (SFT/KTO/GRPO) swallowed errors on
+this write path, so no regression — but if the design intent is
+symmetry, consider adding the knob to the live-dashboard path too.
+GRPO's `MetricsTableCallback` swallows errors; GRPO's
+`LiveDashboardCallback` does not. Intentional divergence should be
+noted.
+
+### M6. `total_epochs` default of 1 shadows `num_train_epochs` for very-early failures
+
+`BaseLiveDashboardCallback.__init__:344` sets `self.total_epochs = 1`
+as a sentinel before `on_train_begin` overwrites it with
+`args.num_train_epochs`. If `on_log` were ever called before
+`on_train_begin` (which HF Trainer shouldn't do), JSONL rows would
+record `total_epochs=1`. Pre-refactor code had the same sentinel —
+no regression. Non-issue in practice but worth a brief comment.
+
+### M7. Epoch float cast ONLY applied to dashboard `update(...)`, not to JSONL row
+
+The `float(logs.get("epoch", 0.0) or 0.0)` cast
+(`base.py:401`) is used for `dashboard.update(epoch=...)`. The JSONL
+row written at `base.py:386-396` uses `**logs` — so `epoch` in the
+JSONL entry is whatever HF emitted (already a float from HF's side).
+This is fine, but the PR description mentions the fix lives in "one
+place"; technically it's one **call site**, and the JSONL row relies
+on HF's native float emission. If HF ever changed that, the JSONL
+reader would break even with the dashboard fix in place. Call out in
+PR description for clarity.
+
+---
+
+## Future
+
+### F1. `CheckpointMonitorCallback.on_save` is a no-op — why does it exist?
+
+`Trainers/shared/callbacks/checkpoints.py:11-12`:
+```python
+def on_save(self, args, state, control, **kwargs):
+    pass
+```
+
+Comment in pre-refactor file says "This is already handled by
+MetricsTableCallback but we keep this for extensibility". Refactor
+preserves this verbatim. Dead code — consider deleting in a follow-up.
+Not this PR.
+
+### F2. `HealthChecker._print_warnings` helper is module-private but used from subclasses
+
+`Trainers/shared/callbacks/health_checks.py:26` — the leading
+underscore suggests private, yet both `SFTHealthChecker.check` and
+`KTOHealthChecker.check` call it from the module scope (same file, so
+it's legal Python). Fine as-is. If `health_checks.py` is ever split,
+rename to `_grad_norm_warning` / `_print_warnings` at module scope is
+the same file — no actual boundary crossed today.
+
+### F3. `NoOpHealthChecker.check` returns `None` explicitly
+
+`health_checks.py:88`: `return` — redundant in a function whose
+default return is `None`. Cosmetic.
+
+### F4. `resolve_cloud_provider` is exported but only `_annotate_cloud` uses it
+
+`__init__.py:35` and `base.py:39` export `resolve_cloud_provider` as
+public API. Nothing outside the package (in the shim modules or the
+train_*.py callers) imports it today. Fine to expose for future use;
+just noting.
+
+---
+
+## Verification Details
+
+### Task-description check items (✓ / ✗)
+
+- ✓ **Code quality**: callbacks are idiomatic Python — class attrs as
+  configuration knobs (`log_every_write`, `log_write_swallow_errors`,
+  `print_checkpoint_on_save`, `print_completion_banner`,
+  `interval_key_name`), strategy-pattern `HealthChecker`, and thin
+  subclass hooks (`_print_header`, `_print_row`, `_dashboard_metrics`,
+  `_fallback_row`). Typing is consistent (`Optional[str]`,
+  `Dict[str, Any]`, `List[Dict[str, Any]]`). Naming is clear.
+
+- ✓ **Shim thinness**: all three shims are ≤113 lines. SFT shim is
+  the thickest (113 lines) because of the `training_type` ctor param
+  plumbing; KTO (102) and GRPO (126) are in the same range. No
+  business logic leaked into the shims — they only (a) subclass and
+  set class attrs, (b) override `_print_header` / `_print_row` /
+  `_dashboard_metrics` / `_fallback_row`, (c) re-export hoisted
+  names. Good.
+
+- ⚠ **Error handling (`log_write_swallow_errors`)**: correct
+  per-trainer — GRPO sets True (swallow), SFT/KTO default to False
+  (raise). Matches pre-refactor behavior. *But* see M5 — the
+  `LiveDashboardCallback` write path has no equivalent switch, and
+  the JSONL write there is unguarded on all three trainers.
+
+- ⚠ **Dict-merge precedence `{...ours, **logs}` = logs wins**:
+  implemented correctly and uniformly in both
+  `BaseMetricsCallback._write_log_row` and
+  `BaseLiveDashboardCallback.on_log`. **But for GRPO this is a
+  precedence flip** — see B2.
+
+- ✓ **Import cleanliness**: no circular imports. Smoke test:
+  `from Trainers.shared.callbacks import *` + each of the three shim
+  imports succeed cleanly.
+
+- ⚠ **Silent drops from old files**: see M1 (SFT banner decorator
+  line) and M2 (SFT fallback banner reshape). Minor, cosmetic, but
+  technically silent output diffs.
+
+- ✓ **`interval_seconds` GRPO byte-exact**: GRPO shim sets
+  `interval_key_name = "interval_seconds"` at
+  `Trainers/grpo/src/training_callbacks.py:35`; base dereferences
+  `self.interval_key_name` at `base.py:240`. Confirmed byte-exact.
+
+- ✓ **Epoch float cast — one place only**: located at
+  `base.py:401` inside `BaseLiveDashboardCallback.on_log`. No other
+  call site casts epoch. The `MetricsTableCallback` path prints
+  `epoch` via `logs.get("epoch", 0.0)` (`sft/src/training_callbacks.py:66`)
+  which stays as HF's native type — this is the console-row side,
+  independent of the dashboard bug. Per M7 above, the JSONL row
+  relies on HF's emission.
+
+### Files reviewed
+
+- `Trainers/shared/callbacks/__init__.py`
+- `Trainers/shared/callbacks/base.py`
+- `Trainers/shared/callbacks/health_checks.py`
+- `Trainers/shared/callbacks/lr_schedules.py`
+- `Trainers/shared/callbacks/checkpoints.py`
+- `Trainers/shared/callbacks/log_suppression.py`
+- `Trainers/sft/src/training_callbacks.py`
+- `Trainers/kto/src/training_callbacks.py`
+- `Trainers/grpo/src/training_callbacks.py`
+- `docs/architecture/training-callbacks-refactor.md` (for context)
+- pre-refactor versions of all three `training_callbacks.py` files
+  (extracted via `git show d1cd904^:...`)
+
+### Call sites confirmed unbroken
+
+- `Trainers/sft/train_sft.py:51-57` → imports
+  `MetricsTableCallback`, `CheckpointMonitorCallback`,
+  `LiveDashboardCallback`, `suppress_training_logs`,
+  `DASHBOARD_AVAILABLE`. All five are re-exported by the SFT shim.
+- `Trainers/kto/train_kto.py:50` → imports
+  `LiveDashboardCallback`, `MetricsTableCallback`,
+  `CheckpointMonitorCallback`, `TwoStageLRCallback`,
+  `DASHBOARD_AVAILABLE`, `RICH_AVAILABLE`. All six re-exported.
+- `Trainers/grpo/train_grpo.py:62` and
+  `Trainers/grpo/train_env_grpo.py:34` → import
+  `LiveDashboardCallback`, `MetricsTableCallback`,
+  `DASHBOARD_AVAILABLE`, `RICH_AVAILABLE`. All four re-exported.
+
+No caller edits required. ✓
+
+---
+
+## Summary for Lead
+
+- **B1 and B2** should be resolved before merge — either by tightening
+  the `on_log` flow in `base.py` (preferred) or by explicitly
+  documenting the drift in the PR description + risk matrix.
+- **M1-M7** are minor cosmetic / ergonomic comments; none are merge
+  blockers.
+- **F1-F4** are follow-up cleanup, not in scope for this PR.
+- The bug fix itself (epoch float cast) is correctly implemented at
+  exactly one location in `BaseLiveDashboardCallback.on_log`.
+- The refactor is structurally sound: strategy pattern for health
+  checks, class-attr knobs for cadence/banner/interval-key
+  divergence, thin per-trainer subclasses, and clean re-exports keep
+  all four call sites untouched.

--- a/docs/review/pr-85-test-engineer.md
+++ b/docs/review/pr-85-test-engineer.md
@@ -1,0 +1,283 @@
+# PR #85 — Test Coverage Review (test-engineer)
+
+**PR**: `fix(trainers): epoch counter in TUI dashboard + DRY callback refactor`
+**Branch**: `fix/tui-epoch-counter` → `main` (+1538 / −1291, net −383 LOC + tests + docs)
+**Reviewer scope**: test quality, coverage rigor, regression scope, mock fairness, edge cases.
+
+---
+
+## Headline
+
+The PR bundles **two changes**: (1) a one-line bug fix for the TUI epoch
+counter (`int(logs.get('epoch', 0))` → `float(logs.get("epoch", 0.0) or 0.0)`
+at `Trainers/shared/callbacks/base.py:401`) and (2) a DRY callback refactor
+that extracts shared lifecycle into `Trainers/shared/callbacks/`.
+
+**The 21 new tests in `tests/trainers/test_callback_refactor.py` cover the
+refactor's 4 stated uncertainties. They do NOT cover the headline bug fix.**
+This is the dominant finding of the review.
+
+---
+
+## Findings
+
+### Blocking
+
+#### B1. The epoch-fix regression guard is missing
+
+The PR title promises an epoch-counter fix, the commit message names it, and
+the PR body's test plan moves byte-level confirmation to a manual post-merge
+SFT run. But no automated test will fail if a future refactor reintroduces
+`int(logs.get("epoch", ...))` on the path that feeds
+`LiveDashboard.update(epoch=…)`.
+
+Concrete evidence:
+
+- Pre-fix, at `HEAD~1`, all three trainers (`sft`, `kto`, `grpo`) passed
+  `epoch=int(logs.get('epoch', 0))` into `self.dashboard.update(...)`
+  (see `Trainers/{sft,kto,grpo}/src/training_callbacks.py:500/475/283` at
+  the parent commit).
+- Post-fix, `base.py:401` uses `float(logs.get("epoch", 0.0) or 0.0)`.
+- `LiveDashboard.update(epoch: float = None)` at `shared/ui/dashboard.py:157`
+  stores the value as `self.metrics.epoch: float = 0.0` and formats it via
+  `f"{self.epoch:.2f}/{total_epochs}"` at `dashboard.py:91`. Passing `int(0)`
+  when real epoch is `0.34` renders `0.00/3` until the integer flips to `1`.
+  That is the user-visible bug.
+- My `TestSftJsonlShape::test_sft_row_has_required_keys_and_types` asserts
+  `row["epoch"] == 0.25` — but this tests `MetricsTableCallback.on_log` →
+  JSONL, NOT `LiveDashboardCallback.on_log` → `dashboard.update(epoch=…)`.
+  The JSONL row path spreads `**logs` verbatim, so this assertion would
+  have passed pre-fix as well. **It does not exercise the bug.**
+
+**Recommendation**: Add a dashboard-targeted unit test. Mock `LiveDashboard`,
+drive `LiveDashboardCallback.on_log` with `logs={"epoch": 0.34, "loss": …}`,
+assert the captured `dashboard.update` kwargs contain `epoch=0.34` (float) —
+not `0` (int). One test per trainer (sft, kto, grpo) since the bug lived in
+all three. This is one small patch, ~30 LOC, and closes the regression door
+on the PR's headline promise.
+
+### Minor
+
+#### M1. Test uncertainty-traceability is one-to-one, but the dict-merge test is semantically broader than the stated uncertainty
+
+Mapping my 21 tests to the 4 uncertainties:
+
+| Uncertainty | Test class | Coverage |
+|---|---|---|
+| [MEDIUM] KTO env-wins cloud-provider | `TestKtoCloudProviderEnvWins` (4 tests) | env-overrides-args, args-fallback, empty-env-fallback, neither-set |
+| [MEDIUM] `log_every_write` cadence knob | `TestLogEveryWriteCadence` (4 tests) | SFT skips non-boundary, KTO/GRPO write every, class-attr grep-visible |
+| [MEDIUM] GRPO dict-merge order | `TestDictMergeOrder` (3 tests) | logs.step wins, loss/lr/reward verbatim, logs can override steps_per_second |
+| [HIGH] GRPO `interval_seconds` key | `TestGrpoIntervalKey` (4 tests) | GRPO has, SFT has interval_time, KTO has interval_time, class-attr grep-visible |
+| (bonus — direct helper) | `TestResolveCloudProvider` (5 tests) | env wins, env absent, neither, empty, whitespace |
+| (bonus — SFT JSONL shape) | `TestSftJsonlShape` (1 test) | shape-only parity |
+
+Classification: tight 1:1 on uncertainties 1, 2, 4. Uncertainty 3 (dict-merge
+order) is *semantically broader* than the lead's restatement — the lead's
+guidance was specifically "GRPO logs.step wins over state.global_step", which
+is covered. My two additional assertions (`loss`/`learning_rate`/`reward`
+verbatim; `steps_per_second` overrideable) are not gratuitous: they document
+the commutative property of the merge order so a future reader can reason
+about it without re-reading `base.py`.
+
+**Recommendation**: No action — this is fine. Note the breadth in the HANDOFF
+so the architect reviewing design conformance can confirm intent.
+
+#### M2. SimpleNamespace mocks omit several real TrainerState/TrainingArguments attributes — none currently read, but fragile
+
+My stubs only set:
+
+- State: `global_step`, `max_steps`, `epoch`
+- Args: `per_device_train_batch_size`, `gradient_accumulation_steps`,
+  `max_grad_norm`, `output_dir`, and optionally `cloud_provider`.
+
+Real HF `TrainerState` carries `log_history`, `best_model_checkpoint`,
+`is_hyper_param_search`, etc. Real `TrainingArguments` carries ~200 fields.
+A future base-class change that reads any unmocked attribute (e.g.,
+`args.num_train_epochs` — which `BaseLiveDashboardCallback.on_train_begin`
+DOES read at `base.py:352`) will surface as `AttributeError` in the test,
+which is still a loud failure. No silent pass risk.
+
+**However**: my tests only exercise `BaseMetricsCallback` (JSONL/table path),
+NOT `BaseLiveDashboardCallback` (which reads `args.num_train_epochs`). The
+dashboard path is the one where the bug lived. So the mock narrowness
+compounds with B1.
+
+**Recommendation**: When adding the B1 dashboard test, extend the args stub
+to include `num_train_epochs`. Keep the pattern: stub only what the code
+under test reads, and let `AttributeError` fail loudly when that invariant
+breaks.
+
+#### M3. `_dashboard_metrics` fallback chains are entirely uncovered
+
+The divergence matrix (design §5) says per-trainer dashboard metric
+extraction stays trainer-specific. My tests cover none of it:
+
+- `Trainers/kto/src/training_callbacks.py:82` — KTO's `kl` falls back to
+  `logps/rejected` when `kl` is absent.
+- `Trainers/grpo/src/training_callbacks.py:91-99` — GRPO tries
+  `reward` → `rewards` → `rewards/mean` → `mean_reward` and similar chains
+  for `reward_std`, `kl_penalty`, `advantage`.
+
+Neither is asserted anywhere. A fallback key rename (e.g. TRL releasing a
+new `rewards/std_dev` field) would silently degrade the dashboard's live
+reward-std display to 0 without any test red.
+
+**Recommendation**: When writing the B1 dashboard test, add three small
+cases asserting each fallback chain. Drive `on_log` with `logs` missing the
+preferred key, assert the dashboard captures the fallback. Combined with
+B1's fix, this becomes ~60 LOC of test code total.
+
+#### M4. Shape-only JSONL parity is rigorous enough for STANDARD risk — do not block on byte parity
+
+A captured pre-refactor baseline would give byte-identity, but:
+
+- Capturing it requires running real training (deferred per §8 migration
+  sequence).
+- The dict-merge order test (M1) already locks down the spread invariant.
+- The `interval_key_name` test (uncertainty #4) locks down the one known
+  GRPO divergence.
+- The `log_every_write` test locks down the cadence divergence.
+- Shape-only parity (required keys + types) catches silent field drift.
+
+Between those four locks, a silent row-shape regression would have to bypass
+all of them. That's acceptable for a STANDARD-tier refactor.
+
+**Recommendation**: Keep shape-only. If byte parity is demanded later, the
+right path is a fixtures-based golden test driven by a ~50-step real SFT run
+captured to JSONL, diffed as structured rows (not bytes — timestamps and
+capacity vary run-to-run).
+
+#### M5. Regression scope was adequate — no hidden callback-touching tests
+
+Exhaustive grep across `tests/` for callback symbols (`MetricsTableCallback`,
+`LiveDashboardCallback`, `BaseMetricsCallback`, `BaseLiveDashboardCallback`,
+`TwoStageLRCallback`, `CheckpointMonitorCallback`, `suppress_training_logs`,
+`HealthChecker`, `training_callbacks`) finds 3 files:
+
+1. `tests/trainers/test_callback_refactor.py` — the new file.
+2. `tests/cloud/test_dashboard.py` — only constructs `LiveDashboard`, does
+   not touch callbacks.
+3. `tests/cloud/test_hf_jobs_backend.py` — stubs `mock_shared_ui.LiveDashboard
+   = DummyDashboard` at line 523, does not touch callbacks.
+
+Both 2 and 3 pass (45/45). Other matches for `from Trainers` are unrelated
+imports (`rewards`, `runpod_sync`, `filter_lora_adapter`, `manage_space`).
+
+1812 total tests collect cleanly at the worktree root, confirming no
+callback-refactor import-path breakage elsewhere.
+
+### Future
+
+#### F1. `capture_runtime_capacity_snapshot` behaviour under GPU vs CPU is indirectly exercised
+
+My tests run on a no-GPU box; the snapshot returns CPU-only fields. The
+GPU-present branch at `shared/training_capacity.py:210+` is not exercised by
+any test in this repo. Not a refactor concern (code unchanged), but a
+candidate for future snapshot-based coverage if callback JSONL rows ever
+become load-bearing for experiment tracking decisions.
+
+#### F2. `suppress_training_logs` hoist from SFT → shared has no direct test
+
+`Trainers/shared/callbacks/log_suppression.py` is new; SFT re-exports it;
+KTO/GRPO don't use it. No test calls `suppress_training_logs()`. The design
+calls this "no-op for kto/grpo" and the module's function presumably still
+does what it always did. If stdout/stderr redirection semantics ever drift,
+no test would catch it. Low-priority given the extraction was byte-identical
+per the design matrix.
+
+#### F3. Health-check output format drift has no snapshot test
+
+Per design §9 risk matrix: "KTO health-check output format drift (spaces,
+punctuation) — Medium likelihood, Low impact — snapshot-test output." No
+such snapshot exists. The `HealthChecker` ABC is not exercised directly by
+any test. If you add any, `capsys` plus a fixed-logs input would snapshot
+the banner lines in under 20 LOC.
+
+#### F4. No byte-level parity baseline captured
+
+Per M4, shape-only is acceptable. Noting the absence here for
+future-tier tests if this code ever moves up from STANDARD to HIGH risk.
+
+---
+
+## Edge Cases — Probed, Clean
+
+| Case | Behaviour | Covered? |
+|---|---|---|
+| `logs=None` | `on_log` returns early (base.py:177 `if not logs: return`) | Implicit — no test, but the guard is trivial |
+| `logs={}` | Same early return (empty dict is falsy) | Implicit — same guard |
+| `state.global_step=0` | `0 % log_every_n_steps == 0` → SFT writes row at step 0; KTO/GRPO always write. Edge: `steps_per_sec=0/elapsed` division guarded (`if elapsed > 0`) | Not explicitly tested — would pass on inspection |
+| `args.output_dir=None` | Base uses `self.default_output_dir` via `output_dir if output_dir is not None else self.default_output_dir` at base.py:138. Safe. | Not explicitly tested |
+| `CLOUD_PROVIDER=" "` (whitespace) | `.strip()` falsy → falls back to args | Covered by `test_whitespace_env_falls_back_to_args` |
+| `logs["step"]` collision | logs wins | Covered |
+| `interval_key_name` collision — what if logs contained `"interval_seconds"`? | logs wins, overrides base's computed interval | Not tested — edge case, likely harmless |
+
+None of these are blockers. `logs={}` / `logs=None` guards are one-liners
+the current tests implicitly rely on (the `_begin` helper feeds non-empty
+logs). A single `test_on_log_with_empty_logs_returns_early` would be a nice
+belt-and-braces addition.
+
+---
+
+## Signal
+
+| Field | Value |
+|---|---|
+| Risk Tier | **HIGH** (elevated from STANDARD — headline bug fix is untested; any regression goes to production dashboards for all three trainers) |
+| Signal | 🟡 **YELLOW** |
+| Coverage | 21/21 new tests pass; 1/1 HIGH + 3/3 MEDIUM refactor uncertainties tested; 0/1 bug-fix regression guard |
+| Uncertainty Coverage | 1 of 1 HIGH flagged by architect/coder tested (interval_seconds) |
+| Blockers | **B1**: add a dashboard-path test locking `epoch: float` into `LiveDashboard.update` |
+| Minors | M1–M5 addressed above |
+| Future | F1–F4 addressed above |
+
+Route back to a coder to add the B1 test (and optionally M3 fallback
+coverage) — do not block the merge on anything else. Once B1 lands, re-run
+the refactor test file to confirm GREEN and re-emit signal.
+
+---
+
+## Proposed remediation (for whoever picks up B1)
+
+```python
+# Add to tests/trainers/test_callback_refactor.py
+
+class TestEpochDashboardRegression:
+    """Lock `float` epoch into `LiveDashboard.update` kwargs. Guards the
+    headline bug this PR fixes: int-cast truncated sub-epoch progress to 0
+    in the TUI, breaking the `X.XX/N` epoch display until epoch completion."""
+
+    def _drive(self, CallbackCls, tmp_path, logs_epoch):
+        from unittest.mock import MagicMock
+        cb = CallbackCls(log_every_n_steps=1, output_dir=str(tmp_path))
+        cb.dashboard = MagicMock()  # bypass real LiveDashboard construction
+        cb.start_time = datetime.now()
+        cb.total_steps = 100
+        cb.total_epochs = 3
+        args = _make_args()
+        args.num_train_epochs = 3
+        cb.on_log(args, _make_state(global_step=1), _make_control(),
+                  logs={"loss": 1.0, "learning_rate": 1e-5, "epoch": logs_epoch})
+        return cb.dashboard.update.call_args
+
+    def test_sft_dashboard_receives_float_epoch(self, tmp_path):
+        from Trainers.sft.src.training_callbacks import LiveDashboardCallback
+        call = self._drive(LiveDashboardCallback, tmp_path / "sft", 0.34)
+        assert call.kwargs["epoch"] == 0.34
+        assert isinstance(call.kwargs["epoch"], float)
+
+    def test_kto_dashboard_receives_float_epoch(self, tmp_path):
+        from Trainers.kto.src.training_callbacks import LiveDashboardCallback
+        call = self._drive(LiveDashboardCallback, tmp_path / "kto", 0.67)
+        assert call.kwargs["epoch"] == 0.67
+        assert isinstance(call.kwargs["epoch"], float)
+
+    def test_grpo_dashboard_receives_float_epoch(self, tmp_path):
+        from Trainers.grpo.src.training_callbacks import LiveDashboardCallback
+        call = self._drive(LiveDashboardCallback, tmp_path / "grpo", 0.12)
+        assert call.kwargs["epoch"] == 0.12
+        assert isinstance(call.kwargs["epoch"], float)
+```
+
+~40 LOC, no GPU, no real HF Trainer, mocks the dashboard so the test
+survives CI environments without rich/LiveDashboard.

--- a/tests/trainers/test_callback_refactor.py
+++ b/tests/trainers/test_callback_refactor.py
@@ -639,3 +639,442 @@ class TestNewKnobsGrepVisible:
         assert SFTMetrics.fields_win_on_collision is False
         assert KTOMetrics.fields_win_on_collision is False
         assert GRPOMetrics.fields_win_on_collision is True
+
+
+# ---------------------------------------------------------------------------
+# M-J — Dashboard metric fallback chains (KTO + GRPO)
+# ---------------------------------------------------------------------------
+
+class TestDashboardMetricFallbacks:
+    """`_dashboard_metrics` uses multi-key fallback chains for trainer-specific
+    metrics. Pins the per-trainer fallback order so a refactor can't silently
+    drop a supported log-key variant.
+
+    - KTO (`kto/training_callbacks.py:82`): `kl` → `logps/rejected` fallback.
+    - GRPO (`grpo/training_callbacks.py:93-103`): `reward` chain is
+      `reward` → `rewards` → `rewards/mean` → `mean_reward`.
+    """
+
+    def test_kto_kl_falls_back_to_logps_rejected(self, tmp_path):
+        from Trainers.kto.src.training_callbacks import LiveDashboardCallback
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, "kto_kl_fallback")
+        args = _dashboard_args()
+        cb.on_log(
+            args,
+            _make_state(global_step=1),
+            _make_control(),
+            logs={"loss": 1.0, "logps/rejected": 0.5},  # no 'kl'
+        )
+        kwargs = cb.dashboard.update.call_args.kwargs
+        assert kwargs["kl"] == 0.5, (
+            f"KTO: expected kl fallback to logs['logps/rejected']=0.5; got {kwargs.get('kl')!r}"
+        )
+
+    def test_kto_kl_preferred_over_logps_rejected(self, tmp_path):
+        """When both keys present, `kl` wins (short-circuit in get-fallback)."""
+        from Trainers.kto.src.training_callbacks import LiveDashboardCallback
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, "kto_kl_preferred")
+        args = _dashboard_args()
+        cb.on_log(
+            args,
+            _make_state(global_step=1),
+            _make_control(),
+            logs={"loss": 1.0, "kl": 0.9, "logps/rejected": 0.1},
+        )
+        kwargs = cb.dashboard.update.call_args.kwargs
+        assert kwargs["kl"] == 0.9
+
+    @pytest.mark.parametrize(
+        "logs_key,logs_value,expected",
+        [
+            ("rewards", 0.7, 0.7),       # no 'reward', falls back to 'rewards'
+            ("rewards/mean", 0.3, 0.3),  # falls back to 'rewards/mean'
+            ("mean_reward", 0.2, 0.2),   # falls back to 'mean_reward'
+        ],
+        ids=["rewards", "rewards_slash_mean", "mean_reward"],
+    )
+    def test_grpo_reward_fallback_chain(self, tmp_path, logs_key, logs_value, expected):
+        from Trainers.grpo.src.training_callbacks import LiveDashboardCallback
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, f"grpo_reward_{logs_key}")
+        args = _dashboard_args()
+        cb.on_log(
+            args,
+            _make_state(global_step=1),
+            _make_control(),
+            logs={"loss": 1.0, logs_key: logs_value},
+        )
+        kwargs = cb.dashboard.update.call_args.kwargs
+        assert kwargs["reward"] == expected, (
+            f"GRPO: logs[{logs_key!r}]={logs_value} should produce reward={expected}; "
+            f"got {kwargs.get('reward')!r}"
+        )
+
+    def test_grpo_reward_preferred_over_fallbacks(self, tmp_path):
+        """When `reward` is present, it wins over all fallback keys."""
+        from Trainers.grpo.src.training_callbacks import LiveDashboardCallback
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, "grpo_reward_preferred")
+        args = _dashboard_args()
+        cb.on_log(
+            args,
+            _make_state(global_step=1),
+            _make_control(),
+            logs={"loss": 1.0, "reward": 0.95, "rewards": 0.1, "rewards/mean": 0.2, "mean_reward": 0.3},
+        )
+        kwargs = cb.dashboard.update.call_args.kwargs
+        assert kwargs["reward"] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# F-A — HealthChecker output format snapshot (stdout capture)
+# ---------------------------------------------------------------------------
+
+class TestHealthCheckerOutputSnapshot:
+    """Frozen-string snapshots of SFT/KTO health-check stdout.
+
+    Design doc §9 risk matrix names 'KTO health-check output format drift' as
+    a medium-likelihood risk. These tests pin the exact warning banner format
+    (100-char bracket lines, emoji prefixes, 'Consider:' footer) so any text
+    change in `Trainers/shared/callbacks/health_checks.py` fails loudly."""
+
+    def test_sft_health_checker_all_branches_snapshot(self, capsys):
+        from Trainers.shared.callbacks.health_checks import SFTHealthChecker
+        checker = SFTHealthChecker()
+        # Drives all three SFT branches: loss-range (loss=500 out of 0..100),
+        # grad-clip (grad_norm=150 > 100), step>50 (step=60, loss=5.0 > 2.0).
+        checker.check(
+            logs={"loss": 500.0, "grad_norm": 150.0},
+            step=60,
+            max_grad_norm=1.0,
+        )
+        out = capsys.readouterr().out
+        # Boundary markers: 100-char "!" lines top + bottom + blank padding.
+        assert out.startswith("\n" + "!" * 100 + "\n"), (
+            f"SFT: missing opening bracket line; got {out[:120]!r}"
+        )
+        assert out.endswith("!" * 100 + "\n\n"), (
+            f"SFT: missing closing bracket line; got {out[-120:]!r}"
+        )
+        # All three warning types present with exact phrasing.
+        assert "⚠ Unusual loss value: 500.0000" in out
+        assert "⚠ High gradient norm: 150.00 → 1.00 (clipped)" in out
+        assert "⚠ Loss remains high after 60 steps: 500.0000" in out
+        # Footer: "Consider:" appears when max_grad_norm is None OR grad_norm > 10*max_grad_norm.
+        # Here grad_norm=150 > 10*1.0=10, so the footer should appear.
+        assert "Consider: reducing learning rate or using tighter gradient clipping" in out
+
+    def test_kto_health_checker_all_branches_snapshot(self, capsys):
+        from Trainers.shared.callbacks.health_checks import KTOHealthChecker
+        checker = KTOHealthChecker()
+        # Drives all four KTO branches: loss-range, margin<-1.0, reward-collapse
+        # (abs(chosen)<0.001, abs(rejected)<0.001, step>10), grad-clip.
+        checker.check(
+            logs={
+                "loss": 500.0,
+                "rewards/margins": -2.5,
+                "rewards/chosen": 0.0,
+                "rewards/rejected": 0.0,
+                "grad_norm": 200.0,
+            },
+            step=20,
+            max_grad_norm=1.0,
+        )
+        out = capsys.readouterr().out
+        assert out.startswith("\n" + "!" * 100 + "\n")
+        assert out.endswith("!" * 100 + "\n\n")
+        assert "⚠ Unusual loss value: 500.0000" in out
+        assert "⚠ Very negative margin: -2.5000 (chosen model may be worse than reference)" in out
+        assert "⚠ Reward collapse detected (both rewards near zero)" in out
+        assert "⚠ High gradient norm: 200.00 → 1.00 (clipped)" in out
+        assert "Consider: reducing learning rate or using tighter gradient clipping" in out
+
+    def test_noop_health_checker_emits_nothing(self, capsys):
+        from Trainers.shared.callbacks.health_checks import NoOpHealthChecker
+        checker = NoOpHealthChecker()
+        checker.check(
+            logs={"loss": 500.0, "grad_norm": 999.0},  # would trigger SFT/KTO warnings
+            step=100,
+            max_grad_norm=1.0,
+        )
+        out = capsys.readouterr().out
+        assert out == "", f"NoOpHealthChecker should emit nothing; got {out!r}"
+
+    def test_sft_no_warnings_when_healthy(self, capsys):
+        """Clean-path: no warnings means no stdout output (early-return via _print_warnings)."""
+        from Trainers.shared.callbacks.health_checks import SFTHealthChecker
+        checker = SFTHealthChecker()
+        checker.check(
+            logs={"loss": 0.5, "grad_norm": 1.0},
+            step=10,
+            max_grad_norm=1.0,
+        )
+        out = capsys.readouterr().out
+        assert out == "", f"SFT with healthy metrics should emit nothing; got {out!r}"
+
+
+# ---------------------------------------------------------------------------
+# F-B — capture_runtime_capacity_snapshot GPU branch
+# ---------------------------------------------------------------------------
+
+class _StubDeviceProps:
+    def __init__(self, name="FakeGPU-H100", total_memory=80 * (1024 ** 3)):
+        self.name = name
+        self.total_memory = total_memory
+
+
+def _make_stub_torch(*, cuda_available: bool, total=80 * (1024 ** 3),
+                     reserved=40 * (1024 ** 3), allocated=20 * (1024 ** 3),
+                     max_reserved=60 * (1024 ** 3), max_allocated=50 * (1024 ** 3)):
+    """Build a minimal torch stub matching `capture_runtime_capacity_snapshot`'s
+    attribute reads: `.cuda.is_available/memory_reserved/memory_allocated/
+    max_memory_reserved/max_memory_allocated/get_device_properties`."""
+    cuda_ns = SimpleNamespace(
+        is_available=lambda: cuda_available,
+        memory_reserved=lambda idx=0: reserved,
+        memory_allocated=lambda idx=0: allocated,
+        max_memory_reserved=lambda idx=0: max_reserved,
+        max_memory_allocated=lambda idx=0: max_allocated,
+        get_device_properties=lambda idx=0: _StubDeviceProps(total_memory=total),
+    )
+    return SimpleNamespace(cuda=cuda_ns)
+
+
+class TestCaptureRuntimeCapacitySnapshotGpuBranch:
+    """Exercise the GPU-branch of `capture_runtime_capacity_snapshot` via a
+    torch_module stub. Covers the 18-field GPU block at
+    `shared/training_capacity.py:218-238` plus OOM-risk classification."""
+
+    def test_gpu_branch_fields_present_and_shaped(self):
+        from shared.training_capacity import capture_runtime_capacity_snapshot
+        # reserved=40GB/80GB=50%, max_reserved=60GB/80GB=75% -> oom_risk=low.
+        torch_stub = _make_stub_torch(cuda_available=True)
+        snap = capture_runtime_capacity_snapshot(torch_module=torch_stub)
+
+        # GPU identity + totals.
+        assert snap["gpu_name"] == "FakeGPU-H100"
+        assert snap["gpu_total_memory_gb"] == 80.0
+        # Current values (reserved = the UI-facing "gpu_memory_gb").
+        assert snap["gpu_memory_gb"] == 40.0
+        assert snap["gpu_memory_reserved_gb"] == 40.0
+        assert snap["gpu_memory_allocated_gb"] == 20.0
+        # Peaks.
+        assert snap["max_gpu_memory_reserved_gb"] == 60.0
+        assert snap["max_gpu_memory_allocated_gb"] == 50.0
+        # Percentages.
+        assert snap["gpu_memory_reserved_pct"] == 50.0
+        assert snap["gpu_memory_allocated_pct"] == 25.0
+        assert snap["max_gpu_memory_reserved_pct"] == 75.0
+        assert snap["max_gpu_memory_allocated_pct"] == 62.5
+        # Headroom.
+        assert snap["gpu_memory_reserved_headroom_gb"] == 40.0
+        assert snap["gpu_memory_allocated_headroom_gb"] == 60.0
+        # OOM risk at 75% max_reserved → "low" (<85%).
+        assert snap["oom_risk_level"] == "low"
+
+    def test_gpu_branch_high_oom_risk_classification(self):
+        from shared.training_capacity import capture_runtime_capacity_snapshot
+        # max_reserved=77GB / 80GB = 96.25% -> oom_risk=high (>=92%, <97%).
+        torch_stub = _make_stub_torch(
+            cuda_available=True,
+            max_reserved=77 * (1024 ** 3),
+        )
+        snap = capture_runtime_capacity_snapshot(torch_module=torch_stub)
+        assert snap["oom_risk_level"] == "high"
+
+    def test_cpu_only_omits_gpu_fields(self):
+        from shared.training_capacity import capture_runtime_capacity_snapshot
+        torch_stub = _make_stub_torch(cuda_available=False)
+        snap = capture_runtime_capacity_snapshot(torch_module=torch_stub)
+        # No GPU fields at all.
+        for key in ("gpu_name", "gpu_total_memory_gb", "gpu_memory_gb",
+                    "gpu_memory_reserved_gb", "oom_risk_level"):
+            assert key not in snap, f"CPU-only snapshot leaked GPU key {key!r}"
+        # System RAM fields should still be populated (psutil / sysconf available on CI).
+        assert "system_ram_total_gb" in snap or "system_ram_used_gb" in snap or True
+        # The `or True` above guards against test env having no psutil/sysconf; we
+        # only strictly assert the GPU-fields-omitted invariant.
+
+
+# ---------------------------------------------------------------------------
+# F-C — suppress_training_logs context manager
+# ---------------------------------------------------------------------------
+
+class TestSuppressTrainingLogs:
+    """Direct coverage of `Trainers.shared.callbacks.log_suppression.suppress_training_logs`.
+
+    Two paths:
+    - `_SUPPRESS_AVAILABLE=True`: returns `shared.ui.suppress_logs(...)` context
+      that raises noisy-logger levels to WARNING inside the block.
+    - `_SUPPRESS_AVAILABLE=False`: returns `contextlib.nullcontext()` — a no-op
+      fallback when `shared.ui` is unimportable."""
+
+    def test_returns_context_manager(self):
+        from Trainers.shared.callbacks.log_suppression import suppress_training_logs
+        ctx = suppress_training_logs()
+        # Must be a usable context manager regardless of availability branch.
+        assert hasattr(ctx, "__enter__") and hasattr(ctx, "__exit__")
+        with ctx:
+            pass  # no-op block executes without error
+
+    def test_nullcontext_fallback_when_unavailable(self, monkeypatch):
+        """When `_SUPPRESS_AVAILABLE` is False, suppress_training_logs returns
+        nullcontext — the block runs without side-effects on logger levels."""
+        import Trainers.shared.callbacks.log_suppression as mod
+        from contextlib import nullcontext
+        monkeypatch.setattr(mod, "_SUPPRESS_AVAILABLE", False)
+
+        ctx = mod.suppress_training_logs()
+        # nullcontext class check.
+        assert isinstance(ctx, type(nullcontext())), (
+            f"Expected nullcontext instance when unavailable; got {type(ctx).__name__}"
+        )
+
+    def test_available_branch_delegates_to_suppress_logs(self, monkeypatch):
+        """When `_SUPPRESS_AVAILABLE=True`, the call is delegated to
+        `shared.ui.suppress_logs(_NOISY_LOGGERS, level=logging.WARNING)`.
+        Verify the delegation args without depending on the real suppress_logs
+        implementation."""
+        import Trainers.shared.callbacks.log_suppression as mod
+        import logging
+
+        captured = {}
+
+        def fake_suppress_logs(loggers, level):
+            captured["loggers"] = list(loggers)
+            captured["level"] = level
+            from contextlib import nullcontext
+            return nullcontext()
+
+        monkeypatch.setattr(mod, "_SUPPRESS_AVAILABLE", True)
+        monkeypatch.setattr(mod, "suppress_logs", fake_suppress_logs, raising=False)
+
+        mod.suppress_training_logs()
+
+        assert captured["level"] == logging.WARNING
+        # The canonical noisy-logger list must be passed through verbatim.
+        assert "unsloth" in captured["loggers"]
+        assert "transformers" in captured["loggers"]
+        assert "trl" in captured["loggers"]
+        # Full list lock: pin exact membership so an accidental reorder/removal fails.
+        assert captured["loggers"] == [
+            "unsloth", "transformers", "datasets", "accelerate",
+            "trl", "peft", "bitsandbytes", "torch", "huggingface_hub",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# F-D — JSONL row shape+value parity vs frozen baseline (restricted scope)
+# ---------------------------------------------------------------------------
+#
+# NOTE: the test-engineer reviewer previously recommended AGAINST byte-level
+# parity at the current STANDARD risk tier. User chose 'Address now'. Honest
+# scope note: after stripping all non-deterministic fields (timestamps,
+# capacity/GPU snapshots, interval timing, nvidia-smi output), the parity
+# test reduces to a key+value check on step, loss, learning_rate, epoch —
+# overlapping with TestSftJsonlShape + TestDictMergeOrder. The stripped
+# fields are precisely the ones where byte-parity would have added value,
+# but they are inherently non-deterministic and cannot be frozen.
+#
+# Value delivered: catches regressions in step-counter drift, log key
+# passthrough, and int/float type drift across a multi-step run. Does NOT
+# catch regressions in timing/capacity/interval field computation.
+# ---------------------------------------------------------------------------
+
+# Non-deterministic keys that must be stripped before frozen-baseline diff.
+_NONDETERMINISTIC_FIELDS = frozenset({
+    "timestamp",
+    "interval_time", "interval_seconds",
+    "elapsed_seconds", "steps_per_second", "samples_per_sec",
+    # Capacity/GPU snapshot — machine/run-specific.
+    "gpu_name", "gpu_total_memory_gb", "gpu_memory_gb",
+    "gpu_memory_reserved_gb", "gpu_memory_allocated_gb",
+    "max_gpu_memory_reserved_gb", "max_gpu_memory_allocated_gb",
+    "gpu_memory_reserved_pct", "gpu_memory_allocated_pct",
+    "max_gpu_memory_reserved_pct", "max_gpu_memory_allocated_pct",
+    "gpu_memory_reserved_headroom_gb", "gpu_memory_allocated_headroom_gb",
+    "max_gpu_memory_reserved_headroom_gb", "max_gpu_memory_allocated_headroom_gb",
+    "gpu_utilization_pct", "gpu_vram_used_gb", "gpu_vram_total_gb",
+    "gpu_vram_utilization_pct",
+    "oom_risk_level",
+    "system_ram_total_gb", "system_ram_used_gb", "system_ram_available_gb",
+    "process_ram_gb",
+    "cloud_provider", "cloud_gpu_type",
+})
+
+
+def _strip_nondeterministic(row: dict) -> dict:
+    return {k: v for k, v in row.items() if k not in _NONDETERMINISTIC_FIELDS}
+
+
+class TestSftJsonlParityBaseline:
+    """Shape+value parity of SFT JSONL rows across a synthetic 10-step run.
+
+    Drives the SFT MetricsTableCallback with deterministic logs over steps 1..10
+    at log_every_n_steps=1 (log_every_write bypass not needed — SFT writes only
+    at boundaries, and every step is a boundary here). Strips non-deterministic
+    fields, compares the remainder against an expected baseline built inline.
+
+    This test's actual reach: step counter integrity + logs passthrough + type
+    stability across many calls. It does NOT cover timing/capacity math."""
+
+    def test_sft_ten_step_synthetic_run_matches_baseline(self, tmp_path):
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        cb = SFTMetrics(log_every_n_steps=1, output_dir=str(tmp_path / "sft_parity"))
+        _begin(cb)
+        args = _make_args()
+
+        # Drive 10 deterministic on_log calls.
+        for step in range(1, 11):
+            cb.on_log(
+                args,
+                _make_state(global_step=step, max_steps=10, epoch=step * 0.1),
+                _make_control(),
+                logs={
+                    "loss": round(1.0 + step * 0.1, 3),
+                    "learning_rate": 1e-5,
+                    "epoch": round(step * 0.1, 2),
+                    "grad_norm": round(0.01 * step, 3),
+                },
+            )
+
+        rows = _read_jsonl_rows(cb.log_file)
+        assert len(rows) == 10, f"Expected 10 rows from 10 on_log calls, got {len(rows)}"
+
+        stripped = [_strip_nondeterministic(r) for r in rows]
+
+        # Frozen expected baseline after stripping non-deterministic fields.
+        # Any drift in step/log passthrough/types fails this test.
+        expected = [
+            {
+                "step": step,
+                "loss": round(1.0 + step * 0.1, 3),
+                "learning_rate": 1e-5,
+                "epoch": round(step * 0.1, 2),
+                "grad_norm": round(0.01 * step, 3),
+            }
+            for step in range(1, 11)
+        ]
+
+        assert stripped == expected, (
+            f"SFT JSONL parity failure. "
+            f"First diff at row 0: stripped={stripped[0]!r} vs expected={expected[0]!r}"
+        )
+
+    def test_sft_row_types_stable_across_run(self, tmp_path):
+        """Type-stability guard: across a multi-step run, `step` stays int,
+        `loss`/`learning_rate`/`epoch`/`grad_norm` stay float. Catches type
+        drift that shape-only tests might miss on a single-step call."""
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        cb = SFTMetrics(log_every_n_steps=1, output_dir=str(tmp_path / "sft_types"))
+        _begin(cb)
+        args = _make_args()
+        for step in range(1, 6):
+            cb.on_log(args, _make_state(global_step=step), _make_control(),
+                      logs={"loss": 1.5, "learning_rate": 1e-5, "epoch": 0.1 * step, "grad_norm": 0.1})
+
+        rows = _read_jsonl_rows(cb.log_file)
+        for i, row in enumerate(rows):
+            assert isinstance(row["step"], int), f"row {i}: step not int"
+            assert isinstance(row["loss"], float), f"row {i}: loss not float"
+            assert isinstance(row["learning_rate"], float), f"row {i}: learning_rate not float"
+            assert isinstance(row["epoch"], float), f"row {i}: epoch not float"
+            assert isinstance(row["grad_norm"], float), f"row {i}: grad_norm not float"

--- a/tests/trainers/test_callback_refactor.py
+++ b/tests/trainers/test_callback_refactor.py
@@ -1,0 +1,384 @@
+"""Targeted tests for the sft/kto/grpo callback DRY refactor.
+
+Verifies the four uncertainties flagged by the architect and coder on the
+callback refactor design (docs/architecture/training-callbacks-refactor.md):
+
+  1. [MEDIUM] KTO cloud_provider env-first resolution (intentional additive
+     change for KTO per §6 — env wins over args).
+  2. [MEDIUM] `log_every_write` cadence knob — SFT writes only at
+     log_every_n_steps boundary; KTO writes every on_log.
+  3. [MEDIUM] GRPO dict-merge order — `**logs` spreads last, so log keys
+     override base's fixed fields (coder's unification direction).
+  4. [HIGH] GRPO `interval_seconds` key preservation — not `interval_time`.
+
+Plus an SFT shape-only test asserting the JSONL row shape is sane
+(keys + types). No pre-refactor baseline rows were captured, so parity is
+asserted by shape, not byte-identity — documented in the handoff.
+
+All tests are unit-level. `TrainerState` / `TrainingArguments` are hand-
+constructed as SimpleNamespace stubs. No GPU, no real training, no network.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# Make Trainers.shared.callbacks importable + each trainer's src/ importable.
+WORKTREE_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(WORKTREE_ROOT))
+sys.path.insert(0, str(WORKTREE_ROOT / "Trainers" / "sft" / "src"))
+sys.path.insert(0, str(WORKTREE_ROOT / "Trainers" / "kto" / "src"))
+sys.path.insert(0, str(WORKTREE_ROOT / "Trainers" / "grpo" / "src"))
+
+
+# ---------------------------------------------------------------------------
+# Stubs for HF TrainerState / TrainingArguments (no GPU, no HF Trainer)
+# ---------------------------------------------------------------------------
+
+def _make_state(global_step: int = 1, max_steps: int = 100, epoch: float = 0.1):
+    return SimpleNamespace(global_step=global_step, max_steps=max_steps, epoch=epoch)
+
+
+def _make_args(cloud_provider=None, max_grad_norm=1.0):
+    """Minimal TrainingArguments stub — only attributes `on_log` reads."""
+    ns = SimpleNamespace(
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=1,
+        max_grad_norm=max_grad_norm,
+        output_dir="./stub_output",
+    )
+    if cloud_provider is not None:
+        ns.cloud_provider = cloud_provider
+    return ns
+
+
+def _make_control():
+    return SimpleNamespace()
+
+
+def _read_jsonl_rows(path: Path):
+    if not path.exists():
+        return []
+    with open(path, "r", encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — per-trainer callback instances writing into tmp_path
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sft_callback(tmp_path):
+    from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+    cb = SFTMetrics(log_every_n_steps=5, output_dir=str(tmp_path / "sft_out"))
+    return cb
+
+
+@pytest.fixture
+def kto_callback(tmp_path):
+    from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+    cb = KTOMetrics(log_every_n_steps=5, output_dir=str(tmp_path / "kto_out"))
+    return cb
+
+
+@pytest.fixture
+def grpo_callback(tmp_path):
+    from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+    cb = GRPOMetrics(log_every_n_steps=5, output_dir=str(tmp_path / "grpo_out"))
+    return cb
+
+
+def _begin(cb, state=None):
+    """Call on_train_begin with default stubs so timing + symlink state is valid."""
+    args = _make_args()
+    control = _make_control()
+    state = state or _make_state()
+    cb.on_train_begin(args, state, control)
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty #1 — KTO cloud_provider env-first (intentional additive, §6)
+# ---------------------------------------------------------------------------
+
+class TestKtoCloudProviderEnvWins:
+    """KTO previously read args.cloud_provider only. Refactor makes env win
+    over args across all trainers. This verifies the env-first precedence
+    lands in KTO's JSONL log rows."""
+
+    def test_env_overrides_args(self, kto_callback, monkeypatch):
+        monkeypatch.setenv("CLOUD_PROVIDER", "hf-jobs")
+        _begin(kto_callback)
+        args = _make_args(cloud_provider="local")
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0, "learning_rate": 1e-5})
+
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert rows, "KTO should have written a row on first on_log (log_every_write=True)"
+        assert rows[0]["cloud_provider"] == "hf-jobs", (
+            f"env-first precedence lost: {rows[0].get('cloud_provider')!r}"
+        )
+
+    def test_args_fallback_when_env_absent(self, kto_callback, monkeypatch):
+        monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+        _begin(kto_callback)
+        args = _make_args(cloud_provider="runpod")
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0, "learning_rate": 1e-5})
+
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert rows[0]["cloud_provider"] == "runpod"
+
+    def test_env_empty_falls_back_to_args(self, kto_callback, monkeypatch):
+        # resolve_cloud_provider strips env; empty-string env must not win.
+        monkeypatch.setenv("CLOUD_PROVIDER", "  ")
+        _begin(kto_callback)
+        args = _make_args(cloud_provider="runpod")
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0})
+
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert rows[0]["cloud_provider"] == "runpod"
+
+    def test_neither_set_omits_key(self, kto_callback, monkeypatch):
+        monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+        _begin(kto_callback)
+        # args has no cloud_provider attr -> getattr default None -> key omitted.
+        args = _make_args(cloud_provider=None)
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0})
+
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert "cloud_provider" not in rows[0], (
+            "cloud_provider key must be absent when resolve returns None"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty #2 — log_every_write cadence single-knob preservation
+# ---------------------------------------------------------------------------
+
+class TestLogEveryWriteCadence:
+    """SFT (log_every_write=False) writes only at log_every_n_steps boundaries.
+    KTO + GRPO (log_every_write=True) write on every on_log call."""
+
+    def test_sft_skips_non_boundary_steps(self, sft_callback):
+        _begin(sft_callback)
+        args = _make_args()
+        # log_every_n_steps=5, so steps 1,2,3,4 must NOT write; step 5 must write.
+        for step in (1, 2, 3, 4):
+            sft_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                logs={"loss": 1.0, "learning_rate": 1e-5})
+        rows_before = _read_jsonl_rows(sft_callback.log_file)
+        assert rows_before == [], f"SFT wrote at non-boundary step: {rows_before}"
+
+        sft_callback.on_log(args, _make_state(global_step=5), _make_control(),
+                            logs={"loss": 1.0, "learning_rate": 1e-5})
+        rows_after = _read_jsonl_rows(sft_callback.log_file)
+        assert len(rows_after) == 1, f"SFT expected 1 row at boundary, got {len(rows_after)}"
+
+    def test_kto_writes_every_on_log(self, kto_callback):
+        _begin(kto_callback)
+        args = _make_args()
+        for step in (1, 2, 3):
+            kto_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                logs={"loss": 1.0, "learning_rate": 1e-5})
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert len(rows) == 3, f"KTO expected 3 rows (one per on_log), got {len(rows)}"
+
+    def test_grpo_writes_every_on_log(self, grpo_callback):
+        _begin(grpo_callback)
+        args = _make_args()
+        for step in (1, 2, 3):
+            grpo_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                 logs={"loss": 1.0, "learning_rate": 1e-5})
+        rows = _read_jsonl_rows(grpo_callback.log_file)
+        assert len(rows) == 3, f"GRPO expected 3 rows (one per on_log), got {len(rows)}"
+
+    def test_cadence_knob_is_class_attr(self):
+        """The design's single-knob claim: `log_every_write` must be grep-visible
+        as a class attribute, so reviewers can audit JSONL write behavior at a
+        glance (per §5 of the architecture doc)."""
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+        from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+
+        assert SFTMetrics.log_every_write is False
+        assert KTOMetrics.log_every_write is True
+        assert GRPOMetrics.log_every_write is True
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty #3 — dict-merge order: logs spread last, logs win
+# ---------------------------------------------------------------------------
+
+class TestDictMergeOrder:
+    """Coder unified the entry-dict build so `**logs` is the LAST spread,
+    meaning any key present in `logs` overrides base's fixed field. This is
+    intentional: trainers produce canonical log rows (e.g. TRL's own `step`
+    from its internal log callback) that should shine through."""
+
+    def test_logs_step_overrides_state_step_grpo(self, grpo_callback):
+        _begin(grpo_callback)
+        args = _make_args()
+        # State says step=1 but logs carry step=42 (simulating TRL-emitted logs).
+        grpo_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                             logs={"loss": 1.0, "step": 42})
+        rows = _read_jsonl_rows(grpo_callback.log_file)
+        assert rows[0]["step"] == 42, (
+            f"logs['step'] must win over state.global_step; got {rows[0]['step']}"
+        )
+
+    def test_logs_loss_appears_verbatim(self, grpo_callback):
+        _begin(grpo_callback)
+        args = _make_args()
+        grpo_callback.on_log(args, _make_state(global_step=7), _make_control(),
+                             logs={"loss": 0.1234, "learning_rate": 2.5e-5,
+                                   "reward": 0.88})
+        rows = _read_jsonl_rows(grpo_callback.log_file)
+        row = rows[0]
+        assert row["loss"] == 0.1234
+        assert row["learning_rate"] == 2.5e-5
+        assert row["reward"] == 0.88
+
+    def test_logs_can_override_elapsed_keys_if_present(self, kto_callback):
+        """Shape-parity guard: if someone ever emits a conflicting key in logs,
+        dict-merge order ensures logs wins, preventing silent field masking."""
+        _begin(kto_callback)
+        args = _make_args()
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0, "steps_per_second": 999.9})
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        assert rows[0]["steps_per_second"] == 999.9
+
+
+# ---------------------------------------------------------------------------
+# Uncertainty #4 — GRPO `interval_seconds` key preservation [HIGH]
+# ---------------------------------------------------------------------------
+
+class TestGrpoIntervalKey:
+    """GRPO's original JSONL schema uses `interval_seconds`, not the
+    `interval_time` key SFT + KTO use. The refactor preserves this via the
+    `interval_key_name` class attr. If this flips, downstream parsers break."""
+
+    def test_grpo_emits_interval_seconds(self, grpo_callback):
+        _begin(grpo_callback)
+        args = _make_args()
+        grpo_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                             logs={"loss": 1.0})
+        rows = _read_jsonl_rows(grpo_callback.log_file)
+        row = rows[0]
+        assert "interval_seconds" in row, (
+            f"GRPO row must contain 'interval_seconds'; keys={list(row.keys())}"
+        )
+        assert "interval_time" not in row, (
+            f"GRPO row must NOT contain 'interval_time'; keys={list(row.keys())}"
+        )
+
+    def test_sft_emits_interval_time(self, sft_callback):
+        """Complement: SFT stays on `interval_time` (default)."""
+        _begin(sft_callback)
+        args = _make_args()
+        sft_callback.on_log(args, _make_state(global_step=5), _make_control(),
+                            logs={"loss": 1.0})
+        rows = _read_jsonl_rows(sft_callback.log_file)
+        row = rows[0]
+        assert "interval_time" in row
+        assert "interval_seconds" not in row
+
+    def test_kto_emits_interval_time(self, kto_callback):
+        _begin(kto_callback)
+        args = _make_args()
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0})
+        rows = _read_jsonl_rows(kto_callback.log_file)
+        row = rows[0]
+        assert "interval_time" in row
+        assert "interval_seconds" not in row
+
+    def test_interval_key_class_attr_is_grep_visible(self):
+        """Same single-knob visibility guarantee as log_every_write."""
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+        from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+
+        assert SFTMetrics.interval_key_name == "interval_time"
+        assert KTOMetrics.interval_key_name == "interval_time"
+        assert GRPOMetrics.interval_key_name == "interval_seconds"
+
+
+# ---------------------------------------------------------------------------
+# SFT JSONL row shape — shape-only parity check
+# ---------------------------------------------------------------------------
+
+class TestSftJsonlShape:
+    """Shape-only parity: no pre-refactor baseline rows captured. This test
+    asserts the canonical SFT JSONL row shape (keys + types) that the base
+    class produces, so future refactors can catch silent field drift."""
+
+    def test_sft_row_has_required_keys_and_types(self, sft_callback):
+        _begin(sft_callback)
+        args = _make_args()
+        sft_callback.on_log(args, _make_state(global_step=5, max_steps=100, epoch=0.25),
+                            _make_control(),
+                            logs={"loss": 0.5, "learning_rate": 1e-5,
+                                  "grad_norm": 0.1, "epoch": 0.25})
+        rows = _read_jsonl_rows(sft_callback.log_file)
+        assert len(rows) == 1
+        row = rows[0]
+
+        # Required base fields.
+        assert isinstance(row["step"], int)
+        assert row["step"] == 5
+        assert isinstance(row["timestamp"], str)
+        assert isinstance(row["interval_time"], (int, float))
+        assert isinstance(row["elapsed_seconds"], (int, float))
+        assert isinstance(row["steps_per_second"], (int, float))
+        assert isinstance(row["samples_per_sec"], (int, float))
+
+        # Logs fields passed through.
+        assert row["loss"] == 0.5
+        assert row["learning_rate"] == 1e-5
+        assert row["grad_norm"] == 0.1
+        assert row["epoch"] == 0.25
+
+
+# ---------------------------------------------------------------------------
+# Bonus: resolve_cloud_provider direct unit coverage
+# ---------------------------------------------------------------------------
+
+class TestResolveCloudProvider:
+    """Direct unit coverage of the helper — documents precedence exhaustively."""
+
+    def test_env_wins(self, monkeypatch):
+        from Trainers.shared.callbacks import resolve_cloud_provider
+        monkeypatch.setenv("CLOUD_PROVIDER", "hf-jobs")
+        args = SimpleNamespace(cloud_provider="local")
+        assert resolve_cloud_provider(args) == "hf-jobs"
+
+    def test_env_absent_uses_args(self, monkeypatch):
+        from Trainers.shared.callbacks import resolve_cloud_provider
+        monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+        args = SimpleNamespace(cloud_provider="local")
+        assert resolve_cloud_provider(args) == "local"
+
+    def test_env_and_args_absent_returns_none(self, monkeypatch):
+        from Trainers.shared.callbacks import resolve_cloud_provider
+        monkeypatch.delenv("CLOUD_PROVIDER", raising=False)
+        args = SimpleNamespace()  # no attribute
+        assert resolve_cloud_provider(args) is None
+
+    def test_empty_env_falls_back_to_args(self, monkeypatch):
+        from Trainers.shared.callbacks import resolve_cloud_provider
+        monkeypatch.setenv("CLOUD_PROVIDER", "")
+        args = SimpleNamespace(cloud_provider="local")
+        assert resolve_cloud_provider(args) == "local"
+
+    def test_whitespace_env_falls_back_to_args(self, monkeypatch):
+        from Trainers.shared.callbacks import resolve_cloud_provider
+        monkeypatch.setenv("CLOUD_PROVIDER", "   ")
+        args = SimpleNamespace(cloud_provider="local")
+        assert resolve_cloud_provider(args) == "local"

--- a/tests/trainers/test_callback_refactor.py
+++ b/tests/trainers/test_callback_refactor.py
@@ -1,15 +1,25 @@
 """Targeted tests for the sft/kto/grpo callback DRY refactor.
 
 Verifies the four uncertainties flagged by the architect and coder on the
-callback refactor design (docs/architecture/training-callbacks-refactor.md):
+callback refactor design (docs/architecture/training-callbacks-refactor.md),
+plus the B1/B2/B3 remediations from PR #85 peer review:
 
   1. [MEDIUM] KTO cloud_provider env-first resolution (intentional additive
      change for KTO per §6 — env wins over args).
   2. [MEDIUM] `log_every_write` cadence knob — SFT writes only at
      log_every_n_steps boundary; KTO writes every on_log.
-  3. [MEDIUM] GRPO dict-merge order — `**logs` spreads last, so log keys
-     override base's fixed fields (coder's unification direction).
-  4. [HIGH] GRPO `interval_seconds` key preservation — not `interval_time`.
+  3. [MEDIUM] Dict-merge order — per-trainer `fields_win_on_collision`
+     class attr (SFT/KTO default False = logs-win; GRPO override True =
+     fields-win, matching pre-refactor GRPO behavior).
+  4. [HIGH]   GRPO `interval_seconds` key preservation — not `interval_time`.
+  5. [B1]    SFT cadence gating — `health_checker.check()` and
+     `last_log_time` update fire only at modulo boundary for SFT (matches
+     pre-refactor top-of-on_log early-return behavior). KTO/GRPO fire
+     every on_log call.
+  6. [B3]    Epoch float-cast regression — `dashboard.update(epoch=...)`
+     receives a float, not an int, so sub-epoch progress (e.g. 0.34) is
+     not truncated to 0. Guards against re-introducing
+     `int(logs.get('epoch', 0))` in BaseLiveDashboardCallback.on_log.
 
 Plus an SFT shape-only test asserting the JSONL row shape is sane
 (keys + types). No pre-refactor baseline rows were captured, so parity is
@@ -24,6 +34,7 @@ import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -216,20 +227,39 @@ class TestLogEveryWriteCadence:
 # ---------------------------------------------------------------------------
 
 class TestDictMergeOrder:
-    """Coder unified the entry-dict build so `**logs` is the LAST spread,
-    meaning any key present in `logs` overrides base's fixed field. This is
-    intentional: trainers produce canonical log rows (e.g. TRL's own `step`
-    from its internal log callback) that should shine through."""
+    """Per-trainer collision precedence, controlled by `fields_win_on_collision`.
 
-    def test_logs_step_overrides_state_step_grpo(self, grpo_callback):
+    SFT + KTO (default False): logs win on collision — preserves pre-refactor
+    `{**our_fields, **capacity, **logs}` build order.
+
+    GRPO (override True): our_fields win on collision — preserves pre-refactor
+    `entry = dict(logs); entry[k]=v; entry.update(cap)` build order."""
+
+    def test_grpo_fields_win_state_step_overrides_logs_step(self, grpo_callback):
+        """GRPO: state.global_step wins over logs['step'] — matches pre-refactor
+        GRPO build order where our fields + capacity were applied AFTER logs."""
         _begin(grpo_callback)
         args = _make_args()
-        # State says step=1 but logs carry step=42 (simulating TRL-emitted logs).
+        # State says step=1 but logs carry step=42; GRPO's fields_win_on_collision
+        # means step=1 (from state) overrides logs['step']=42.
         grpo_callback.on_log(args, _make_state(global_step=1), _make_control(),
                              logs={"loss": 1.0, "step": 42})
         rows = _read_jsonl_rows(grpo_callback.log_file)
+        assert rows[0]["step"] == 1, (
+            f"GRPO fields_win_on_collision=True: state.global_step must override "
+            f"logs['step']; got {rows[0]['step']}"
+        )
+
+    def test_kto_logs_win_logs_step_overrides_state_step(self, kto_callback):
+        """KTO: logs['step'] wins — default fields_win_on_collision=False."""
+        _begin(kto_callback)
+        args = _make_args()
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0, "step": 42})
+        rows = _read_jsonl_rows(kto_callback.log_file)
         assert rows[0]["step"] == 42, (
-            f"logs['step'] must win over state.global_step; got {rows[0]['step']}"
+            f"KTO fields_win_on_collision=False: logs['step'] must win over "
+            f"state.global_step; got {rows[0]['step']}"
         )
 
     def test_logs_loss_appears_verbatim(self, grpo_callback):
@@ -382,3 +412,230 @@ class TestResolveCloudProvider:
         monkeypatch.setenv("CLOUD_PROVIDER", "   ")
         args = SimpleNamespace(cloud_provider="local")
         assert resolve_cloud_provider(args) == "local"
+
+
+# ---------------------------------------------------------------------------
+# B3 — Epoch float-cast regression (dashboard.update kwargs path)
+# ---------------------------------------------------------------------------
+
+def _make_dashboard_cb(cb_cls, tmp_path, subdir: str):
+    """Build a BaseLiveDashboardCallback subclass with a mocked dashboard.
+
+    Bypasses `DASHBOARD_AVAILABLE` / `RICH_AVAILABLE` gates by setting
+    `cb.dashboard` directly and seeding `cb.start_time` so on_log does not
+    trip on unset timing state.
+    """
+    from datetime import datetime
+    cb = cb_cls(log_every_n_steps=1, output_dir=str(tmp_path / subdir))
+    cb.dashboard = MagicMock()
+    cb.start_time = datetime.now()
+    cb.total_steps = 100
+    cb.total_epochs = 3
+    return cb
+
+
+def _dashboard_args():
+    """TrainingArguments stub the LiveDashboardCallback.on_log body reads."""
+    return SimpleNamespace(
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=1,
+        max_grad_norm=1.0,
+        num_train_epochs=3,
+        output_dir="./stub",
+    )
+
+
+class TestEpochDashboardRegression:
+    """Regression guard for the PR #85 headline bug: epoch counter stuck at 0/X
+    in the TUI dashboard because `dashboard.update(epoch=int(logs.get('epoch', 0)))`
+    truncated sub-epoch progress (0.34 -> 0). Fix: cast to float.
+
+    These tests assert `mock_dashboard.update.call_args.kwargs['epoch']` is a
+    float ≈ the sub-epoch value the trainer emitted. If someone re-introduces
+    the int-cast, these tests fail loudly (0 != 0.34)."""
+
+    @pytest.mark.parametrize("trainer_name", ["sft", "kto", "grpo"])
+    def test_epoch_passed_as_float_to_dashboard_update(self, tmp_path, trainer_name):
+        if trainer_name == "sft":
+            from Trainers.sft.src.training_callbacks import LiveDashboardCallback
+        elif trainer_name == "kto":
+            from Trainers.kto.src.training_callbacks import LiveDashboardCallback
+        else:
+            from Trainers.grpo.src.training_callbacks import LiveDashboardCallback
+
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, f"{trainer_name}_dash")
+        args = _dashboard_args()
+
+        # log_every_n_steps=1, so every on_log call triggers a dashboard.update.
+        cb.on_log(
+            args,
+            _make_state(global_step=1, max_steps=100, epoch=0.34),
+            _make_control(),
+            logs={"loss": 1.0, "learning_rate": 1e-5, "epoch": 0.34},
+        )
+
+        assert cb.dashboard.update.called, (
+            f"{trainer_name}: expected dashboard.update(...) to be called once"
+        )
+        kwargs = cb.dashboard.update.call_args.kwargs
+        assert "epoch" in kwargs, f"{trainer_name}: epoch kwarg missing from update()"
+        epoch_val = kwargs["epoch"]
+        # Regression guard #1: must be float, not int.
+        assert isinstance(epoch_val, float), (
+            f"{trainer_name}: epoch must be float (regression); got "
+            f"{type(epoch_val).__name__}={epoch_val!r}"
+        )
+        # Regression guard #2: must preserve sub-epoch precision.
+        assert abs(epoch_val - 0.34) < 1e-9, (
+            f"{trainer_name}: epoch value truncated; got {epoch_val!r}, expected ~0.34"
+        )
+        # Regression guard #3: explicitly not the truncated int-cast value.
+        assert epoch_val != 0, (
+            f"{trainer_name}: epoch truncated to 0 — int() cast regression"
+        )
+
+    def test_epoch_none_falls_back_to_zero_float(self, tmp_path):
+        """When logs omits 'epoch', the `or 0.0` fallback yields 0.0 (float),
+        not 0 (int). Covers the right-hand side of `float(... or 0.0)`."""
+        from Trainers.sft.src.training_callbacks import LiveDashboardCallback
+        cb = _make_dashboard_cb(LiveDashboardCallback, tmp_path, "sft_dash_none")
+        args = _dashboard_args()
+
+        cb.on_log(
+            args,
+            _make_state(global_step=1),
+            _make_control(),
+            logs={"loss": 1.0, "learning_rate": 1e-5},  # no 'epoch'
+        )
+        epoch_val = cb.dashboard.update.call_args.kwargs["epoch"]
+        assert isinstance(epoch_val, float)
+        assert epoch_val == 0.0
+
+
+# ---------------------------------------------------------------------------
+# B1 — SFT cadence gating: health_check + last_log_time modulo gate
+# ---------------------------------------------------------------------------
+
+class TestSftCadenceGating:
+    """SFT overrides `health_check_every_on_log=False` and
+    `interval_time_updates_every_on_log=False`. Pre-refactor SFT gated the
+    entire on_log body on the interval multiple, so health checks and
+    last_log_time updates fired only at printed-row cadence. KTO + GRPO
+    (defaults True) fired them every on_log. These tests pin that split
+    so a future refactor cannot silently drift SFT to every-call cadence."""
+
+    def test_sft_health_check_only_at_modulo_boundary(self, sft_callback):
+        _begin(sft_callback)
+        sft_callback.health_checker = MagicMock()
+        args = _make_args()
+
+        # log_every_n_steps=5: non-boundary steps 1..4 must NOT call health_checker.check.
+        for step in (1, 2, 3, 4):
+            sft_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                logs={"loss": 1.0})
+        assert sft_callback.health_checker.check.call_count == 0, (
+            f"SFT called health_checker.check at non-boundary step "
+            f"(expected 0 calls, got {sft_callback.health_checker.check.call_count})"
+        )
+
+        # Step 5 is a boundary — health_checker.check must fire exactly once.
+        sft_callback.on_log(args, _make_state(global_step=5), _make_control(),
+                            logs={"loss": 1.0})
+        assert sft_callback.health_checker.check.call_count == 1, (
+            f"SFT did not call health_checker.check at boundary step "
+            f"(expected 1 call, got {sft_callback.health_checker.check.call_count})"
+        )
+
+    def test_kto_health_check_every_on_log(self, kto_callback):
+        _begin(kto_callback)
+        kto_callback.health_checker = MagicMock()
+        args = _make_args()
+
+        for step in (1, 2, 3, 4):
+            kto_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                logs={"loss": 1.0})
+        assert kto_callback.health_checker.check.call_count == 4, (
+            f"KTO should call health_checker.check every on_log (expected 4, "
+            f"got {kto_callback.health_checker.check.call_count})"
+        )
+
+    def test_grpo_health_check_every_on_log(self, grpo_callback):
+        _begin(grpo_callback)
+        grpo_callback.health_checker = MagicMock()
+        args = _make_args()
+
+        for step in (1, 2, 3, 4):
+            grpo_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                 logs={"loss": 1.0})
+        assert grpo_callback.health_checker.check.call_count == 4, (
+            f"GRPO should call health_checker.check every on_log (expected 4, "
+            f"got {grpo_callback.health_checker.check.call_count})"
+        )
+
+    def test_sft_last_log_time_only_updates_at_boundary(self, sft_callback):
+        _begin(sft_callback)
+        args = _make_args()
+        # Snapshot last_log_time set by on_train_begin.
+        baseline = sft_callback.last_log_time
+
+        # Non-boundary steps must NOT advance last_log_time.
+        for step in (1, 2, 3, 4):
+            sft_callback.on_log(args, _make_state(global_step=step), _make_control(),
+                                logs={"loss": 1.0})
+        assert sft_callback.last_log_time == baseline, (
+            "SFT advanced last_log_time at non-boundary step"
+        )
+
+        # Boundary step must advance last_log_time.
+        sft_callback.on_log(args, _make_state(global_step=5), _make_control(),
+                            logs={"loss": 1.0})
+        assert sft_callback.last_log_time != baseline, (
+            "SFT did not advance last_log_time at boundary step"
+        )
+
+    def test_kto_last_log_time_updates_every_on_log(self, kto_callback):
+        _begin(kto_callback)
+        args = _make_args()
+        baseline = kto_callback.last_log_time
+        kto_callback.on_log(args, _make_state(global_step=1), _make_control(),
+                            logs={"loss": 1.0})
+        assert kto_callback.last_log_time != baseline, (
+            "KTO must advance last_log_time on every on_log call (non-boundary)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Grep-visibility of new class-attr knobs (single-knob design contract)
+# ---------------------------------------------------------------------------
+
+class TestNewKnobsGrepVisible:
+    """The three new knobs introduced by the B1+B2 remediation must be
+    class attributes so reviewers can audit behavior splits at a glance.
+
+    - `health_check_every_on_log`: base True, SFT False.
+    - `interval_time_updates_every_on_log`: base True, SFT False.
+    - `fields_win_on_collision`: base False, GRPO True."""
+
+    def test_health_check_knob_per_trainer(self):
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+        from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+        assert SFTMetrics.health_check_every_on_log is False
+        assert KTOMetrics.health_check_every_on_log is True
+        assert GRPOMetrics.health_check_every_on_log is True
+
+    def test_interval_time_update_knob_per_trainer(self):
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+        from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+        assert SFTMetrics.interval_time_updates_every_on_log is False
+        assert KTOMetrics.interval_time_updates_every_on_log is True
+        assert GRPOMetrics.interval_time_updates_every_on_log is True
+
+    def test_fields_win_knob_per_trainer(self):
+        from Trainers.sft.src.training_callbacks import MetricsTableCallback as SFTMetrics
+        from Trainers.kto.src.training_callbacks import MetricsTableCallback as KTOMetrics
+        from Trainers.grpo.src.training_callbacks import MetricsTableCallback as GRPOMetrics
+        assert SFTMetrics.fields_win_on_collision is False
+        assert KTOMetrics.fields_win_on_collision is False
+        assert GRPOMetrics.fields_win_on_collision is True


### PR DESCRIPTION
## Summary

- **Bug fix**: Training TUI dashboard epoch counter was stuck at `0.00/X` through most of each epoch because three trainer callback classes (`sft`, `kto`, `grpo`) were casting HuggingFace's float epoch (`logs['epoch']`) to int before dashboard update. Fix: preserve as float.
- **DRY refactor**: Same bug existed identically in three files — motivated extracting a shared `Trainers/shared/callbacks/` package (`BaseMetricsCallback` + `BaseLiveDashboardCallback`, `HealthChecker` strategy, hoisted `TwoStageLRCallback` / `CheckpointMonitorCallback`). Per-trainer `training_callbacks.py` reduced to thin re-exporting subclasses.
- **Net**: -383 LOC overall; zero caller edits; all public symbols preserved at original import paths.
- **Intentional additive change**: KTO and GRPO now gain env-fallback (`CLOUD_PROVIDER` env var) cloud-provider resolution. SFT unchanged. See [design doc §6 risk matrix](./docs/architecture/training-callbacks-refactor.md).

## Epoch fix — scope note

The `float(logs.get("epoch", 0.0) or 0.0)` cast lives at one **call site** — `BaseLiveDashboardCallback.on_log` → `self.dashboard.update(epoch=…)`. The JSONL row path uses `**logs` unchanged and therefore relies on HuggingFace Trainer's native float emission for `logs["epoch"]`. Current HF behavior emits float, so JSONL rows are correct. If HF ever changed that, the JSONL reader would need its own cast — but the dashboard is the only consumer that was user-visibly broken.

## Design reference

`docs/architecture/training-callbacks-refactor.md` — architect's 11-section spec covering component responsibilities, strategy interfaces, migration order, risk matrix, and explicit no-public-API-change confirmation.

## Test plan

- [x] 52 unit tests (`tests/trainers/test_callback_refactor.py`) — all GREEN. Initial 21 covered the 4 refactor uncertainties; remediation added 31 more for B3 (epoch regression guard), M-J (fallback chains), F-A (HealthChecker snapshot), F-B (GPU-branch snapshot), F-C (suppress_training_logs), F-D (shape-parity baseline).
- [x] 107 trainer-adjacent existing tests — no regressions
- [x] Import smoke: all 4 public symbols resolve at original paths from each trainer
- [ ] **Manual**: first real SFT training run should confirm dashboard shows fractional epoch progress (e.g., `0.34/3.00`) rather than `0.00/3.00` until epoch completion

## Review focus

- Reviewers should verify the additive cloud-provider env fallback is intentional (design §6).
- Per-trainer divergences that intentionally STAY (log metrics like `rewards/chosen`, health-check heuristics, `log_every_write` cadence, `interval_key_name`) are documented in design §6 divergence matrix.

## Review remediation log

- **Blockers resolved**: B1 (SFT health-check cadence gating via `health_check_every_on_log` class attr), B2 (GRPO dict-merge precedence via `fields_win_on_collision`), B3 (epoch float-cast regression tests).
- **Post-review minor/future items addressed**: M-A, M-D, M-E, M-F, M-G, M-H, M-I, M-J, F-A, F-B, F-C, F-D, F-E, F-F (commit `9f6a069`).
- **Deferred / not addressed**: M-B (banner text-order drift on no-rich-dashboard fallback path), M-C (format_time DRY unification between base classes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)