### PR TITLE
feat: add privacy preprocess and OPF integration

### DIFF
--- a/.agents/skills/synethetic-data-generation/SKILL.md
+++ b/.agents/skills/synethetic-data-generation/SKILL.md
@@ -154,7 +154,71 @@ LMSTUDIO_HOST=localhost               # LM Studio host
 LMSTUDIO_PORT=1234                    # LM Studio port
 OLLAMA_HOST=http://localhost:11434    # Ollama endpoint
 HF_TOKEN=hf_...                       # HuggingFace uploads
+OPF_CHECKPOINT=/path/to/privacy-filter-checkpoint   # Local OpenAI Privacy Filter checkpoint
+TIKTOKEN_CACHE_DIR=/path/to/tiktoken-cache          # Local tiktoken cache for OPF
+VLLM_HOST=127.0.0.1                  # Optional OpenAI-compatible vLLM polish endpoint
+VLLM_PORT=8000
 ```
+
+## Privacy Setup
+
+Use the privacy preprocess path when raw docs or JSONL may contain PII or secrets and you want SynthChat to sanitize that content before it reaches the generation/improvement model.
+
+Runtime split:
+- `openai/privacy-filter` is the local span-detection/redaction model
+- `opf` is the runtime wrapper used to load and run that model
+- `vllm` is only for the optional post-sanitize `llm_polish` step, not for OPF itself
+
+Profiles live in:
+- `SynthChat/config/privacy_profiles.yaml`
+
+Global defaults live in:
+- `SynthChat/config/settings.yaml` under `privacy_preprocess`
+
+Scenario-level opt-in lives in:
+- `seed_data.preprocess_profile`
+
+Recommended first-use setup when auto-download is unreliable:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+```
+
+OPF also needs the `o200k_base.tiktoken` encoding file. If that does not auto-download cleanly, cache it locally:
+
+```powershell
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+```
+
+Then set:
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+Once those are set, the real OPF-backed sanitize flow can run fully from local files.
 
 ## Config-Driven Architecture
 
@@ -188,3 +252,4 @@ To add a new tool-call format, add a named entry to `tool_call_formats.yaml` and
 - If a response-stage retry is driven by environment feedback, each retry round must be judged against a freshly rerun environment result. Do not carry a prior round's environment failure forward into later judgments after the response has changed.
 - For non-default tool names, provide `--env-tool-schema` and `--env-exec-config`
 - Prefer checked-in `SynthChat/config/targets_*.json` manifests over ad hoc inline JSON when running smoke tests or repeatable generation slices
+- For privacy smoke tests, prefer the checked-in fixtures under `tests/fixtures/privacy/`, the target manifest `SynthChat/config/targets_privacy_docs_smoke.json`, and the runbook `docs/plans/synthchat-privacy-smoke-runbook.md`

--- a/.agents/skills/synethetic-data-generation/SKILL.md
+++ b/.agents/skills/synethetic-data-generation/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 
 # SynthChat: Synthetic Data Generation
 
-Generate, improve, validate, and evaluate synthetic training datasets via CLI and YAML configuration.
+Generate, improve, validate, sanitize, and evaluate synthetic training datasets via CLI and YAML configuration.
 
 ## Quick Reference
 
@@ -17,6 +17,7 @@ Generate, improve, validate, and evaluate synthetic training datasets via CLI an
 | Generate with custom tool schema/rules | `python -m SynthChat.run generate --env-backend local --env-tool-schema path/to/tool_schema.yaml --env-exec-config path/to/environment_execution.yaml [options]` |
 | Improve dataset | `python -m SynthChat.run improve -i FILE [options]` |
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
+| Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
@@ -38,7 +39,7 @@ Load the specific reference you need:
 
 | Reference | When to Load | Path |
 |-----------|-------------|------|
-| **CLI Commands** | Running generate/improve/validate/eval | `reference/cli-commands.md` |
+| **CLI Commands** | Running generate/improve/validate/sanitize/eval | `reference/cli-commands.md` |
 | **Settings Config** | Configuring providers, models, workers, targets | `reference/settings-config.md` |
 | **Scenario Authoring** | Writing or modifying scenario YAMLs | `reference/scenario-authoring.md` |
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
@@ -113,6 +114,17 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 **Generate from docs:**
 ```bash
 python -m SynthChat.run generate --docs "path/to/essays/" --scenarios essay_outline --per-doc 1
+```
+
+**Generate from raw docs with privacy preprocessing:**
+```bash
+python -m SynthChat.run generate --docs "tests/fixtures/privacy/raw_seed_docs" --targets-file SynthChat/config/targets_privacy_docs_smoke.json --privacy-profile realistic_pseudonyms
+```
+
+**Sanitize a docs folder or JSONL dataset:**
+```bash
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_docs --privacy-profile realistic_pseudonyms -o tmp/privacy_docs
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_dataset.jsonl --privacy-profile mask_only -o tmp/privacy_dataset.jsonl
 ```
 
 **Dry-run a checked-in smoke target manifest:**

--- a/.agents/skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.agents/skills/synethetic-data-generation/reference/cli-commands.md
@@ -9,6 +9,48 @@ python -m Evaluator.cli [options]                                # Evaluator
 python tuner.py                                                  # Main CLI
 ```
 
+## Privacy Runtime Prereqs
+
+For OPF-backed sanitization, the local runtime needs:
+
+- the `opf` Python package
+- a local `openai/privacy-filter` checkpoint
+- the `o200k_base.tiktoken` encoding cache file
+
+Recommended PowerShell setup when automatic downloads are blocked or flaky:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+If those env vars are already set to valid local paths, `sanitize` / `generate --privacy-profile` / `improve --privacy-profile` / `validate --privacy-profile` will reuse them.
+
 ---
 
 ## `generate` — Create New Dataset
@@ -199,6 +241,14 @@ python -m SynthChat.run sanitize \
 python -m SynthChat.run sanitize \
   -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
   -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+
+# Real OPF-backed docs sanitize using a local checkpoint/tokenizer cache
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_pseudonyms_docs \
   --privacy-profile realistic_pseudonyms
 ```
 

--- a/.agents/skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.agents/skills/synethetic-data-generation/reference/cli-commands.md
@@ -3,7 +3,7 @@
 ## Entry Points
 
 ```bash
-python -m SynthChat.run [generate|improve|validate] [options]   # Direct
+python -m SynthChat.run [generate|improve|validate|sanitize] [options]   # Direct
 python -m Evaluator.cli [options]                                # Evaluator
 ./run.sh                                                         # Interactive menu
 python tuner.py                                                  # Main CLI
@@ -33,6 +33,7 @@ python -m SynthChat.run generate [options]
 | `--workers, -w N` | Parallel worker threads | `1` |
 | `--docs PATH` | Doc file or folder for docs-based generation | None |
 | `--per-doc N` | Examples to generate per doc | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for raw docs before generation | None |
 | `--env-backend` | Runtime validation backend (`none`, `local`, `e2b`) | From settings / `none` |
 | `--env-template` | E2B template ID (for `--env-backend e2b`) | None |
 | `--env-timeout` | Runtime timeout in seconds | From settings / `120` |
@@ -54,6 +55,11 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 
 # Docs-based generation
 python -m SynthChat.run generate --docs "essays/" --scenarios essay_outline --per-doc 1
+
+# Docs-based generation with privacy preprocessing
+python -m SynthChat.run generate --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms
 
 # Custom targets file, limited iterations
 python -m SynthChat.run generate --targets-file my_targets.json --max-iterations 3 -o test_run.jsonl
@@ -93,6 +99,7 @@ python -m SynthChat.run improve [options]
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
 | `--workers, -w N` | Parallel workers | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before improvement | None |
 
 **Examples:**
 
@@ -120,6 +127,11 @@ python -m SynthChat.run improve -i data.jsonl -o regen_slice.jsonl \
 # Powerful model for judging
 python -m SynthChat.run improve -i data.jsonl \
   --provider openrouter --model openai/gpt-oss-120b --max-iterations 5
+
+# Sanitize dataset content before improvement sends it to the model
+python -m SynthChat.run improve -i data.jsonl \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1
 ```
 
 Notes:
@@ -144,11 +156,50 @@ python -m SynthChat.run validate [options]
 | `--rubrics NAMES` | Comma-separated rubric names | From settings.yaml |
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before validation | None |
 
 **Output:** Pass rate, failing lines, failures grouped by rubric. Suggests `improve` command to fix.
 
 ```bash
 python -m SynthChat.run validate -i data.jsonl --rubrics system_prompt_format,factuality
+```
+
+```bash
+python -m SynthChat.run validate -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+```
+
+---
+
+## `sanitize` — Apply Privacy Preprocessing
+
+Sanitizes docs or JSONL datasets without running the SynthChat judge/improve loop.
+
+```bash
+python -m SynthChat.run sanitize [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input, -i PATH` | **Required.** Input file or directory | — |
+| `--output, -o PATH` | Output file or directory | Auto-derived |
+| `--config-dir PATH` | Config directory | `SynthChat/config` |
+| `--privacy-profile NAME` | Privacy preprocess profile to apply | From settings / required in practice |
+
+**Examples:**
+
+```bash
+# Mask-only docs sanitize
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+# Realistic pseudonymization for JSONL
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
 ```
 
 ---

--- a/.agents/skills/synethetic-data-generation/reference/settings-config.md
+++ b/.agents/skills/synethetic-data-generation/reference/settings-config.md
@@ -113,6 +113,35 @@ cost_tracking:
   include_usage: true
 ```
 
+## Privacy Preprocess Settings
+
+Privacy preprocessing is opt-in. It is intended for sanitizing raw docs or JSONL before that content is shown to a generation/improvement model.
+
+```yaml
+privacy_preprocess:
+  enabled: false
+  profile: null
+  apply_to:
+    docs: true
+    input_jsonl: false
+    generated_output: false
+  on_error: fail                  # fail | skip | keep_masked
+```
+
+Profiles are defined separately in `SynthChat/config/privacy_profiles.yaml`.
+
+Current built-in profiles:
+- `mask_only`
+- `realistic_pseudonyms`
+- `realistic_pseudonyms_vllm_polish`
+
+Operational notes:
+- OPF is the detector runtime, not a chat/completions LLM
+- `generated_output` is optional and should stay off unless you explicitly want output-side sanitization
+- `input_jsonl` applies to `improve` and `validate`
+- `docs` applies to docs-based generation before `{doc_content}` is rendered into prompts
+- OPF needs both a local checkpoint path (`OPF_CHECKPOINT`) and a working `tiktoken` cache (`TIKTOKEN_CACHE_DIR`) if auto-download is not reliable
+
 ---
 
 ## Environment Runtime Validation (Optional)

--- a/.agents/skills/synethetic-data-generation/reference/testing-protocol.md
+++ b/.agents/skills/synethetic-data-generation/reference/testing-protocol.md
@@ -24,6 +24,11 @@ If you are running a smoke test without rubrics/judges, call that out explicitly
 as a plumbing-only test. Do not mistake a wrapper-format smoke pass for a
 quality pass.
 
+For privacy preprocessing changes, the first smoke is usually `sanitize`, not a
+full dataset run. Prove the OPF checkpoint, tokenizer cache, and replacement
+behavior on the checked-in privacy fixtures before you run a larger SynthChat
+generation or improvement pass.
+
 ---
 
 ## Protocol Steps
@@ -64,6 +69,34 @@ python -m SynthChat.run validate \
   --input YOUR_DATASET.jsonl \
   --rubrics YOUR_RUBRIC_NAME \
   --start-line 1 --end-line 5
+```
+
+**For privacy preprocessing changes** (testing the sanitization path itself):
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_pseudonyms_docs \
+  --privacy-profile realistic_pseudonyms
+```
+
+Then run a small docs-based generation smoke:
+
+```powershell
+python -m SynthChat.run generate \
+  --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1 \
+  --output Datasets/synthchat/privacy_docs_smoke.jsonl
 ```
 
 ### Step 2: Convert to Markdown for Review
@@ -163,6 +196,7 @@ Quick dry-run for testing new or modified scenarios:
 | Modified rubric judge/improver | YES (validate mode) | Scoring may shift, threshold may need adjustment |
 | Changed `pass_threshold` | YES (validate mode) | Could mass-pass or mass-fail |
 | Changed settings.yaml model/provider | YES | Different model = different output quality |
+| Changed privacy preprocess config/profile/runtime | YES | Could leak raw content or break replacements |
 | Changed settings.yaml targets only | NO | Just counts, doesn't affect content |
 | Changed settings.yaml logging/resilience | NO | Infrastructure, not content |
 
@@ -249,6 +283,10 @@ Stop and fix the YAML if you see:
   result, not the prior round's failure unless the rerun reproduces it
 
 ---
+
+Additional privacy-specific red flags:
+- Raw PII survives the sanitize pass. Stop and inspect `OPF_CHECKPOINT` and `TIKTOKEN_CACHE_DIR` before trusting the run.
+- Sanitize mutates fields you did not intend to touch. Inspect the emitted privacy reports and metadata before scaling up to larger datasets.
 
 ## Gotcha: stale environment feedback in response retries
 

--- a/.claude/skills/synethetic-data-generation/SKILL.md
+++ b/.claude/skills/synethetic-data-generation/SKILL.md
@@ -154,7 +154,71 @@ LMSTUDIO_HOST=localhost               # LM Studio host
 LMSTUDIO_PORT=1234                    # LM Studio port
 OLLAMA_HOST=http://localhost:11434    # Ollama endpoint
 HF_TOKEN=hf_...                       # HuggingFace uploads
+OPF_CHECKPOINT=/path/to/privacy-filter-checkpoint   # Local OpenAI Privacy Filter checkpoint
+TIKTOKEN_CACHE_DIR=/path/to/tiktoken-cache          # Local tiktoken cache for OPF
+VLLM_HOST=127.0.0.1                  # Optional OpenAI-compatible vLLM polish endpoint
+VLLM_PORT=8000
 ```
+
+## Privacy Setup
+
+Use the privacy preprocess path when raw docs or JSONL may contain PII or secrets and you want SynthChat to sanitize that content before it reaches the generation/improvement model.
+
+Runtime split:
+- `openai/privacy-filter` is the local span-detection/redaction model
+- `opf` is the runtime wrapper used to load and run that model
+- `vllm` is only for the optional post-sanitize `llm_polish` step, not for OPF itself
+
+Profiles live in:
+- `SynthChat/config/privacy_profiles.yaml`
+
+Global defaults live in:
+- `SynthChat/config/settings.yaml` under `privacy_preprocess`
+
+Scenario-level opt-in lives in:
+- `seed_data.preprocess_profile`
+
+Recommended first-use setup when auto-download is unreliable:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+```
+
+OPF also needs the `o200k_base.tiktoken` encoding file. If that does not auto-download cleanly, cache it locally:
+
+```powershell
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+```
+
+Then set:
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+Once those are set, the real OPF-backed sanitize flow can run fully from local files.
 
 ## Config-Driven Architecture
 
@@ -188,3 +252,4 @@ To add a new tool-call format, add a named entry to `tool_call_formats.yaml` and
 - If a response-stage retry is driven by environment feedback, each retry round must be judged against a freshly rerun environment result. Do not carry a prior round's environment failure forward into later judgments after the response has changed.
 - For non-default tool names, provide `--env-tool-schema` and `--env-exec-config`
 - Prefer checked-in `SynthChat/config/targets_*.json` manifests over ad hoc inline JSON when running smoke tests or repeatable generation slices
+- For privacy smoke tests, prefer the checked-in fixtures under `tests/fixtures/privacy/`, the target manifest `SynthChat/config/targets_privacy_docs_smoke.json`, and the runbook `docs/plans/synthchat-privacy-smoke-runbook.md`

--- a/.claude/skills/synethetic-data-generation/SKILL.md
+++ b/.claude/skills/synethetic-data-generation/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 
 # SynthChat: Synthetic Data Generation
 
-Generate, improve, validate, and evaluate synthetic training datasets via CLI and YAML configuration.
+Generate, improve, validate, sanitize, and evaluate synthetic training datasets via CLI and YAML configuration.
 
 ## Quick Reference
 
@@ -17,6 +17,7 @@ Generate, improve, validate, and evaluate synthetic training datasets via CLI an
 | Generate with custom tool schema/rules | `python -m SynthChat.run generate --env-backend local --env-tool-schema path/to/tool_schema.yaml --env-exec-config path/to/environment_execution.yaml [options]` |
 | Improve dataset | `python -m SynthChat.run improve -i FILE [options]` |
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
+| Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
@@ -38,7 +39,7 @@ Load the specific reference you need:
 
 | Reference | When to Load | Path |
 |-----------|-------------|------|
-| **CLI Commands** | Running generate/improve/validate/eval | `reference/cli-commands.md` |
+| **CLI Commands** | Running generate/improve/validate/sanitize/eval | `reference/cli-commands.md` |
 | **Settings Config** | Configuring providers, models, workers, targets | `reference/settings-config.md` |
 | **Scenario Authoring** | Writing or modifying scenario YAMLs | `reference/scenario-authoring.md` |
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
@@ -113,6 +114,17 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 **Generate from docs:**
 ```bash
 python -m SynthChat.run generate --docs "path/to/essays/" --scenarios essay_outline --per-doc 1
+```
+
+**Generate from raw docs with privacy preprocessing:**
+```bash
+python -m SynthChat.run generate --docs "tests/fixtures/privacy/raw_seed_docs" --targets-file SynthChat/config/targets_privacy_docs_smoke.json --privacy-profile realistic_pseudonyms
+```
+
+**Sanitize a docs folder or JSONL dataset:**
+```bash
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_docs --privacy-profile realistic_pseudonyms -o tmp/privacy_docs
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_dataset.jsonl --privacy-profile mask_only -o tmp/privacy_dataset.jsonl
 ```
 
 **Dry-run a checked-in smoke target manifest:**

--- a/.claude/skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.claude/skills/synethetic-data-generation/reference/cli-commands.md
@@ -9,6 +9,48 @@ python -m Evaluator.cli [options]                                # Evaluator
 python tuner.py                                                  # Main CLI
 ```
 
+## Privacy Runtime Prereqs
+
+For OPF-backed sanitization, the local runtime needs:
+
+- the `opf` Python package
+- a local `openai/privacy-filter` checkpoint
+- the `o200k_base.tiktoken` encoding cache file
+
+Recommended PowerShell setup when automatic downloads are blocked or flaky:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+If those env vars are already set to valid local paths, `sanitize` / `generate --privacy-profile` / `improve --privacy-profile` / `validate --privacy-profile` will reuse them.
+
 ---
 
 ## `generate` — Create New Dataset
@@ -199,6 +241,14 @@ python -m SynthChat.run sanitize \
 python -m SynthChat.run sanitize \
   -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
   -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+
+# Real OPF-backed docs sanitize using a local checkpoint/tokenizer cache
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_pseudonyms_docs \
   --privacy-profile realistic_pseudonyms
 ```
 

--- a/.claude/skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.claude/skills/synethetic-data-generation/reference/cli-commands.md
@@ -3,7 +3,7 @@
 ## Entry Points
 
 ```bash
-python -m SynthChat.run [generate|improve|validate] [options]   # Direct
+python -m SynthChat.run [generate|improve|validate|sanitize] [options]   # Direct
 python -m Evaluator.cli [options]                                # Evaluator
 ./run.sh                                                         # Interactive menu
 python tuner.py                                                  # Main CLI
@@ -33,6 +33,7 @@ python -m SynthChat.run generate [options]
 | `--workers, -w N` | Parallel worker threads | `1` |
 | `--docs PATH` | Doc file or folder for docs-based generation | None |
 | `--per-doc N` | Examples to generate per doc | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for raw docs before generation | None |
 | `--env-backend` | Runtime validation backend (`none`, `local`, `e2b`) | From settings / `none` |
 | `--env-template` | E2B template ID (for `--env-backend e2b`) | None |
 | `--env-timeout` | Runtime timeout in seconds | From settings / `120` |
@@ -54,6 +55,11 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 
 # Docs-based generation
 python -m SynthChat.run generate --docs "essays/" --scenarios essay_outline --per-doc 1
+
+# Docs-based generation with privacy preprocessing
+python -m SynthChat.run generate --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms
 
 # Custom targets file, limited iterations
 python -m SynthChat.run generate --targets-file my_targets.json --max-iterations 3 -o test_run.jsonl
@@ -93,6 +99,7 @@ python -m SynthChat.run improve [options]
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
 | `--workers, -w N` | Parallel workers | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before improvement | None |
 
 **Examples:**
 
@@ -120,6 +127,11 @@ python -m SynthChat.run improve -i data.jsonl -o regen_slice.jsonl \
 # Powerful model for judging
 python -m SynthChat.run improve -i data.jsonl \
   --provider openrouter --model openai/gpt-oss-120b --max-iterations 5
+
+# Sanitize dataset content before improvement sends it to the model
+python -m SynthChat.run improve -i data.jsonl \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1
 ```
 
 Notes:
@@ -144,11 +156,50 @@ python -m SynthChat.run validate [options]
 | `--rubrics NAMES` | Comma-separated rubric names | From settings.yaml |
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before validation | None |
 
 **Output:** Pass rate, failing lines, failures grouped by rubric. Suggests `improve` command to fix.
 
 ```bash
 python -m SynthChat.run validate -i data.jsonl --rubrics system_prompt_format,factuality
+```
+
+```bash
+python -m SynthChat.run validate -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+```
+
+---
+
+## `sanitize` — Apply Privacy Preprocessing
+
+Sanitizes docs or JSONL datasets without running the SynthChat judge/improve loop.
+
+```bash
+python -m SynthChat.run sanitize [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input, -i PATH` | **Required.** Input file or directory | — |
+| `--output, -o PATH` | Output file or directory | Auto-derived |
+| `--config-dir PATH` | Config directory | `SynthChat/config` |
+| `--privacy-profile NAME` | Privacy preprocess profile to apply | From settings / required in practice |
+
+**Examples:**
+
+```bash
+# Mask-only docs sanitize
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+# Realistic pseudonymization for JSONL
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
 ```
 
 ---

--- a/.claude/skills/synethetic-data-generation/reference/settings-config.md
+++ b/.claude/skills/synethetic-data-generation/reference/settings-config.md
@@ -113,6 +113,35 @@ cost_tracking:
   include_usage: true
 ```
 
+## Privacy Preprocess Settings
+
+Privacy preprocessing is opt-in. It is intended for sanitizing raw docs or JSONL before that content is shown to a generation/improvement model.
+
+```yaml
+privacy_preprocess:
+  enabled: false
+  profile: null
+  apply_to:
+    docs: true
+    input_jsonl: false
+    generated_output: false
+  on_error: fail                  # fail | skip | keep_masked
+```
+
+Profiles are defined separately in `SynthChat/config/privacy_profiles.yaml`.
+
+Current built-in profiles:
+- `mask_only`
+- `realistic_pseudonyms`
+- `realistic_pseudonyms_vllm_polish`
+
+Operational notes:
+- OPF is the detector runtime, not a chat/completions LLM
+- `generated_output` is optional and should stay off unless you explicitly want output-side sanitization
+- `input_jsonl` applies to `improve` and `validate`
+- `docs` applies to docs-based generation before `{doc_content}` is rendered into prompts
+- OPF needs both a local checkpoint path (`OPF_CHECKPOINT`) and a working `tiktoken` cache (`TIKTOKEN_CACHE_DIR`) if auto-download is not reliable
+
 ---
 
 ## Environment Runtime Validation (Optional)

--- a/.claude/skills/synethetic-data-generation/reference/testing-protocol.md
+++ b/.claude/skills/synethetic-data-generation/reference/testing-protocol.md
@@ -24,6 +24,11 @@ If you are running a smoke test without rubrics/judges, call that out explicitly
 as a plumbing-only test. Do not mistake a wrapper-format smoke pass for a
 quality pass.
 
+For privacy preprocessing changes, the first smoke is usually `sanitize`, not a
+full dataset run. Prove the OPF checkpoint, tokenizer cache, and replacement
+behavior on the checked-in privacy fixtures before you run a larger SynthChat
+generation or improvement pass.
+
 ---
 
 ## Protocol Steps
@@ -64,6 +69,34 @@ python -m SynthChat.run validate \
   --input YOUR_DATASET.jsonl \
   --rubrics YOUR_RUBRIC_NAME \
   --start-line 1 --end-line 5
+```
+
+**For privacy preprocessing changes** (testing the sanitization path itself):
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_pseudonyms_docs \
+  --privacy-profile realistic_pseudonyms
+```
+
+Then run a small docs-based generation smoke:
+
+```powershell
+python -m SynthChat.run generate \
+  --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1 \
+  --output Datasets/synthchat/privacy_docs_smoke.jsonl
 ```
 
 ### Step 2: Convert to Markdown for Review
@@ -163,6 +196,7 @@ Quick dry-run for testing new or modified scenarios:
 | Modified rubric judge/improver | YES (validate mode) | Scoring may shift, threshold may need adjustment |
 | Changed `pass_threshold` | YES (validate mode) | Could mass-pass or mass-fail |
 | Changed settings.yaml model/provider | YES | Different model = different output quality |
+| Changed privacy preprocess config/profile/runtime | YES | Could leak raw content or break replacements |
 | Changed settings.yaml targets only | NO | Just counts, doesn't affect content |
 | Changed settings.yaml logging/resilience | NO | Infrastructure, not content |
 
@@ -249,6 +283,10 @@ Stop and fix the YAML if you see:
   result, not the prior round's failure unless the rerun reproduces it
 
 ---
+
+Additional privacy-specific red flags:
+- Raw PII survives the sanitize pass. Stop and inspect `OPF_CHECKPOINT` and `TIKTOKEN_CACHE_DIR` before trusting the run.
+- Sanitize mutates fields you did not intend to touch. Inspect the emitted privacy reports and metadata before scaling up to larger datasets.
 
 ## Gotcha: stale environment feedback in response retries
 

--- a/.skills/synethetic-data-generation/SKILL.md
+++ b/.skills/synethetic-data-generation/SKILL.md
@@ -154,7 +154,71 @@ LMSTUDIO_HOST=localhost               # LM Studio host
 LMSTUDIO_PORT=1234                    # LM Studio port
 OLLAMA_HOST=http://localhost:11434    # Ollama endpoint
 HF_TOKEN=hf_...                       # HuggingFace uploads
+OPF_CHECKPOINT=/path/to/privacy-filter-checkpoint   # Local OpenAI Privacy Filter checkpoint
+TIKTOKEN_CACHE_DIR=/path/to/tiktoken-cache          # Local tiktoken cache for OPF
+VLLM_HOST=127.0.0.1                  # Optional OpenAI-compatible vLLM polish endpoint
+VLLM_PORT=8000
 ```
+
+## Privacy Setup
+
+Use the privacy preprocess path when raw docs or JSONL may contain PII or secrets and you want SynthChat to sanitize that content before it reaches the generation/improvement model.
+
+Runtime split:
+- `openai/privacy-filter` is the local span-detection/redaction model
+- `opf` is the runtime wrapper used to load and run that model
+- `vllm` is only for the optional post-sanitize `llm_polish` step, not for OPF itself
+
+Profiles live in:
+- `SynthChat/config/privacy_profiles.yaml`
+
+Global defaults live in:
+- `SynthChat/config/settings.yaml` under `privacy_preprocess`
+
+Scenario-level opt-in lives in:
+- `seed_data.preprocess_profile`
+
+Recommended first-use setup when auto-download is unreliable:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+```
+
+OPF also needs the `o200k_base.tiktoken` encoding file. If that does not auto-download cleanly, cache it locally:
+
+```powershell
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+```
+
+Then set:
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+Once those are set, the real OPF-backed sanitize flow can run fully from local files.
 
 ## Config-Driven Architecture
 
@@ -188,3 +252,4 @@ To add a new tool-call format, add a named entry to `tool_call_formats.yaml` and
 - If a response-stage retry is driven by environment feedback, each retry round must be judged against a freshly rerun environment result. Do not carry a prior round's environment failure forward into later judgments after the response has changed.
 - For non-default tool names, provide `--env-tool-schema` and `--env-exec-config`
 - Prefer checked-in `SynthChat/config/targets_*.json` manifests over ad hoc inline JSON when running smoke tests or repeatable generation slices
+- For privacy smoke tests, prefer the checked-in fixtures under `tests/fixtures/privacy/`, the target manifest `SynthChat/config/targets_privacy_docs_smoke.json`, and the runbook `docs/plans/synthchat-privacy-smoke-runbook.md`

--- a/.skills/synethetic-data-generation/SKILL.md
+++ b/.skills/synethetic-data-generation/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 
 # SynthChat: Synthetic Data Generation
 
-Generate, improve, validate, and evaluate synthetic training datasets via CLI and YAML configuration.
+Generate, improve, validate, sanitize, and evaluate synthetic training datasets via CLI and YAML configuration.
 
 ## Quick Reference
 
@@ -17,6 +17,7 @@ Generate, improve, validate, and evaluate synthetic training datasets via CLI an
 | Generate with custom tool schema/rules | `python -m SynthChat.run generate --env-backend local --env-tool-schema path/to/tool_schema.yaml --env-exec-config path/to/environment_execution.yaml [options]` |
 | Improve dataset | `python -m SynthChat.run improve -i FILE [options]` |
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
+| Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
@@ -38,7 +39,7 @@ Load the specific reference you need:
 
 | Reference | When to Load | Path |
 |-----------|-------------|------|
-| **CLI Commands** | Running generate/improve/validate/eval | `reference/cli-commands.md` |
+| **CLI Commands** | Running generate/improve/validate/sanitize/eval | `reference/cli-commands.md` |
 | **Settings Config** | Configuring providers, models, workers, targets | `reference/settings-config.md` |
 | **Scenario Authoring** | Writing or modifying scenario YAMLs | `reference/scenario-authoring.md` |
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
@@ -113,6 +114,17 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 **Generate from docs:**
 ```bash
 python -m SynthChat.run generate --docs "path/to/essays/" --scenarios essay_outline --per-doc 1
+```
+
+**Generate from raw docs with privacy preprocessing:**
+```bash
+python -m SynthChat.run generate --docs "tests/fixtures/privacy/raw_seed_docs" --targets-file SynthChat/config/targets_privacy_docs_smoke.json --privacy-profile realistic_pseudonyms
+```
+
+**Sanitize a docs folder or JSONL dataset:**
+```bash
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_docs --privacy-profile realistic_pseudonyms -o tmp/privacy_docs
+python -m SynthChat.run sanitize -i tests/fixtures/privacy/raw_seed_dataset.jsonl --privacy-profile mask_only -o tmp/privacy_dataset.jsonl
 ```
 
 **Dry-run a checked-in smoke target manifest:**

--- a/.skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.skills/synethetic-data-generation/reference/cli-commands.md
@@ -9,6 +9,48 @@ python -m Evaluator.cli [options]                                # Evaluator
 python tuner.py                                                  # Main CLI
 ```
 
+## Privacy Runtime Prereqs
+
+For OPF-backed sanitization, the local runtime needs:
+
+- the `opf` Python package
+- a local `openai/privacy-filter` checkpoint
+- the `o200k_base.tiktoken` encoding cache file
+
+Recommended PowerShell setup when automatic downloads are blocked or flaky:
+
+```powershell
+python - <<'PY'
+from pathlib import Path
+import shutil
+from huggingface_hub import snapshot_download
+
+target = Path(r"F:\Code\Toolset-Training\tmp\opf_privacy_filter")
+if not target.exists():
+    target.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id="openai/privacy-filter",
+        local_dir=str(target),
+        allow_patterns=["original/*"],
+    )
+    original = target / "original"
+    for path in original.iterdir():
+        shutil.move(str(path), str(target / path.name))
+    original.rmdir()
+print(target)
+PY
+
+New-Item -ItemType Directory -Force -Path F:\Code\Toolset-Training\tmp\tiktoken_cache | Out-Null
+Invoke-WebRequest `
+  -Uri "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken" `
+  -OutFile "F:\Code\Toolset-Training\tmp\tiktoken_cache\fb374d419588a4632f3f557e76b4b70aebbca790"
+
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+```
+
+If those env vars are already set to valid local paths, `sanitize` / `generate --privacy-profile` / `improve --privacy-profile` / `validate --privacy-profile` will reuse them.
+
 ---
 
 ## `generate` — Create New Dataset
@@ -199,6 +241,14 @@ python -m SynthChat.run sanitize \
 python -m SynthChat.run sanitize \
   -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
   -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+
+# Real OPF-backed docs sanitize using a local checkpoint/tokenizer cache
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_pseudonyms_docs \
   --privacy-profile realistic_pseudonyms
 ```
 

--- a/.skills/synethetic-data-generation/reference/cli-commands.md
+++ b/.skills/synethetic-data-generation/reference/cli-commands.md
@@ -3,7 +3,7 @@
 ## Entry Points
 
 ```bash
-python -m SynthChat.run [generate|improve|validate] [options]   # Direct
+python -m SynthChat.run [generate|improve|validate|sanitize] [options]   # Direct
 python -m Evaluator.cli [options]                                # Evaluator
 ./run.sh                                                         # Interactive menu
 python tuner.py                                                  # Main CLI
@@ -33,6 +33,7 @@ python -m SynthChat.run generate [options]
 | `--workers, -w N` | Parallel worker threads | `1` |
 | `--docs PATH` | Doc file or folder for docs-based generation | None |
 | `--per-doc N` | Examples to generate per doc | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for raw docs before generation | None |
 | `--env-backend` | Runtime validation backend (`none`, `local`, `e2b`) | From settings / `none` |
 | `--env-template` | E2B template ID (for `--env-backend e2b`) | None |
 | `--env-timeout` | Runtime timeout in seconds | From settings / `120` |
@@ -54,6 +55,11 @@ python -m SynthChat.run generate --provider openrouter --model openai/gpt-oss-12
 
 # Docs-based generation
 python -m SynthChat.run generate --docs "essays/" --scenarios essay_outline --per-doc 1
+
+# Docs-based generation with privacy preprocessing
+python -m SynthChat.run generate --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms
 
 # Custom targets file, limited iterations
 python -m SynthChat.run generate --targets-file my_targets.json --max-iterations 3 -o test_run.jsonl
@@ -93,6 +99,7 @@ python -m SynthChat.run improve [options]
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
 | `--workers, -w N` | Parallel workers | `1` |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before improvement | None |
 
 **Examples:**
 
@@ -120,6 +127,11 @@ python -m SynthChat.run improve -i data.jsonl -o regen_slice.jsonl \
 # Powerful model for judging
 python -m SynthChat.run improve -i data.jsonl \
   --provider openrouter --model openai/gpt-oss-120b --max-iterations 5
+
+# Sanitize dataset content before improvement sends it to the model
+python -m SynthChat.run improve -i data.jsonl \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1
 ```
 
 Notes:
@@ -144,11 +156,50 @@ python -m SynthChat.run validate [options]
 | `--rubrics NAMES` | Comma-separated rubric names | From settings.yaml |
 | `--provider PROVIDER` | LLM provider override | From settings.yaml |
 | `--model MODEL` | Model name override | From settings.yaml |
+| `--privacy-profile NAME` | Privacy preprocess profile for input JSONL before validation | None |
 
 **Output:** Pass rate, failing lines, failures grouped by rubric. Suggests `improve` command to fix.
 
 ```bash
 python -m SynthChat.run validate -i data.jsonl --rubrics system_prompt_format,factuality
+```
+
+```bash
+python -m SynthChat.run validate -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
+```
+
+---
+
+## `sanitize` — Apply Privacy Preprocessing
+
+Sanitizes docs or JSONL datasets without running the SynthChat judge/improve loop.
+
+```bash
+python -m SynthChat.run sanitize [options]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input, -i PATH` | **Required.** Input file or directory | — |
+| `--output, -o PATH` | Output file or directory | Auto-derived |
+| `--config-dir PATH` | Config directory | `SynthChat/config` |
+| `--privacy-profile NAME` | Privacy preprocess profile to apply | From settings / required in practice |
+
+**Examples:**
+
+```bash
+# Mask-only docs sanitize
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_docs \
+  -o tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+# Realistic pseudonymization for JSONL
+python -m SynthChat.run sanitize \
+  -i tests/fixtures/privacy/raw_seed_dataset.jsonl \
+  -o tmp/privacy_pseudonyms_dataset.jsonl \
+  --privacy-profile realistic_pseudonyms
 ```
 
 ---

--- a/.skills/synethetic-data-generation/reference/settings-config.md
+++ b/.skills/synethetic-data-generation/reference/settings-config.md
@@ -113,6 +113,35 @@ cost_tracking:
   include_usage: true
 ```
 
+## Privacy Preprocess Settings
+
+Privacy preprocessing is opt-in. It is intended for sanitizing raw docs or JSONL before that content is shown to a generation/improvement model.
+
+```yaml
+privacy_preprocess:
+  enabled: false
+  profile: null
+  apply_to:
+    docs: true
+    input_jsonl: false
+    generated_output: false
+  on_error: fail                  # fail | skip | keep_masked
+```
+
+Profiles are defined separately in `SynthChat/config/privacy_profiles.yaml`.
+
+Current built-in profiles:
+- `mask_only`
+- `realistic_pseudonyms`
+- `realistic_pseudonyms_vllm_polish`
+
+Operational notes:
+- OPF is the detector runtime, not a chat/completions LLM
+- `generated_output` is optional and should stay off unless you explicitly want output-side sanitization
+- `input_jsonl` applies to `improve` and `validate`
+- `docs` applies to docs-based generation before `{doc_content}` is rendered into prompts
+- OPF needs both a local checkpoint path (`OPF_CHECKPOINT`) and a working `tiktoken` cache (`TIKTOKEN_CACHE_DIR`) if auto-download is not reliable
+
 ---
 
 ## Environment Runtime Validation (Optional)

--- a/.skills/synethetic-data-generation/reference/testing-protocol.md
+++ b/.skills/synethetic-data-generation/reference/testing-protocol.md
@@ -24,6 +24,11 @@ If you are running a smoke test without rubrics/judges, call that out explicitly
 as a plumbing-only test. Do not mistake a wrapper-format smoke pass for a
 quality pass.
 
+For privacy preprocessing changes, the first smoke is usually `sanitize`, not a
+full dataset run. Prove the OPF checkpoint, tokenizer cache, and replacement
+behavior on the checked-in privacy fixtures before you run a larger SynthChat
+generation or improvement pass.
+
 ---
 
 ## Protocol Steps
@@ -64,6 +69,34 @@ python -m SynthChat.run validate \
   --input YOUR_DATASET.jsonl \
   --rubrics YOUR_RUBRIC_NAME \
   --start-line 1 --end-line 5
+```
+
+**For privacy preprocessing changes** (testing the sanitization path itself):
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Code\Toolset-Training\tmp\opf_privacy_filter"
+$env:TIKTOKEN_CACHE_DIR="F:\Code\Toolset-Training\tmp\tiktoken_cache"
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_mask_only_docs \
+  --privacy-profile mask_only
+
+python -m SynthChat.run sanitize \
+  --input tests/fixtures/privacy/raw_seed_docs \
+  --output tmp/privacy_pseudonyms_docs \
+  --privacy-profile realistic_pseudonyms
+```
+
+Then run a small docs-based generation smoke:
+
+```powershell
+python -m SynthChat.run generate \
+  --docs tests/fixtures/privacy/raw_seed_docs \
+  --targets-file SynthChat/config/targets_privacy_docs_smoke.json \
+  --privacy-profile realistic_pseudonyms \
+  --max-iterations 1 \
+  --output Datasets/synthchat/privacy_docs_smoke.jsonl
 ```
 
 ### Step 2: Convert to Markdown for Review
@@ -163,6 +196,7 @@ Quick dry-run for testing new or modified scenarios:
 | Modified rubric judge/improver | YES (validate mode) | Scoring may shift, threshold may need adjustment |
 | Changed `pass_threshold` | YES (validate mode) | Could mass-pass or mass-fail |
 | Changed settings.yaml model/provider | YES | Different model = different output quality |
+| Changed privacy preprocess config/profile/runtime | YES | Could leak raw content or break replacements |
 | Changed settings.yaml targets only | NO | Just counts, doesn't affect content |
 | Changed settings.yaml logging/resilience | NO | Infrastructure, not content |
 
@@ -249,6 +283,10 @@ Stop and fix the YAML if you see:
   result, not the prior round's failure unless the rerun reproduces it
 
 ---
+
+Additional privacy-specific red flags:
+- Raw PII survives the sanitize pass. Stop and inspect `OPF_CHECKPOINT` and `TIKTOKEN_CACHE_DIR` before trusting the run.
+- Sanitize mutates fields you did not intend to touch. Inspect the emitted privacy reports and metadata before scaling up to larger datasets.
 
 ## Gotcha: stale environment feedback in response retries
 

--- a/SynthChat/config/privacy.py
+++ b/SynthChat/config/privacy.py
@@ -1,0 +1,117 @@
+"""Privacy preprocess configuration helpers."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..utils.yaml_loader import load_yaml
+
+_CONFIG_DIR = Path(__file__).parent
+
+_DEFAULT_PRIVACY_SETTINGS: Dict[str, Any] = {
+    "enabled": False,
+    "profile": None,
+    "apply_to": {
+        "docs": True,
+        "input_jsonl": False,
+        "generated_output": False,
+    },
+    "on_error": "fail",
+}
+
+_DEFAULT_PRIVACY_PROFILES: Dict[str, Any] = {
+    "profiles": {
+        "mask_only": {
+            "detector": {
+                "provider": "opf",
+                "checkpoint": None,
+                "device": "cpu",
+                "output_mode": "typed",
+            },
+            "transform": {
+                "mode": "mask",
+                "keep_typed_placeholders": True,
+                "consistency_scope": "document",
+            },
+        },
+        "realistic_pseudonyms": {
+            "detector": {
+                "provider": "opf",
+                "checkpoint": None,
+                "device": "cpu",
+                "output_mode": "typed",
+            },
+            "transform": {
+                "mode": "pseudonymize",
+                "provider": "programmatic",
+                "consistency_scope": "document",
+                "faker_locale": "en_US",
+                "fake_email_domain": "example.com",
+                "preserve_date_shape": True,
+                "preserve_account_number_shape": True,
+                "secret_strategy": "mask",
+                "llm_polish": {
+                    "enabled": False,
+                },
+            },
+        },
+    }
+}
+
+
+def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Deep-merge override into a copy of base."""
+    result = deepcopy(base)
+    for key, value in (override or {}).items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = _deep_merge(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+def get_default_privacy_settings() -> Dict[str, Any]:
+    """Return default privacy preprocess settings."""
+    return deepcopy(_DEFAULT_PRIVACY_SETTINGS)
+
+
+def load_privacy_profiles(config_path: Optional[str | Path] = None) -> Dict[str, Any]:
+    """Load named privacy preprocess profiles."""
+    path = Path(config_path) if config_path else _CONFIG_DIR / "privacy_profiles.yaml"
+    if path.is_file():
+        data = load_yaml(path)
+        if isinstance(data, dict) and isinstance(data.get("profiles"), dict):
+            return {
+                "profiles": {
+                    **deepcopy(_DEFAULT_PRIVACY_PROFILES["profiles"]),
+                    **deepcopy(data["profiles"]),
+                }
+            }
+    return deepcopy(_DEFAULT_PRIVACY_PROFILES)
+
+
+def resolve_privacy_settings(settings: Dict[str, Any], overrides: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Resolve global privacy settings from defaults, settings, and optional overrides."""
+    repo_settings = settings.get("privacy_preprocess") if isinstance(settings, dict) else None
+    resolved = _deep_merge(_DEFAULT_PRIVACY_SETTINGS, repo_settings or {})
+    if overrides:
+        resolved = _deep_merge(resolved, overrides)
+    return resolved
+
+
+def resolve_privacy_profile(
+    *,
+    profile_name: Optional[str],
+    profiles_registry: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Resolve a named privacy profile."""
+    if not profile_name:
+        return None
+    profiles = (profiles_registry or {}).get("profiles") or {}
+    profile = profiles.get(profile_name)
+    if not isinstance(profile, dict):
+        raise KeyError(f"Privacy profile not found: {profile_name}")
+    return deepcopy(profile)
+

--- a/SynthChat/config/privacy_profiles.yaml
+++ b/SynthChat/config/privacy_profiles.yaml
@@ -1,0 +1,56 @@
+profiles:
+  mask_only:
+    detector:
+      provider: opf
+      checkpoint: null
+      device: cpu
+      output_mode: typed
+    transform:
+      mode: mask
+      keep_typed_placeholders: true
+      consistency_scope: document
+
+  realistic_pseudonyms:
+    detector:
+      provider: opf
+      checkpoint: null
+      device: cpu
+      output_mode: typed
+    transform:
+      mode: pseudonymize
+      provider: programmatic
+      consistency_scope: document
+      faker_locale: en_US
+      fake_email_domain: example.com
+      preserve_date_shape: true
+      preserve_account_number_shape: true
+      secret_strategy: mask
+      llm_polish:
+        enabled: false
+
+  realistic_pseudonyms_vllm_polish:
+    detector:
+      provider: opf
+      checkpoint: null
+      device: cpu
+      output_mode: typed
+    transform:
+      mode: pseudonymize
+      provider: hybrid
+      consistency_scope: document
+      faker_locale: en_US
+      fake_email_domain: example.com
+      preserve_date_shape: true
+      preserve_account_number_shape: true
+      secret_strategy: mask
+      llm_polish:
+        enabled: true
+        provider: vllm
+        host_env: VLLM_HOST
+        port_env: VLLM_PORT
+        default_host: 127.0.0.1
+        default_port: 8000
+        model: local-model
+        temperature: 0.1
+        max_tokens: 2048
+

--- a/SynthChat/config/settings.yaml
+++ b/SynthChat/config/settings.yaml
@@ -75,6 +75,17 @@ generation:
   random_seed: null  # Set for reproducibility, null for random
   stage_validation: true  # Validate each stage before proceeding
 
+# Optional privacy preprocessing for seed data and dataset sanitization.
+# When enabled with a profile, raw seed text is sanitized before generation.
+privacy_preprocess:
+  enabled: false
+  profile: null
+  apply_to:
+    docs: true
+    input_jsonl: false
+    generated_output: false
+  on_error: fail   # fail | skip | keep_masked
+
 # Optional environment-backed tool execution checks.
 # This runs generated tool calls against an isolated runtime and stores traces
 # in example metadata to support downstream filtering/evaluation.

--- a/SynthChat/config/targets_privacy_docs_smoke.json
+++ b/SynthChat/config/targets_privacy_docs_smoke.json
@@ -1,0 +1,4 @@
+{
+  "docs_qa_test": 2,
+  "docs_debug_test": 1
+}

--- a/SynthChat/generator.py
+++ b/SynthChat/generator.py
@@ -64,6 +64,7 @@ from .config.format_resolver import (
     resolve_tool_call_format,
     resolve_workspace_format,
 )
+from .config.privacy import load_privacy_profiles, resolve_privacy_settings
 from .parsing import (
     stringify_assistant_message,
     parse_assistant_response,
@@ -87,6 +88,8 @@ from .agentic.episode import (
     validate_agentic_synthchat_response,
 )
 from shared.llm.factory import create_client  # noqa: F401 — re-exported for test monkeypatching
+
+from .services.privacy_preprocess import PrivacyPreprocessor
 
 try:
     from shared.environments import EnvironmentValidator
@@ -166,7 +169,9 @@ class SynthChatGenerator:
         engine: Optional[ImprovementEngine] = None,
         environment_validator: Optional["EnvironmentValidator"] = None,
         enable_stage_validation: bool = True,
-        logger=None
+        logger=None,
+        privacy_settings: Optional[Dict[str, Any]] = None,
+        privacy_preprocessor_factory=None,
     ):
         """
         Initialize generator.
@@ -181,6 +186,8 @@ class SynthChatGenerator:
                 tool execution checks.
             enable_stage_validation: Whether to validate each stage (default: True)
             logger: Logger instance (optional)
+            privacy_settings: Optional privacy preprocess settings from settings.yaml / CLI.
+            privacy_preprocessor_factory: Optional factory for test injection.
         """
         self.config_dir = Path(config_dir)
         self.llm_client = llm_client
@@ -197,6 +204,11 @@ class SynthChatGenerator:
         self._tool_call_formats = load_tool_call_formats()
         self._workspace_formats = load_workspace_formats()
         self._label_mappings = load_label_mappings()
+        self._privacy_settings = resolve_privacy_settings({"privacy_preprocess": privacy_settings or {}})
+        self._privacy_profiles = load_privacy_profiles(self.config_dir / "privacy_profiles.yaml")
+        self._privacy_preprocessor_factory = privacy_preprocessor_factory or PrivacyPreprocessor.from_registry
+        self._privacy_preprocessor_cache: Dict[str, PrivacyPreprocessor] = {}
+        self._privacy_doc_cache: Dict[Tuple[str, str], Dict[str, Any]] = {}
 
         # Initialize or use provided improvement engine
         if engine is None and enable_stage_validation:
@@ -421,8 +433,9 @@ class SynthChatGenerator:
         """Prepare a reusable environment/system-context seed for one or more rollouts."""
         prompts = scenario.get("prompts", {})
         template_vars = {}
-        if doc_context:
-            template_vars["doc_content"] = doc_context.content
+        doc_seed = self._resolve_doc_seed(scenario, doc_context)
+        if doc_seed is not None:
+            template_vars["doc_content"] = doc_seed["content"]
             template_vars["doc_path"] = doc_context.path
 
         def render_prompt(prompt: str) -> str:
@@ -546,11 +559,12 @@ class SynthChatGenerator:
         prompts = scenario.get("prompts", {})
         # Get all rubrics from scenario config - fully config-driven
         scenario_rubrics = scenario.get("rubrics", {})
+        doc_seed = self._resolve_doc_seed(scenario, doc_context)
 
         # Build template variables from doc context
         template_vars = {}
-        if doc_context:
-            template_vars["doc_content"] = doc_context.content
+        if doc_seed is not None:
+            template_vars["doc_content"] = doc_seed["content"]
             template_vars["doc_path"] = doc_context.path
 
         def render_prompt(prompt: str) -> str:
@@ -1199,10 +1213,23 @@ class SynthChatGenerator:
             stage_reviews["final"] = final_review
             if final_review.get("passed") is False and final_review.get("enforce", True):
                 stage_failures.append("final")
+        example, output_privacy = self._sanitize_generated_output(
+            scenario_key=scenario_key,
+            scenario=scenario,
+            example=example,
+        )
         if doc_context:
             example["metadata"]["source_doc"] = doc_context.path
+        if doc_seed and doc_seed.get("privacy") is not None:
+            example["metadata"]["source_doc_privacy"] = doc_seed["privacy"]
+        if output_privacy is not None:
+            example["metadata"]["generated_output_privacy"] = output_privacy
         if stage_reviews:
             example["metadata"]["stage_reviews"] = stage_reviews
+        combined_privacy = self._merge_privacy_traces(
+            (doc_seed or {}).get("privacy"),
+            output_privacy,
+        )
         example["metadata"]["labels"] = self._build_metadata_labels(
             scenario_key=scenario_key,
             scenario=scenario,
@@ -1210,6 +1237,7 @@ class SynthChatGenerator:
             stage_failures=stage_failures,
             environment_trace=environment_trace,
             generated_environment=generated_environment,
+            privacy_trace=combined_privacy,
         )
 
         return GenerationResult(
@@ -1543,6 +1571,7 @@ class SynthChatGenerator:
         stage_failures: List[str],
         environment_trace: Optional[Dict[str, Any]],
         generated_environment: Dict[str, Any],
+        privacy_trace: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Build structured labels for downstream filtering and KTO/GRPO slicing."""
         return build_metadata_labels(
@@ -1552,8 +1581,156 @@ class SynthChatGenerator:
             stage_failures=stage_failures,
             environment_trace=environment_trace,
             generated_environment=generated_environment,
+            privacy_trace=privacy_trace,
             label_mappings=self._label_mappings,
         )
+
+    def _resolve_privacy_profile_name(self, scenario: Dict[str, Any]) -> Optional[str]:
+        seed_data = scenario.get("seed_data") if isinstance(scenario, dict) else None
+        if isinstance(seed_data, dict):
+            profile_name = str(seed_data.get("preprocess_profile") or "").strip()
+            if profile_name:
+                return profile_name
+        if self._privacy_settings.get("enabled"):
+            profile_name = str(self._privacy_settings.get("profile") or "").strip()
+            if profile_name:
+                return profile_name
+        return None
+
+    def _get_privacy_preprocessor(self, profile_name: str) -> PrivacyPreprocessor:
+        if profile_name not in self._privacy_preprocessor_cache:
+            self._privacy_preprocessor_cache[profile_name] = self._privacy_preprocessor_factory(
+                profile_name=profile_name,
+                profiles_registry=self._privacy_profiles,
+            )
+        return self._privacy_preprocessor_cache[profile_name]
+
+    def _resolve_doc_seed(
+        self,
+        scenario: Dict[str, Any],
+        doc_context: Optional[DocFile],
+    ) -> Optional[Dict[str, Any]]:
+        if doc_context is None:
+            return None
+        if not bool((self._privacy_settings.get("apply_to") or {}).get("docs", True)):
+            return {"content": doc_context.content, "privacy": None}
+
+        profile_name = self._resolve_privacy_profile_name(scenario)
+        if not profile_name:
+            return {"content": doc_context.content, "privacy": None}
+
+        cache_key = (profile_name, doc_context.path)
+        if cache_key not in self._privacy_doc_cache:
+            result = self._get_privacy_preprocessor(profile_name).process_text(
+                doc_context.content,
+                scope_key=doc_context.path,
+            )
+            self._privacy_doc_cache[cache_key] = {
+                "content": result.sanitized_text,
+                "privacy": result.to_metadata(),
+            }
+        return deepcopy(self._privacy_doc_cache[cache_key])
+
+    def _sanitize_generated_output(
+        self,
+        *,
+        scenario_key: str,
+        scenario: Dict[str, Any],
+        example: Dict[str, Any],
+    ) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+        if not bool((self._privacy_settings.get("apply_to") or {}).get("generated_output", False)):
+            return example, None
+
+        profile_name = self._resolve_privacy_profile_name(scenario)
+        if not profile_name:
+            return example, None
+
+        payload: Dict[str, Any] = {}
+        for field_name in ("conversations", "conversation_trace"):
+            if field_name in example:
+                payload[field_name] = deepcopy(example[field_name])
+        if not payload:
+            return example, None
+
+        sanitized_payload, reports = self._get_privacy_preprocessor(profile_name).sanitize_payload(
+            payload,
+            scope_key=f"{scenario_key}:generated_output",
+        )
+        for field_name, value in sanitized_payload.items():
+            example[field_name] = value
+        return example, self._summarize_privacy_reports(profile_name=profile_name, reports=reports)
+
+    @staticmethod
+    def _summarize_privacy_reports(
+        *,
+        profile_name: str,
+        reports: List[Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        labels = set()
+        span_count = 0
+        for report in reports:
+            detection = report.get("detection") if isinstance(report, dict) else None
+            if not isinstance(detection, dict):
+                continue
+            for label in detection.get("labels") or []:
+                if label:
+                    labels.add(str(label))
+            try:
+                span_count += int(detection.get("span_count", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+
+        summary: Dict[str, Any] = {
+            "profile": profile_name,
+            "changed": bool(reports),
+            "report_count": len(reports),
+            "reports": reports,
+            "detection": {
+                "labels": sorted(labels),
+                "span_count": span_count,
+            },
+        }
+        return summary
+
+    @staticmethod
+    def _merge_privacy_traces(*traces: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        active_traces = [trace for trace in traces if isinstance(trace, dict)]
+        if not active_traces:
+            return None
+
+        labels = set()
+        span_count = 0
+        changed = False
+        profiles: List[str] = []
+        for trace in active_traces:
+            if bool(trace.get("changed")):
+                changed = True
+            profile_name = str(trace.get("profile") or "").strip()
+            if profile_name:
+                profiles.append(profile_name)
+            detection = trace.get("detection") if isinstance(trace.get("detection"), dict) else {}
+            for label in detection.get("labels") or []:
+                if label:
+                    labels.add(str(label))
+            try:
+                span_count += int(detection.get("span_count", 0) or 0)
+            except (TypeError, ValueError):
+                continue
+
+        deduped_profiles = list(dict.fromkeys(profiles))
+        merged: Dict[str, Any] = {
+            "changed": changed,
+            "detection": {
+                "labels": sorted(labels),
+                "span_count": span_count,
+            },
+        }
+        if len(deduped_profiles) == 1:
+            merged["profile"] = deduped_profiles[0]
+        elif deduped_profiles:
+            merged["profile"] = "multiple"
+            merged["profiles"] = deduped_profiles
+        return merged
 
     def _improve_stage(
         self,

--- a/SynthChat/labeling.py
+++ b/SynthChat/labeling.py
@@ -99,6 +99,7 @@ def build_metadata_labels(
     stage_failures: List[str],
     environment_trace: Optional[Dict[str, Any]],
     generated_environment: Dict[str, Any],
+    privacy_trace: Optional[Dict[str, Any]],
     label_mappings: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Build structured labels for downstream filtering and KTO/GRPO slicing.
@@ -183,6 +184,44 @@ def build_metadata_labels(
     if generated_environment:
         flat_labels.add("environment:generated_payload")
 
+    privacy_filter: Dict[str, Any] = {}
+    if isinstance(privacy_trace, dict):
+        flat_labels.add("privacy:present")
+        changed = bool(privacy_trace.get("changed"))
+        flat_labels.add(f"privacy_changed:{str(changed).lower()}")
+        profile_name = _slugify_label(str(privacy_trace.get("profile") or ""))
+        if profile_name:
+            flat_labels.add(f"privacy_profile:{profile_name}")
+
+        detection = privacy_trace.get("detection")
+        if isinstance(detection, dict):
+            labels = [str(label).strip() for label in detection.get("labels", []) if str(label).strip()]
+            for label in labels:
+                flat_labels.add(f"privacy_label:{label}")
+            privacy_filter = {
+                "present": True,
+                "changed": changed,
+                "profile": str(privacy_trace.get("profile") or "") or None,
+                "labels": sorted(labels),
+                "span_count": int(detection.get("span_count", 0) or 0),
+            }
+        else:
+            privacy_filter = {
+                "present": True,
+                "changed": changed,
+                "profile": str(privacy_trace.get("profile") or "") or None,
+                "labels": [],
+                "span_count": 0,
+            }
+    else:
+        privacy_filter = {
+            "present": False,
+            "changed": False,
+            "profile": None,
+            "labels": [],
+            "span_count": 0,
+        }
+
     if has_environment and environment_passed is True and not stage_failure_labels:
         flat_labels.add("kto_candidate:positive")
     elif has_environment and environment_passed is False:
@@ -216,5 +255,6 @@ def build_metadata_labels(
                 stage_failures=stage_failure_labels,
                 issue_labels=issue_labels,
             ),
+            "privacy": privacy_filter,
         },
     }

--- a/SynthChat/modes/generate.py
+++ b/SynthChat/modes/generate.py
@@ -11,6 +11,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..config.privacy import resolve_privacy_settings
 from ..utils.logger import get_logger
 from ..engine import ImprovementEngine
 from ..generator import SynthChatGenerator
@@ -43,6 +44,10 @@ def generate_mode(args, *, load_settings, create_llm_client, create_environment_
     # Load configuration
     config_dir = Path(args.config_dir or "SynthChat/config")
     settings = load_settings(config_dir)
+    privacy_overrides: Dict[str, Any] = {}
+    if getattr(args, "privacy_profile", None):
+        privacy_overrides = {"enabled": True, "profile": args.privacy_profile}
+    settings["privacy_preprocess"] = resolve_privacy_settings(settings, privacy_overrides)
     logger = get_logger("synthchat_generate")
 
     scenarios_dir = Path(args.scenarios_dir or "SynthChat/scenarios")
@@ -78,6 +83,7 @@ def generate_mode(args, *, load_settings, create_llm_client, create_environment_
         environment_validator=environment_validator,
         enable_stage_validation=settings["generation"]["stage_validation"],
         logger=logger,
+        privacy_settings=settings.get("privacy_preprocess"),
     )
 
     # Load targets
@@ -131,6 +137,8 @@ def generate_mode(args, *, load_settings, create_llm_client, create_environment_
         docs = DocsLoader().load(args.docs)
         print(f"Loaded {len(docs)} document(s)")
         print(f"Will generate {args.per_doc} example(s) per doc\n")
+        if settings.get("privacy_preprocess", {}).get("enabled") and settings.get("privacy_preprocess", {}).get("profile"):
+            print(f"Privacy seed preprocessing enabled (profile={settings['privacy_preprocess']['profile']})")
 
     # Generate
     max_iterations = args.max_iterations or settings["improvement"]["max_iterations"]

--- a/SynthChat/modes/improve.py
+++ b/SynthChat/modes/improve.py
@@ -15,6 +15,10 @@ from typing import Dict, List, Sequence, Tuple
 from ..engine import ImprovementEngine
 from ..parallel.improve_workers import run_parallel_improvement
 from ..result_writer import generate_output_path
+from ..services.privacy_preprocess import (
+    resolve_privacy_preprocessor,
+    sanitize_payload_with_metadata,
+)
 
 
 def _parse_line_selectors(spec: str) -> List[int]:
@@ -109,6 +113,16 @@ def improve_mode(args, *, load_settings, create_llm_client):
     config_dir = Path(args.config_dir or "SynthChat/config")
     settings = load_settings(config_dir)
     rubrics_dir = Path(args.rubrics_dir or "SynthChat/rubrics")
+    privacy_preprocessor = resolve_privacy_preprocessor(
+        config_dir=config_dir,
+        settings=settings,
+        apply_target="input_jsonl",
+        profile_override=getattr(args, "privacy_profile", None),
+    )
+    sanitize_generated_output = bool(
+        privacy_preprocessor is not None
+        and ((settings.get("privacy_preprocess") or {}).get("apply_to") or {}).get("generated_output", False)
+    )
 
     # Load input dataset
     if not args.input:
@@ -149,7 +163,27 @@ def improve_mode(args, *, load_settings, create_llm_client):
     examples = [example for _, example in selected_examples]
     selected_line_numbers = [line_number for line_number, _ in selected_examples]
 
+    input_privacy_changed = 0
+    if privacy_preprocessor is not None:
+        sanitized_examples = []
+        for line_number, example in zip(selected_line_numbers, examples):
+            sanitized_example, summary = sanitize_payload_with_metadata(
+                example,
+                preprocessor=privacy_preprocessor,
+                scope_key=f"{input_path}:{line_number}",
+                metadata_field="privacy_preprocess_input",
+            )
+            if summary.get("changed"):
+                input_privacy_changed += 1
+            sanitized_examples.append(sanitized_example)
+        examples = sanitized_examples
+
     print(f"Loaded {len(examples)} examples from {input_path}\n")
+    if privacy_preprocessor is not None:
+        print(
+            f"Privacy input preprocessing enabled (profile={privacy_preprocessor.profile_name}, "
+            f"changed={input_privacy_changed}/{len(examples)})\n"
+        )
 
     # Determine rubrics to use
     rubrics = args.rubrics or settings["improvement"]["default_rubrics"]
@@ -200,7 +234,17 @@ def improve_mode(args, *, load_settings, create_llm_client):
                     "error": "parallel_result_missing",
                 })
                 continue
-            improved_examples.append(result.improved_example)
+            improved_example = result.improved_example
+            output_privacy_changed = False
+            if sanitize_generated_output:
+                improved_example, output_summary = sanitize_payload_with_metadata(
+                    improved_example,
+                    preprocessor=privacy_preprocessor,
+                    scope_key=f"{input_path}:{original_line_number}:output",
+                    metadata_field="privacy_preprocess_output",
+                )
+                output_privacy_changed = bool(output_summary.get("changed"))
+            improved_examples.append(improved_example)
             if result.passed:
                 passed_count += 1
             else:
@@ -211,6 +255,10 @@ def improve_mode(args, *, load_settings, create_llm_client):
                 "iterations": int(result.iterations),
                 "final_scores": result.final_scores,
                 "scopes_improved": result.scopes_improved,
+                "privacy_input_changed": bool(
+                    ((example.get("metadata") or {}).get("privacy_preprocess_input") or {}).get("changed")
+                ),
+                "privacy_output_changed": output_privacy_changed,
             })
     else:
         # Create LLM client (CLI args override settings.yaml)
@@ -238,11 +286,33 @@ def improve_mode(args, *, load_settings, create_llm_client):
                     max_iterations=max_iterations
                 )
 
-                improved_examples.append(result.improved_example)
+                improved_example = result.improved_example
+                output_privacy_changed = False
+                if sanitize_generated_output:
+                    improved_example, output_summary = sanitize_payload_with_metadata(
+                        improved_example,
+                        preprocessor=privacy_preprocessor,
+                        scope_key=f"{input_path}:{original_line_number}:output",
+                        metadata_field="privacy_preprocess_output",
+                    )
+                    output_privacy_changed = bool(output_summary.get("changed"))
+
+                improved_examples.append(improved_example)
                 if result.passed:
                     passed_count += 1
                 else:
                     failed_count += 1
+                result_rows.append({
+                    "line_number": original_line_number,
+                    "passed": bool(result.passed),
+                    "iterations": int(result.iterations),
+                    "final_scores": result.final_scores,
+                    "scopes_improved": result.scopes_improved,
+                    "privacy_input_changed": bool(
+                        ((example.get("metadata") or {}).get("privacy_preprocess_input") or {}).get("changed")
+                    ),
+                    "privacy_output_changed": output_privacy_changed,
+                })
 
             except Exception as e:
                 print(f"  Error: {e}")
@@ -255,6 +325,10 @@ def improve_mode(args, *, load_settings, create_llm_client):
                     "final_scores": {},
                     "scopes_improved": [],
                     "error": str(e),
+                    "privacy_input_changed": bool(
+                        ((example.get("metadata") or {}).get("privacy_preprocess_input") or {}).get("changed")
+                    ),
+                    "privacy_output_changed": False,
                 })
                 continue
 
@@ -282,6 +356,9 @@ def improve_mode(args, *, load_settings, create_llm_client):
         "total_processed": len(examples),
         "passed": passed_count,
         "failed": failed_count,
+        "privacy_profile": privacy_preprocessor.profile_name if privacy_preprocessor is not None else None,
+        "privacy_input_changed": input_privacy_changed,
+        "privacy_output_enabled": sanitize_generated_output,
         "results": result_rows,
     }
     with open(report_path, "w") as f:

--- a/SynthChat/modes/sanitize.py
+++ b/SynthChat/modes/sanitize.py
@@ -1,0 +1,165 @@
+"""SynthChat Sanitize Mode - Apply privacy preprocessing to docs or datasets."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from ..config.privacy import load_privacy_profiles, resolve_privacy_settings
+from ..services.privacy_preprocess import PrivacyPreprocessor
+
+
+_DOC_EXTENSIONS = {".md", ".txt", ".html", ".htm"}
+
+
+def sanitize_mode(args, *, load_settings):
+    """Sanitize input docs or datasets using a named privacy preprocess profile."""
+    print("=== SynthChat: Sanitize Mode ===\n")
+
+    config_dir = Path(args.config_dir or "SynthChat/config")
+    settings = load_settings(config_dir)
+    privacy_overrides: Dict[str, Any] = {}
+    if getattr(args, "privacy_profile", None):
+        privacy_overrides = {"enabled": True, "profile": args.privacy_profile}
+    settings["privacy_preprocess"] = resolve_privacy_settings(settings, privacy_overrides)
+
+    profile_name = str(settings.get("privacy_preprocess", {}).get("profile") or "").strip()
+    if not profile_name:
+        print("Error: Privacy sanitize mode requires a profile via settings.yaml or --privacy-profile")
+        sys.exit(1)
+
+    profiles_registry = load_privacy_profiles(config_dir / "privacy_profiles.yaml")
+    preprocessor = PrivacyPreprocessor.from_registry(
+        profile_name=profile_name,
+        profiles_registry=profiles_registry,
+    )
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"Error: Input not found: {input_path}")
+        sys.exit(1)
+
+    if input_path.is_dir():
+        output_dir = Path(args.output) if args.output else input_path.parent / f"{input_path.name}_sanitized"
+        summary = _sanitize_directory(input_path, output_dir, preprocessor)
+        report_path = output_dir / "privacy_sanitize_report.json"
+        report_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print(f"Sanitized {summary['files_written']} file(s)")
+        print(f"Output: {output_dir}")
+        print(f"Report: {report_path}")
+        return
+
+    if input_path.suffix.lower() == ".jsonl":
+        output_file = Path(args.output) if args.output else input_path.with_name(f"{input_path.stem}_sanitized.jsonl")
+        summary = _sanitize_jsonl(input_path, output_file, preprocessor)
+        report_path = output_file.with_name(f"{output_file.name}.privacy_report.json")
+        report_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print(f"Sanitized {summary['records_processed']} JSONL record(s)")
+        print(f"Output: {output_file}")
+        print(f"Report: {report_path}")
+        return
+
+    output_file = Path(args.output) if args.output else input_path.with_name(f"{input_path.stem}_sanitized{input_path.suffix}")
+    summary = _sanitize_text_file(input_path, output_file, preprocessor)
+    report_path = output_file.with_name(f"{output_file.name}.privacy_report.json")
+    report_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print("Sanitized 1 file")
+    print(f"Output: {output_file}")
+    print(f"Report: {report_path}")
+
+
+def _sanitize_directory(input_dir: Path, output_dir: Path, preprocessor: PrivacyPreprocessor) -> Dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    file_reports: List[Dict[str, Any]] = []
+    files_written = 0
+
+    for source in sorted(path for path in input_dir.rglob("*") if path.is_file()):
+        if source.suffix.lower() not in _DOC_EXTENSIONS and source.suffix.lower() != ".jsonl":
+            continue
+        relative = source.relative_to(input_dir)
+        target = output_dir / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if source.suffix.lower() == ".jsonl":
+            summary = _sanitize_jsonl(source, target, preprocessor)
+        else:
+            summary = _sanitize_text_file(source, target, preprocessor)
+        file_reports.append(summary)
+        files_written += 1
+
+    return {
+        "mode": "directory",
+        "profile": preprocessor.profile_name,
+        "input": str(input_dir),
+        "output": str(output_dir),
+        "files_written": files_written,
+        "files": file_reports,
+    }
+
+
+def _sanitize_text_file(input_file: Path, output_file: Path, preprocessor: PrivacyPreprocessor) -> Dict[str, Any]:
+    text = input_file.read_text(encoding="utf-8")
+    result = preprocessor.process_text(text, scope_key=str(input_file))
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(result.sanitized_text, encoding="utf-8")
+    return {
+        "mode": "text",
+        "profile": preprocessor.profile_name,
+        "input": str(input_file),
+        "output": str(output_file),
+        "changed": result.changed,
+        "metadata": result.to_metadata(),
+    }
+
+
+def _sanitize_jsonl(input_file: Path, output_file: Path, preprocessor: PrivacyPreprocessor) -> Dict[str, Any]:
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    records_processed = 0
+    changed_records = 0
+    record_reports: List[Dict[str, Any]] = []
+
+    with input_file.open("r", encoding="utf-8") as src, output_file.open("w", encoding="utf-8") as dst:
+        for line_number, raw_line in enumerate(src, start=1):
+            line = raw_line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if isinstance(payload, dict) and "_meta" in payload:
+                payload.setdefault("_meta", {})
+                payload["_meta"]["privacy_preprocess"] = {"profile": preprocessor.profile_name}
+                dst.write(json.dumps(payload) + "\n")
+                continue
+
+            sanitized_payload, reports = preprocessor.sanitize_payload(payload, scope_key=f"{input_file}:{line_number}")
+            if isinstance(sanitized_payload, dict):
+                metadata = sanitized_payload.setdefault("metadata", {})
+                if isinstance(metadata, dict):
+                    metadata["privacy_preprocess"] = {
+                        "profile": preprocessor.profile_name,
+                        "changed": bool(reports),
+                        "report_count": len(reports),
+                        "reports": reports,
+                    }
+            dst.write(json.dumps(sanitized_payload) + "\n")
+            records_processed += 1
+            if reports:
+                changed_records += 1
+            record_reports.append(
+                {
+                    "line_number": line_number,
+                    "changed": bool(reports),
+                    "report_count": len(reports),
+                }
+            )
+
+    return {
+        "mode": "jsonl",
+        "profile": preprocessor.profile_name,
+        "input": str(input_file),
+        "output": str(output_file),
+        "records_processed": records_processed,
+        "changed_records": changed_records,
+        "records": record_reports,
+    }
+

--- a/SynthChat/modes/validate.py
+++ b/SynthChat/modes/validate.py
@@ -13,6 +13,10 @@ from pathlib import Path
 from typing import Dict
 
 from ..engine import ImprovementEngine
+from ..services.privacy_preprocess import (
+    resolve_privacy_preprocessor,
+    sanitize_payload_with_metadata,
+)
 
 
 def validate_mode(args, *, load_settings, create_llm_client):
@@ -35,6 +39,12 @@ def validate_mode(args, *, load_settings, create_llm_client):
     config_dir = Path(args.config_dir or "SynthChat/config")
     settings = load_settings(config_dir)
     rubrics_dir = Path(args.rubrics_dir or "SynthChat/rubrics")
+    privacy_preprocessor = resolve_privacy_preprocessor(
+        config_dir=config_dir,
+        settings=settings,
+        apply_target="input_jsonl",
+        profile_override=getattr(args, "privacy_profile", None),
+    )
 
     # Load input dataset
     if not args.input:
@@ -58,6 +68,24 @@ def validate_mode(args, *, load_settings, create_llm_client):
                     print(f"Warning: Skipping malformed JSON at line {line_num}: {e}")
 
     print(f"Loaded {len(examples)} examples from {input_path}\n")
+    if privacy_preprocessor is not None:
+        changed_count = 0
+        sanitized_examples = []
+        for line_num, example in examples:
+            sanitized_example, summary = sanitize_payload_with_metadata(
+                example,
+                preprocessor=privacy_preprocessor,
+                scope_key=f"{input_path}:{line_num}",
+                metadata_field="privacy_preprocess_input",
+            )
+            if summary.get("changed"):
+                changed_count += 1
+            sanitized_examples.append((line_num, sanitized_example))
+        examples = sanitized_examples
+        print(
+            f"Privacy input preprocessing enabled (profile={privacy_preprocessor.profile_name}, "
+            f"changed={changed_count}/{len(examples)})\n"
+        )
 
     # Create LLM client for judging (CLI args override settings.yaml)
     print("Initializing validation LLM client...")
@@ -123,6 +151,8 @@ def validate_mode(args, *, load_settings, create_llm_client):
     print(f"Total examples: {total}")
     print(f"Passed: {total_passed} ({pass_rate:.1f}%)")
     print(f"Failed: {total_failed} ({100 - pass_rate:.1f}%)")
+    if privacy_preprocessor is not None:
+        print(f"Privacy profile: {privacy_preprocessor.profile_name}")
 
     if failing_lines:
         print(f"\nFailing lines: {', '.join(map(str, failing_lines[:20]))}")

--- a/SynthChat/parallel/workers.py
+++ b/SynthChat/parallel/workers.py
@@ -95,6 +95,7 @@ def create_worker_generator(
         environment_validator=create_environment_validator_from_options(environment_options or {}),
         enable_stage_validation=settings["generation"]["stage_validation"],
         logger=logger,
+        privacy_settings=settings.get("privacy_preprocess"),
     )
     return generator
 

--- a/SynthChat/result_writer.py
+++ b/SynthChat/result_writer.py
@@ -46,6 +46,12 @@ class StreamingResultWriter:
                     "streaming": True
                 }
             }
+            privacy_settings = self._settings.get("privacy_preprocess") or {}
+            if privacy_settings.get("enabled") and privacy_settings.get("profile"):
+                metadata["_meta"]["privacy_preprocess"] = {
+                    "profile": privacy_settings.get("profile"),
+                    "apply_to": dict(privacy_settings.get("apply_to") or {}),
+                }
             self._file.write(json.dumps(metadata) + "\n")
             self._file.flush()
 
@@ -128,6 +134,12 @@ def save_results(results: List, output_file: Path, settings: Dict):
                     }
                 }
             }
+            privacy_settings = settings.get("privacy_preprocess") or {}
+            if privacy_settings.get("enabled") and privacy_settings.get("profile"):
+                metadata["_meta"]["privacy_preprocess"] = {
+                    "profile": privacy_settings.get("profile"),
+                    "apply_to": dict(privacy_settings.get("apply_to") or {}),
+                }
             f.write(json.dumps(metadata) + "\n")
 
         # Write examples

--- a/SynthChat/run.py
+++ b/SynthChat/run.py
@@ -4,13 +4,14 @@ Location: SynthChat/run.py
 Purpose: Single CLI for both "generate", "improve", and "validate" modes.
          Contains only the argument parser, factory functions for LLM clients
          and environment validators, and the main() dispatcher. Mode logic
-         lives in SynthChat.modes.{generate,improve,validate}.
-Usage: python -m SynthChat.run [generate|improve|validate] [options]
+         lives in SynthChat.modes.{generate,improve,validate,sanitize}.
+Usage: python -m SynthChat.run [generate|improve|validate|sanitize] [options]
 
 Commands:
     generate - Create new dataset from scenarios
     improve  - Improve existing dataset with rubrics
     validate - Check if dataset passes rubrics (no improvement)
+    sanitize - Apply privacy preprocessing to docs or datasets
 """
 
 import argparse
@@ -24,6 +25,7 @@ from .utils.yaml_loader import load_yaml
 
 from .modes.generate import generate_mode
 from .modes.improve import improve_mode
+from .modes.sanitize import sanitize_mode
 from .modes.validate import validate_mode
 
 
@@ -135,6 +137,11 @@ def main():
     generate_parser.add_argument("--per-doc", type=int, default=1, help="Examples to generate per doc (default: 1)")
     generate_parser.add_argument("--workers", "-w", type=int, default=1, help="Number of parallel workers (default: 1)")
     generate_parser.add_argument(
+        "--privacy-profile",
+        default=None,
+        help="Named privacy preprocess profile to apply to seed docs before generation",
+    )
+    generate_parser.add_argument(
         "--env-backend",
         choices=["none", "local", "e2b"],
         default=None,
@@ -186,6 +193,11 @@ def main():
     improve_parser.add_argument("--provider", help="LLM provider (overrides settings.yaml)")
     improve_parser.add_argument("--model", help="Model name (overrides settings.yaml)")
     improve_parser.add_argument("--workers", "-w", type=int, default=1, help="Number of parallel workers (default: 1)")
+    improve_parser.add_argument(
+        "--privacy-profile",
+        default=None,
+        help="Named privacy preprocess profile to apply to input JSONL before improvement",
+    )
 
     # Validate command
     validate_parser = subparsers.add_parser("validate", help="Validate dataset (no improvement)")
@@ -195,6 +207,21 @@ def main():
     validate_parser.add_argument("--rubrics", help="Comma-separated rubric names")
     validate_parser.add_argument("--provider", help="LLM provider (overrides settings.yaml)")
     validate_parser.add_argument("--model", help="Model name (overrides settings.yaml)")
+    validate_parser.add_argument(
+        "--privacy-profile",
+        default=None,
+        help="Named privacy preprocess profile to apply to input JSONL before validation",
+    )
+
+    sanitize_parser = subparsers.add_parser("sanitize", help="Sanitize docs or JSONL datasets")
+    sanitize_parser.add_argument("--input", "-i", required=True, help="Input file or directory")
+    sanitize_parser.add_argument("--output", "-o", help="Output file or directory")
+    sanitize_parser.add_argument("--config-dir", help="Config directory path")
+    sanitize_parser.add_argument(
+        "--privacy-profile",
+        default=None,
+        help="Named privacy preprocess profile (overrides settings.yaml)",
+    )
 
     args = parser.parse_args()
 
@@ -221,6 +248,11 @@ def main():
             args,
             load_settings=load_settings,
             create_llm_client=create_llm_client,
+        )
+    elif args.command == "sanitize":
+        sanitize_mode(
+            args,
+            load_settings=load_settings,
         )
 
 

--- a/SynthChat/services/privacy_filter.py
+++ b/SynthChat/services/privacy_filter.py
@@ -1,0 +1,154 @@
+"""Privacy detection wrappers for local sanitization."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+
+_PLACEHOLDER_BY_LABEL = {
+    "private_person": "[PRIVATE_PERSON]",
+    "private_address": "[PRIVATE_ADDRESS]",
+    "private_email": "[PRIVATE_EMAIL]",
+    "private_phone": "[PRIVATE_PHONE]",
+    "private_url": "[PRIVATE_URL]",
+    "private_date": "[PRIVATE_DATE]",
+    "account_number": "[ACCOUNT_NUMBER]",
+    "secret": "[SECRET]",
+}
+
+
+@dataclass(frozen=True)
+class PrivacySpan:
+    """One detected privacy span."""
+
+    label: str
+    start: int
+    end: int
+    text: str
+    placeholder: str
+
+
+@dataclass(frozen=True)
+class PrivacyDetectionResult:
+    """Detection output for one input string."""
+
+    text: str
+    masked_text: str
+    spans: tuple[PrivacySpan, ...]
+    provider: str
+
+    def to_metadata(self) -> Dict[str, Any]:
+        counts: Dict[str, int] = {}
+        for span in self.spans:
+            counts[span.label] = counts.get(span.label, 0) + 1
+        return {
+            "provider": self.provider,
+            "span_count": len(self.spans),
+            "labels": sorted(counts.keys()),
+            "by_label": counts,
+            "masked_text_changed": self.masked_text != self.text,
+            "spans": [
+                {
+                    "label": span.label,
+                    "start": int(span.start),
+                    "end": int(span.end),
+                    "placeholder": span.placeholder,
+                }
+                for span in self.spans
+            ],
+        }
+
+
+class PrivacyFilterService:
+    """Local privacy detector service."""
+
+    _runtime_local = threading.local()
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        self.config = dict(config or {})
+        self.provider = str(self.config.get("provider", "opf")).strip().lower() or "opf"
+        self.checkpoint = self.config.get("checkpoint")
+        self.device = str(self.config.get("device", "cpu")).strip().lower() or "cpu"
+        self.output_mode = str(self.config.get("output_mode", "typed")).strip().lower() or "typed"
+
+    def detect(self, text: str) -> PrivacyDetectionResult:
+        """Detect privacy spans and return a typed masked rendering."""
+        if self.provider != "opf":
+            raise ValueError(f"Unsupported privacy detector provider: {self.provider}")
+
+        redactor = self._get_opf_runtime()
+        result = redactor.redact(text)
+        spans = self._normalize_spans(getattr(result, "detected_spans", ()) or ())
+        masked_text = self._apply_placeholders(text, spans)
+        return PrivacyDetectionResult(
+            text=text,
+            masked_text=masked_text,
+            spans=tuple(spans),
+            provider="opf",
+        )
+
+    def _get_opf_runtime(self):
+        """Load or reuse a cached OPF runtime in this thread."""
+        cache = getattr(self._runtime_local, "cache", None)
+        if cache is None:
+            cache = {}
+            self._runtime_local.cache = cache
+
+        cache_key = (self.checkpoint or "", self.device, self.output_mode)
+        if cache_key in cache:
+            return cache[cache_key]
+
+        try:
+            from opf import OPF  # type: ignore
+        except ImportError as exc:  # pragma: no cover - import depends on local runtime
+            raise RuntimeError(
+                "Privacy profile requires the OPF runtime, but `opf` is not installed. "
+                "Install the OpenAI Privacy Filter helper runtime before enabling this profile."
+            ) from exc
+
+        redactor = OPF(
+            model=self.checkpoint,
+            device="cuda" if self.device == "cuda" else "cpu",
+            output_mode="typed",
+            output_text_only=False,
+        )
+        cache[cache_key] = redactor
+        return redactor
+
+    def _normalize_spans(self, raw_spans: Iterable[Any]) -> List[PrivacySpan]:
+        spans: List[PrivacySpan] = []
+        for raw in raw_spans:
+            label = str(getattr(raw, "label", "") or "").strip().lower()
+            start = int(getattr(raw, "start", 0) or 0)
+            end = int(getattr(raw, "end", 0) or 0)
+            text = str(getattr(raw, "text", "") or "")
+            if not label or end <= start:
+                continue
+            spans.append(
+                PrivacySpan(
+                    label=label,
+                    start=start,
+                    end=end,
+                    text=text,
+                    placeholder=_PLACEHOLDER_BY_LABEL.get(label, "[REDACTED]"),
+                )
+            )
+        spans.sort(key=lambda item: (item.start, item.end))
+        return spans
+
+    @staticmethod
+    def _apply_placeholders(text: str, spans: List[PrivacySpan]) -> str:
+        if not spans:
+            return text
+        pieces: List[str] = []
+        cursor = 0
+        for span in spans:
+            if span.start < cursor:
+                continue
+            pieces.append(text[cursor:span.start])
+            pieces.append(span.placeholder)
+            cursor = span.end
+        pieces.append(text[cursor:])
+        return "".join(pieces)

--- a/SynthChat/services/privacy_preprocess.py
+++ b/SynthChat/services/privacy_preprocess.py
@@ -1,0 +1,255 @@
+"""Privacy preprocess orchestration."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from shared.llm.providers.lmstudio import LMStudioClient
+
+from ..config.privacy import (
+    load_privacy_profiles,
+    resolve_privacy_profile,
+    resolve_privacy_settings,
+)
+from .privacy_filter import PrivacyFilterService
+from .pseudonymizer import Pseudonymizer
+
+
+@dataclass(frozen=True)
+class PrivacyPreprocessResult:
+    """Combined sanitize result for one text input."""
+
+    original_text: str
+    masked_text: str
+    sanitized_text: str
+    changed: bool
+    profile_name: str
+    detection: Dict[str, Any]
+    transform: Dict[str, Any]
+    polish: Optional[Dict[str, Any]] = None
+
+    def to_metadata(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "profile": self.profile_name,
+            "changed": self.changed,
+            "detection": dict(self.detection),
+            "transform": dict(self.transform),
+        }
+        if self.polish is not None:
+            payload["polish"] = dict(self.polish)
+        return payload
+
+
+class OpenAICompatiblePolisher:
+    """Optional post-sanitize polishing step using an OpenAI-compatible endpoint."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        self.config = dict(config or {})
+        host_env = str(self.config.get("host_env", "VLLM_HOST")).strip() or "VLLM_HOST"
+        port_env = str(self.config.get("port_env", "VLLM_PORT")).strip() or "VLLM_PORT"
+        host = os.getenv(host_env, str(self.config.get("default_host", "127.0.0.1")))
+        port = int(os.getenv(port_env, str(self.config.get("default_port", 8000))))
+        model = str(self.config.get("model", "local-model")).strip() or "local-model"
+        self.temperature = float(self.config.get("temperature", 0.1))
+        self.max_tokens = int(self.config.get("max_tokens", 2048))
+        self.client = LMStudioClient(host=host, port=port, model=model)
+
+    def polish(self, text: str) -> str:
+        """Polish already-sanitized text without changing entities."""
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Rewrite the user-provided text for fluency and naturalness. "
+                    "Do not add or remove facts. Preserve all placeholder tokens and all synthetic identities exactly. "
+                    "Do not invent, recover, or infer any original private information. "
+                    "Return plain text only."
+                ),
+            },
+            {"role": "user", "content": text},
+        ]
+        return self.client.chat(
+            messages,
+            temperature=self.temperature,
+            max_tokens=self.max_tokens,
+        )
+
+
+class PrivacyPreprocessor:
+    """Config-driven text privacy preprocess pipeline."""
+
+    def __init__(
+        self,
+        *,
+        profile_name: str,
+        profile: Dict[str, Any],
+        detector: Optional[PrivacyFilterService] = None,
+        pseudonymizer: Optional[Pseudonymizer] = None,
+        polisher: Optional[OpenAICompatiblePolisher] = None,
+    ):
+        self.profile_name = profile_name
+        self.profile = dict(profile or {})
+        self.detector = detector or PrivacyFilterService(self.profile.get("detector"))
+        self.transform_config = dict(self.profile.get("transform") or {})
+        self.pseudonymizer = pseudonymizer or Pseudonymizer(self.transform_config)
+        polish_cfg = dict(self.transform_config.get("llm_polish") or {})
+        self.polisher = polisher or (OpenAICompatiblePolisher(polish_cfg) if polish_cfg.get("enabled") else None)
+
+    @classmethod
+    def from_registry(
+        cls,
+        *,
+        profile_name: str,
+        profiles_registry: Dict[str, Any],
+    ) -> "PrivacyPreprocessor":
+        profile = resolve_privacy_profile(profile_name=profile_name, profiles_registry=profiles_registry)
+        if profile is None:
+            raise KeyError(f"Privacy profile not found: {profile_name}")
+        return cls(profile_name=profile_name, profile=profile)
+
+    def process_text(
+        self,
+        text: str,
+        *,
+        scope_key: Optional[str] = None,
+    ) -> PrivacyPreprocessResult:
+        """Run detect -> transform -> optional polish on one text string."""
+        detection = self.detector.detect(text)
+        mode = str(self.transform_config.get("mode", "mask")).strip().lower() or "mask"
+        sanitized_text = detection.masked_text
+        transform_meta: Dict[str, Any] = {
+            "mode": mode,
+            "changed": sanitized_text != text,
+        }
+
+        if mode == "pseudonymize":
+            pseudonymized = self.pseudonymizer.pseudonymize(detection, scope_key=scope_key)
+            sanitized_text = pseudonymized.replaced_text
+            transform_meta.update(pseudonymized.to_metadata())
+
+        polish_meta: Optional[Dict[str, Any]] = None
+        if self.polisher is not None and sanitized_text.strip():
+            before = sanitized_text
+            after = self.polisher.polish(sanitized_text)
+            sanitized_text = after.strip() or before
+            polish_meta = {
+                "enabled": True,
+                "changed": sanitized_text != before,
+            }
+
+        return PrivacyPreprocessResult(
+            original_text=text,
+            masked_text=detection.masked_text,
+            sanitized_text=sanitized_text,
+            changed=sanitized_text != text,
+            profile_name=self.profile_name,
+            detection=detection.to_metadata(),
+            transform=transform_meta,
+            polish=polish_meta,
+        )
+
+    def sanitize_payload(
+        self,
+        payload: Any,
+        *,
+        scope_key: Optional[str] = None,
+    ) -> Tuple[Any, List[Dict[str, Any]]]:
+        """Recursively sanitize string values inside a payload."""
+        reports: List[Dict[str, Any]] = []
+
+        def walk(value: Any, path: str) -> Any:
+            if isinstance(value, str):
+                result = self.process_text(value, scope_key=scope_key or path)
+                if result.changed:
+                    reports.append({"path": path, **result.to_metadata()})
+                return result.sanitized_text
+            if isinstance(value, list):
+                return [walk(item, f"{path}[{idx}]") for idx, item in enumerate(value)]
+            if isinstance(value, dict):
+                return {key: walk(item, f"{path}.{key}" if path else str(key)) for key, item in value.items()}
+            return value
+
+        return walk(payload, ""), reports
+
+
+def summarize_privacy_reports(
+    *,
+    profile_name: str,
+    reports: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Summarize recursive sanitize reports into lightweight metadata."""
+    labels = set()
+    span_count = 0
+    for report in reports:
+        detection = report.get("detection") if isinstance(report, dict) else None
+        if not isinstance(detection, dict):
+            continue
+        for label in detection.get("labels") or []:
+            if label:
+                labels.add(str(label))
+        try:
+            span_count += int(detection.get("span_count", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+
+    return {
+        "profile": profile_name,
+        "changed": bool(reports),
+        "report_count": len(reports),
+        "reports": reports,
+        "detection": {
+            "labels": sorted(labels),
+            "span_count": span_count,
+        },
+    }
+
+
+def sanitize_payload_with_metadata(
+    payload: Any,
+    *,
+    preprocessor: PrivacyPreprocessor,
+    scope_key: Optional[str] = None,
+    metadata_field: str = "privacy_preprocess",
+) -> Tuple[Any, Dict[str, Any]]:
+    """Sanitize a payload and attach summary metadata when the payload is a dict."""
+    sanitized_payload, reports = preprocessor.sanitize_payload(payload, scope_key=scope_key)
+    summary = summarize_privacy_reports(profile_name=preprocessor.profile_name, reports=reports)
+
+    if isinstance(sanitized_payload, dict):
+        metadata = sanitized_payload.setdefault("metadata", {})
+        if isinstance(metadata, dict):
+            metadata[metadata_field] = summary
+
+    return sanitized_payload, summary
+
+
+def resolve_privacy_preprocessor(
+    *,
+    config_dir: str | Path,
+    settings: Dict[str, Any],
+    apply_target: str,
+    profile_override: Optional[str] = None,
+) -> Optional[PrivacyPreprocessor]:
+    """Resolve an enabled privacy preprocessor for one CLI mode/target."""
+    overrides: Dict[str, Any] = {}
+    if profile_override:
+        overrides = {"enabled": True, "profile": profile_override}
+    resolved = resolve_privacy_settings(settings, overrides)
+    apply_to = resolved.get("apply_to") if isinstance(resolved, dict) else {}
+    if not resolved.get("enabled"):
+        return None
+    if not bool((apply_to or {}).get(apply_target, False)):
+        return None
+
+    profile_name = str(resolved.get("profile") or "").strip()
+    if not profile_name:
+        return None
+
+    profiles_registry = load_privacy_profiles(Path(config_dir) / "privacy_profiles.yaml")
+    return PrivacyPreprocessor.from_registry(
+        profile_name=profile_name,
+        profiles_registry=profiles_registry,
+    )

--- a/SynthChat/services/pseudonymizer.py
+++ b/SynthChat/services/pseudonymizer.py
@@ -1,0 +1,250 @@
+"""Programmatic pseudonymization helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import random
+import re
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency
+    from faker import Faker  # type: ignore
+except ImportError:  # pragma: no cover - fallback covered indirectly
+    Faker = None
+
+from .privacy_filter import PrivacyDetectionResult, PrivacySpan
+
+
+class _SimpleFaker:
+    """Minimal fallback generator when Faker is unavailable."""
+
+    FIRST_NAMES = ["Alex", "Jordan", "Taylor", "Morgan", "Casey", "Riley"]
+    LAST_NAMES = ["Hart", "Rowe", "Quinn", "Blake", "Parker", "Reed"]
+    STREETS = ["Maple Ave", "Oak Street", "Pine Road", "Cedar Lane"]
+    CITIES = ["Springfield", "Fairview", "Riverton", "Ashford"]
+    STATES = ["CA", "NY", "TX", "WA"]
+
+    def __init__(self, locale: str = "en_US"):
+        self.locale = locale
+        self.random = random.Random(0)
+
+    def seed_instance(self, seed: int) -> None:
+        self.random.seed(seed)
+
+    def name(self) -> str:
+        return f"{self.random.choice(self.FIRST_NAMES)} {self.random.choice(self.LAST_NAMES)}"
+
+    def first_name(self) -> str:
+        return self.random.choice(self.FIRST_NAMES)
+
+    def last_name(self) -> str:
+        return self.random.choice(self.LAST_NAMES)
+
+    def phone_number(self) -> str:
+        return f"({self.random.randint(200, 999)}) {self.random.randint(200, 999)}-{self.random.randint(1000, 9999)}"
+
+    def street_address(self) -> str:
+        return f"{self.random.randint(100, 9999)} {self.random.choice(self.STREETS)}"
+
+    def city(self) -> str:
+        return self.random.choice(self.CITIES)
+
+    def state_abbr(self) -> str:
+        return self.random.choice(self.STATES)
+
+    def postcode(self) -> str:
+        return f"{self.random.randint(10000, 99999)}"
+
+    def url(self) -> str:
+        return f"https://www.{self.random.choice(['example', 'sample', 'demo'])}.test"
+
+
+def _make_faker(locale: str):
+    if Faker is not None:  # pragma: no branch
+        return Faker(locale)
+    return _SimpleFaker(locale)
+
+
+@dataclass(frozen=True)
+class PseudonymizationResult:
+    """Result from pseudonymizing already-detected spans."""
+
+    text: str
+    replaced_text: str
+    replacements: Dict[str, str]
+    strategy: str
+
+    def to_metadata(self) -> Dict[str, Any]:
+        return {
+            "strategy": self.strategy,
+            "replacement_count": len(self.replacements),
+            "changed": self.text != self.replaced_text,
+        }
+
+
+class Pseudonymizer:
+    """Replace typed privacy spans with synthetic realistic values."""
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        self.config = dict(config or {})
+        self.locale = str(self.config.get("faker_locale", "en_US")).strip() or "en_US"
+        self.fake_email_domain = str(self.config.get("fake_email_domain", "example.com")).strip() or "example.com"
+        self.consistency_scope = str(self.config.get("consistency_scope", "document")).strip().lower() or "document"
+        self.preserve_date_shape = bool(self.config.get("preserve_date_shape", True))
+        self.preserve_account_number_shape = bool(self.config.get("preserve_account_number_shape", True))
+        self.secret_strategy = str(self.config.get("secret_strategy", "mask")).strip().lower() or "mask"
+        self.seed_salt = str(self.config.get("seed_salt") or os.getenv("SYNTHCHAT_PRIVACY_SEED", "synthchat-privacy"))
+        self._scope_maps: Dict[str, Dict[tuple[str, str], str]] = {}
+
+    def pseudonymize(
+        self,
+        detection: PrivacyDetectionResult,
+        *,
+        scope_key: Optional[str],
+    ) -> PseudonymizationResult:
+        """Replace detected spans with synthetic values."""
+        if not detection.spans:
+            return PseudonymizationResult(
+                text=detection.text,
+                replaced_text=detection.text,
+                replacements={},
+                strategy="programmatic",
+            )
+
+        effective_scope = self._resolve_scope_key(scope_key)
+        mapping = self._scope_maps.setdefault(effective_scope, {})
+        replacements: Dict[str, str] = {}
+        pieces: List[str] = []
+        cursor = 0
+
+        for span in detection.spans:
+            if span.start < cursor:
+                continue
+            pieces.append(detection.text[cursor:span.start])
+            replacement = mapping.get((span.label, span.text))
+            if replacement is None:
+                replacement = self._replacement_for_span(span, effective_scope)
+                mapping[(span.label, span.text)] = replacement
+            replacements[span.text] = replacement
+            pieces.append(replacement)
+            cursor = span.end
+
+        pieces.append(detection.text[cursor:])
+        return PseudonymizationResult(
+            text=detection.text,
+            replaced_text="".join(pieces),
+            replacements=replacements,
+            strategy="programmatic",
+        )
+
+    def _resolve_scope_key(self, scope_key: Optional[str]) -> str:
+        if self.consistency_scope == "run":
+            return "__run__"
+        if self.consistency_scope == "global":
+            return "__global__"
+        return str(scope_key or "__document__")
+
+    def _replacement_for_span(self, span: PrivacySpan, scope_key: str) -> str:
+        rng = random.Random(self._seed_for(scope_key, span.label, span.text))
+        fake = _make_faker(self.locale)
+        if hasattr(fake, "seed_instance"):
+            fake.seed_instance(rng.randint(0, 2**31 - 1))
+
+        if span.label == "private_person":
+            return str(fake.name())
+        if span.label == "private_email":
+            return self._fake_email(fake, rng)
+        if span.label == "private_phone":
+            return self._fake_phone(fake)
+        if span.label == "private_address":
+            return self._fake_address(fake)
+        if span.label == "private_url":
+            return self._fake_url(fake)
+        if span.label == "private_date":
+            return self._fake_date(span.text, rng)
+        if span.label == "account_number":
+            if self.preserve_account_number_shape:
+                return self._shape_preserving_digits(span.text, rng)
+            return "".join(str(rng.randint(0, 9)) for _ in range(max(8, len(re.sub(r"\D", "", span.text)))))
+        if span.label == "secret":
+            if self.secret_strategy == "mask":
+                return span.placeholder
+            return self._fake_secret(span.text, rng)
+        return span.placeholder
+
+    def _seed_for(self, scope_key: str, label: str, text: str) -> int:
+        digest = hashlib.sha256(f"{self.seed_salt}|{scope_key}|{label}|{text}".encode("utf-8")).hexdigest()
+        return int(digest[:16], 16)
+
+    def _fake_email(self, fake: Any, rng: random.Random) -> str:
+        first = str(getattr(fake, "first_name")())
+        last = str(getattr(fake, "last_name")())
+        separator = rng.choice([".", "_", ""])
+        local = f"{first}{separator}{last}".lower()
+        return f"{local}@{self.fake_email_domain}"
+
+    def _fake_phone(self, fake: Any) -> str:
+        return str(getattr(fake, "phone_number")())
+
+    def _fake_address(self, fake: Any) -> str:
+        street = str(getattr(fake, "street_address")())
+        city = str(getattr(fake, "city")())
+        state = str(getattr(fake, "state_abbr")())
+        postcode = str(getattr(fake, "postcode")())
+        return f"{street}, {city}, {state} {postcode}"
+
+    def _fake_url(self, fake: Any) -> str:
+        return str(getattr(fake, "url")())
+
+    def _fake_date(self, original_text: str, rng: random.Random) -> str:
+        if self.preserve_date_shape:
+            preserved = self._shape_preserving_date(original_text, rng)
+            if preserved:
+                return preserved
+        base = date(2024, 1, 1) + timedelta(days=rng.randint(0, 365))
+        return base.isoformat()
+
+    def _shape_preserving_date(self, original_text: str, rng: random.Random) -> Optional[str]:
+        text = original_text.strip()
+        iso_match = re.fullmatch(r"(\d{4})-(\d{2})-(\d{2})", text)
+        if iso_match:
+            shifted = date(int(iso_match.group(1)), int(iso_match.group(2)), int(iso_match.group(3))) + timedelta(days=rng.randint(30, 400))
+            return shifted.isoformat()
+        slash_match = re.fullmatch(r"(\d{1,2})/(\d{1,2})/(\d{4})", text)
+        if slash_match:
+            month = rng.randint(1, 12)
+            day = rng.randint(1, 28)
+            year = max(2000, min(2035, int(slash_match.group(3)) + rng.randint(-2, 2)))
+            return f"{month:0{len(slash_match.group(1))}d}/{day:0{len(slash_match.group(2))}d}/{year}"
+        month_name_match = re.fullmatch(r"([A-Za-z]+) (\d{1,2}), (\d{4})", text)
+        if month_name_match:
+            month_names = [
+                "January", "February", "March", "April", "May", "June",
+                "July", "August", "September", "October", "November", "December",
+            ]
+            month = rng.choice(month_names)
+            day = rng.randint(1, 28)
+            year = max(2000, min(2035, int(month_name_match.group(3)) + rng.randint(-2, 2)))
+            return f"{month} {day}, {year}"
+        return None
+
+    def _shape_preserving_digits(self, original_text: str, rng: random.Random) -> str:
+        pieces: List[str] = []
+        for char in original_text:
+            if char.isdigit():
+                pieces.append(str(rng.randint(0, 9)))
+            else:
+                pieces.append(char)
+        return "".join(pieces)
+
+    def _fake_secret(self, original_text: str, rng: random.Random) -> str:
+        alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        if original_text.startswith("sk-"):
+            return "sk-" + "".join(rng.choice(alphabet) for _ in range(max(20, len(original_text) - 3)))
+        if original_text.startswith("hf_"):
+            return "hf_" + "".join(rng.choice(alphabet) for _ in range(max(20, len(original_text) - 3)))
+        length = max(16, len(original_text))
+        return "".join(rng.choice(alphabet) for _ in range(length))

--- a/SynthChat/utils/yaml_loader.py
+++ b/SynthChat/utils/yaml_loader.py
@@ -24,7 +24,7 @@ def load_yaml(file_path: str) -> Dict[str, Any]:
     if not path.exists():
         raise FileNotFoundError(f"YAML file not found: {file_path}")
 
-    with open(path, 'r') as f:
+    with open(path, 'r', encoding='utf-8') as f:
         return yaml.safe_load(f)
 
 

--- a/docs/plans/synthchat-privacy-smoke-runbook.md
+++ b/docs/plans/synthchat-privacy-smoke-runbook.md
@@ -1,0 +1,142 @@
+# SynthChat Privacy Smoke Runbook
+
+## Purpose
+
+This is the runnable smoke sequence for the privacy preprocess feature once local compute is available.
+
+It covers:
+
+1. standalone sanitize on synthetic fixture docs
+2. standalone sanitize on a synthetic JSONL fixture
+3. docs-based SynthChat generation with privacy preprocess enabled
+4. optional vLLM-backed `llm_polish` smoke
+
+The checked-in fake inputs live under `tests/fixtures/privacy/`.
+
+## Prerequisites
+
+- `opf`, `Faker`, and `pytest` installed in the active Python environment
+- an OPF checkpoint available locally
+- enough free CPU/GPU/RAM to load the privacy filter model
+
+Recommended environment variables:
+
+```powershell
+$env:OPF_CHECKPOINT="F:\Models\privacy-filter"
+$env:VLLM_HOST="127.0.0.1"
+$env:VLLM_PORT="8000"
+```
+
+If `OPF_CHECKPOINT` is unset, OPF will try to download the default checkpoint from Hugging Face.
+
+## 1. Unit Coverage
+
+```powershell
+python -B -m pytest tests\test_privacy_preprocess.py tests\synthchat\test_labeling.py -q
+```
+
+## 2. Mask-Only Sanitize Smoke
+
+```powershell
+python -B -m SynthChat.run sanitize `
+  --input tests\fixtures\privacy\raw_seed_docs `
+  --output tmp\privacy_mask_only_docs `
+  --privacy-profile mask_only
+```
+
+```powershell
+python -B -m SynthChat.run sanitize `
+  --input tests\fixtures\privacy\raw_seed_dataset.jsonl `
+  --output tmp\privacy_mask_only_dataset.jsonl `
+  --privacy-profile mask_only
+```
+
+Expected outcome:
+
+- typed placeholders such as `[PRIVATE_PERSON]` and `[SECRET]`
+- `privacy_sanitize_report.json` for docs
+- per-record `metadata.privacy_preprocess` for JSONL output
+
+## 3. Realistic Pseudonymization Smoke
+
+```powershell
+python -B -m SynthChat.run sanitize `
+  --input tests\fixtures\privacy\raw_seed_docs `
+  --output tmp\privacy_pseudonyms_docs `
+  --privacy-profile realistic_pseudonyms
+```
+
+```powershell
+python -B -m SynthChat.run sanitize `
+  --input tests\fixtures\privacy\raw_seed_dataset.jsonl `
+  --output tmp\privacy_pseudonyms_dataset.jsonl `
+  --privacy-profile realistic_pseudonyms
+```
+
+Expected outcome:
+
+- names, emails, phones, addresses, URLs, and dates replaced with synthetic values
+- repeated entities remain consistent within a document
+- secrets remain masked when `secret_strategy: mask`
+
+## 4. Docs-Based SynthChat Generation Smoke
+
+This path verifies the integrated preprocess hook, not just standalone sanitize.
+
+```powershell
+python -B -m SynthChat.run generate `
+  --docs tests\fixtures\privacy\raw_seed_docs `
+  --targets-file SynthChat\config\targets_privacy_docs_smoke.json `
+  --privacy-profile realistic_pseudonyms `
+  --per-doc 1 `
+  --max-iterations 1 `
+  --output Datasets\synthchat\privacy_docs_smoke.jsonl
+```
+
+Inspect the output for:
+
+- `_meta.privacy_preprocess`
+- `metadata.source_doc_privacy`
+- absence of the original fixture PII strings in prompts and final examples
+
+## 5. Improve / Validate Input Sanitization Smoke
+
+These commands verify that JSONL input can be sanitized before improvement or validation sends content to the model.
+
+```powershell
+python -B -m SynthChat.run validate `
+  --input tests\fixtures\privacy\raw_seed_dataset.jsonl `
+  --privacy-profile realistic_pseudonyms
+```
+
+```powershell
+python -B -m SynthChat.run improve `
+  --input tests\fixtures\privacy\raw_seed_dataset.jsonl `
+  --privacy-profile realistic_pseudonyms `
+  --max-iterations 1 `
+  --output tmp\privacy_improve_smoke.jsonl
+```
+
+Inspect:
+
+- `metadata.privacy_preprocess_input`
+- `metadata.privacy_preprocess_output` when generated-output sanitization is enabled in settings
+- the `.improve_report.json` privacy summary fields
+
+## 6. Optional vLLM Polish Smoke
+
+Use the `realistic_pseudonyms_vllm_polish` profile only after a local OpenAI-compatible vLLM endpoint is running.
+
+```powershell
+python -B -m SynthChat.run sanitize `
+  --input tests\fixtures\privacy\raw_seed_docs `
+  --output tmp\privacy_vllm_polish_docs `
+  --privacy-profile realistic_pseudonyms_vllm_polish
+```
+
+Success criteria:
+
+- OPF sees raw fixture text locally
+- the polish model only sees sanitized text
+- synthetic entities remain unchanged
+- no masked secrets are expanded into fake secret values

--- a/tests/fixtures/privacy/raw_seed_dataset.jsonl
+++ b/tests/fixtures/privacy/raw_seed_dataset.jsonl
@@ -1,0 +1,2 @@
+{"_meta": {"fixture": "privacy_smoke", "version": 1}}
+{"conversations": [{"role": "user", "content": "Please update Jane Roe at jane.roe@example.com and call her at (415) 555-0187."}], "metadata": {"scenario": "privacy_smoke"}}

--- a/tests/fixtures/privacy/raw_seed_docs/crm_export.md
+++ b/tests/fixtures/privacy/raw_seed_docs/crm_export.md
@@ -1,0 +1,7 @@
+# CRM Export Snapshot
+
+- Customer: Maya Chen
+- Email: maya.chen@example.com
+- Phone: +1 (212) 555-0142
+- Address: 217 Maple Avenue, Riverton, WA 98052
+- Next appointment: September 18, 2026

--- a/tests/fixtures/privacy/raw_seed_docs/customer_support_email.txt
+++ b/tests/fixtures/privacy/raw_seed_docs/customer_support_email.txt
@@ -1,0 +1,8 @@
+Subject: Billing follow-up
+
+Hi Jane Roe,
+
+Thanks for calling today. I updated your contact details and noted that your preferred callback number is (415) 555-0187. If you need anything else, reply to jane.roe@example.com and reference account 4829-1037-5581.
+
+Best,
+Alex Hart

--- a/tests/fixtures/privacy/raw_seed_docs/dev_notes_with_secrets.txt
+++ b/tests/fixtures/privacy/raw_seed_docs/dev_notes_with_secrets.txt
@@ -1,0 +1,7 @@
+Deployment notes:
+
+- Service owner: Jordan Vale
+- Pager phone: 646-555-0199
+- Personal fallback email: jordan.vale@example.com
+- Temporary password: P@ssword-7781
+- API token: sk-test-ABCD1234WXYZ9876

--- a/tests/synthchat/test_labeling.py
+++ b/tests/synthchat/test_labeling.py
@@ -122,6 +122,7 @@ class TestBuildMetadataLabels:
             "stage_failures": [],
             "environment_trace": None,
             "generated_environment": {},
+            "privacy_trace": None,
             "label_mappings": _default_label_mappings(),
         }
         defaults.update(overrides)
@@ -207,3 +208,22 @@ class TestBuildMetadataLabels:
             scenario={"type": "tool", "triggers": ["On Create Note"]}
         ))
         assert "trigger:on_create_note" in result["flat"]
+
+    def test_privacy_labels(self):
+        result = build_metadata_labels(**self._base_args(
+            privacy_trace={
+                "profile": "realistic_pseudonyms",
+                "changed": True,
+                "detection": {
+                    "labels": ["private_email", "private_person"],
+                    "span_count": 2,
+                },
+            }
+        ))
+        flat = result["flat"]
+        assert "privacy:present" in flat
+        assert "privacy_changed:true" in flat
+        assert "privacy_profile:realistic_pseudonyms" in flat
+        assert "privacy_label:private_email" in flat
+        assert result["filter"]["privacy"]["present"] is True
+        assert result["filter"]["privacy"]["span_count"] == 2

--- a/tests/test_privacy_preprocess.py
+++ b/tests/test_privacy_preprocess.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from SynthChat.generator import SynthChatGenerator
+from SynthChat.modes.sanitize import _sanitize_jsonl
+from SynthChat.services.privacy_filter import PrivacyDetectionResult, PrivacySpan
+from SynthChat.services.privacy_preprocess import (
+    PrivacyPreprocessResult,
+    PrivacyPreprocessor,
+    resolve_privacy_preprocessor,
+    sanitize_payload_with_metadata,
+)
+from SynthChat.services.pseudonymizer import Pseudonymizer
+from SynthChat.utils.docs_loader import DocFile
+
+
+class _FakeLLMClient:
+    def __init__(self, responses=None):
+        self._responses = list(responses or [])
+        self.messages = []
+        self.structured_messages = []
+        self.default_max_tokens = None
+        self.provider = None
+        self.timeout_seconds = 60.0
+
+    @property
+    def provider_name(self):
+        return "openrouter"
+
+    @property
+    def model_name(self):
+        return "fake/model"
+
+    def chat(self, messages, temperature=0.7, max_tokens=2048):
+        self.messages.append({"messages": messages, "temperature": temperature, "max_tokens": max_tokens})
+        if not self._responses:
+            raise AssertionError("No more fake responses available")
+        return self._responses.pop(0)
+
+    def structured_output(self, messages, schema, temperature=0.3, max_tokens=2048):
+        self.structured_messages.append(
+            {
+                "messages": messages,
+                "schema": schema,
+                "temperature": temperature,
+                "max_tokens": max_tokens,
+            }
+        )
+        raise AssertionError("Structured output was not expected in this test")
+
+
+class _FakeDetector:
+    def __init__(self, detection: PrivacyDetectionResult):
+        self.detection = detection
+        self.calls = []
+
+    def detect(self, text: str) -> PrivacyDetectionResult:
+        self.calls.append(text)
+        return self.detection
+
+
+class _FakePreprocessor:
+    def __init__(self, sanitized_text: str):
+        self.sanitized_text = sanitized_text
+        self.calls = []
+
+    def process_text(self, text: str, *, scope_key=None):
+        self.calls.append({"text": text, "scope_key": scope_key})
+        return PrivacyPreprocessResult(
+            original_text=text,
+            masked_text=self.sanitized_text,
+            sanitized_text=self.sanitized_text,
+            changed=self.sanitized_text != text,
+            profile_name="mask_only",
+            detection={"labels": ["private_person"], "span_count": 1, "by_label": {"private_person": 1}, "spans": []},
+            transform={"mode": "mask", "changed": self.sanitized_text != text},
+            polish=None,
+        )
+
+
+class _FakeSanitizePreprocessor:
+    profile_name = "mask_only"
+
+    def sanitize_payload(self, payload, *, scope_key=None):
+        data = json.loads(json.dumps(payload))
+        text = data["conversations"][0]["content"]
+        data["conversations"][0]["content"] = text.replace("Jane Roe", "[PRIVATE_PERSON]").replace(
+            "jane.roe@example.com", "[PRIVATE_EMAIL]"
+        )
+        return data, [{"path": "conversations[0].content", "profile": self.profile_name, "changed": True}]
+
+
+class _FakeOutputPreprocessor:
+    profile_name = "mask_only"
+
+    def process_text(self, text: str, *, scope_key=None):
+        return PrivacyPreprocessResult(
+            original_text=text,
+            masked_text=text,
+            sanitized_text=text,
+            changed=False,
+            profile_name=self.profile_name,
+            detection={"labels": [], "span_count": 0, "by_label": {}, "spans": []},
+            transform={"mode": "mask", "changed": False},
+            polish=None,
+        )
+
+    def sanitize_payload(self, payload, *, scope_key=None):
+        data = json.loads(json.dumps(payload))
+        reports = []
+        for index, message in enumerate(data.get("conversations", [])):
+            content = message.get("content")
+            if isinstance(content, str) and "Jane Roe" in content:
+                message["content"] = content.replace("Jane Roe", "[PRIVATE_PERSON]")
+                reports.append(
+                    {
+                        "path": f"conversations[{index}].content",
+                        "profile": self.profile_name,
+                        "changed": True,
+                        "detection": {
+                            "labels": ["private_person"],
+                            "span_count": 1,
+                        },
+                    }
+                )
+        return data, reports
+
+
+def test_pseudonymizer_preserves_account_number_shape():
+    detection = PrivacyDetectionResult(
+        text="Account 4829-1037-5581 is on file.",
+        masked_text="Account [ACCOUNT_NUMBER] is on file.",
+        spans=(
+            PrivacySpan(
+                label="account_number",
+                start=8,
+                end=22,
+                text="4829-1037-5581",
+                placeholder="[ACCOUNT_NUMBER]",
+            ),
+        ),
+        provider="opf",
+    )
+    result = Pseudonymizer({"preserve_account_number_shape": True}).pseudonymize(
+        detection,
+        scope_key="doc-1",
+    )
+    replaced = result.replaced_text.split("Account ", 1)[1].split(" is on file.", 1)[0]
+    assert replaced != "4829-1037-5581"
+    assert len(replaced) == len("4829-1037-5581")
+    assert replaced.count("-") == 2
+
+
+def test_privacy_preprocessor_pseudonymizes_detected_spans():
+    text = "Contact Jane Roe at jane.roe@example.com."
+    detection = PrivacyDetectionResult(
+        text=text,
+        masked_text="Contact [PRIVATE_PERSON] at [PRIVATE_EMAIL].",
+        spans=(
+            PrivacySpan(
+                label="private_person",
+                start=8,
+                end=16,
+                text="Jane Roe",
+                placeholder="[PRIVATE_PERSON]",
+            ),
+            PrivacySpan(
+                label="private_email",
+                start=20,
+                end=40,
+                text="jane.roe@example.com",
+                placeholder="[PRIVATE_EMAIL]",
+            ),
+        ),
+        provider="opf",
+    )
+    preprocessor = PrivacyPreprocessor(
+        profile_name="realistic_pseudonyms",
+        profile={
+            "detector": {"provider": "opf"},
+            "transform": {
+                "mode": "pseudonymize",
+                "provider": "programmatic",
+                "fake_email_domain": "example.com",
+            },
+        },
+        detector=_FakeDetector(detection),
+    )
+    result = preprocessor.process_text(text, scope_key="doc-1")
+    assert result.changed is True
+    assert "Jane Roe" not in result.sanitized_text
+    assert "jane.roe@example.com" not in result.sanitized_text
+    assert "@example.com" in result.sanitized_text
+
+
+def test_generator_uses_sanitized_doc_seed_in_prompt():
+    repo_root = Path(__file__).resolve().parents[1]
+    config_dir = repo_root / "SynthChat" / "config"
+    scenarios_dir = repo_root / "SynthChat" / "scenarios"
+    rubrics_dir = repo_root / "SynthChat" / "rubrics"
+
+    fake_preprocessor = _FakePreprocessor("Customer record for [PRIVATE_PERSON].")
+
+    def _factory(*, profile_name, profiles_registry):
+        return fake_preprocessor
+
+    client = _FakeLLMClient(
+        responses=[
+            "Write a request about the customer record.",
+            "I can help with that.",
+        ]
+    )
+    generator = SynthChatGenerator(
+        config_dir=config_dir,
+        scenarios_dir=scenarios_dir,
+        rubrics_dir=rubrics_dir,
+        llm_client=client,
+        engine=None,
+        enable_stage_validation=False,
+        privacy_settings={"enabled": False, "apply_to": {"docs": True}},
+        privacy_preprocessor_factory=_factory,
+    )
+
+    scenario = {
+        "type": "behavioral",
+        "system": False,
+        "seed_data": {"preprocess_profile": "mask_only"},
+        "prompts": {
+            "user": "Create a user request about this source document:\n{doc_content}",
+            "assistant": "Reply briefly to the user.",
+        },
+    }
+    doc_context = DocFile(path="tests/fixtures/privacy/raw_seed_docs/customer_support_email.txt", content="Customer record for Jane Roe.")
+
+    result = generator.generate_single(
+        scenario_key="privacy_doc_test",
+        scenario=scenario,
+        max_iterations=1,
+        randomize_params=False,
+        doc_context=doc_context,
+    )
+
+    prompt_dump = json.dumps(client.messages[0]["messages"])
+    assert "[PRIVATE_PERSON]" in prompt_dump
+    assert "Jane Roe" not in prompt_dump
+    assert result.example["metadata"]["source_doc_privacy"]["profile"] == "mask_only"
+
+
+def test_sanitize_jsonl_adds_privacy_metadata():
+    tmp_path = Path("tmp/test_privacy_preprocess") / uuid4().hex
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    try:
+        input_path = tmp_path / "input.jsonl"
+        output_path = tmp_path / "output.jsonl"
+        input_path.write_text(
+            '\n'.join(
+                [
+                    json.dumps({"_meta": {"version": 1}}),
+                    json.dumps(
+                        {
+                            "conversations": [
+                                {"role": "user", "content": "Contact Jane Roe at jane.roe@example.com"}
+                            ]
+                        }
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        summary = _sanitize_jsonl(input_path, output_path, _FakeSanitizePreprocessor())
+        lines = [json.loads(line) for line in output_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+        assert summary["records_processed"] == 1
+        assert lines[0]["_meta"]["privacy_preprocess"]["profile"] == "mask_only"
+        assert lines[1]["metadata"]["privacy_preprocess"]["changed"] is True
+        assert "[PRIVATE_PERSON]" in lines[1]["conversations"][0]["content"]
+    finally:
+        shutil.rmtree(tmp_path, ignore_errors=True)
+
+
+def test_sanitize_payload_with_metadata_adds_summary():
+    payload = {
+        "conversations": [
+            {"role": "user", "content": "Contact Jane Roe at jane.roe@example.com"}
+        ]
+    }
+    sanitized_payload, summary = sanitize_payload_with_metadata(
+        payload,
+        preprocessor=_FakeSanitizePreprocessor(),
+        scope_key="example-1",
+        metadata_field="privacy_preprocess_input",
+    )
+
+    assert summary["profile"] == "mask_only"
+    assert summary["changed"] is True
+    assert sanitized_payload["metadata"]["privacy_preprocess_input"]["report_count"] == 1
+    assert "[PRIVATE_PERSON]" in sanitized_payload["conversations"][0]["content"]
+
+
+def test_resolve_privacy_preprocessor_for_input_jsonl():
+    repo_root = Path(__file__).resolve().parents[1]
+    preprocessor = resolve_privacy_preprocessor(
+        config_dir=repo_root / "SynthChat" / "config",
+        settings={
+            "privacy_preprocess": {
+                "enabled": True,
+                "profile": "mask_only",
+                "apply_to": {
+                    "docs": False,
+                    "input_jsonl": True,
+                    "generated_output": False,
+                },
+            }
+        },
+        apply_target="input_jsonl",
+    )
+
+    assert preprocessor is not None
+    assert preprocessor.profile_name == "mask_only"
+
+
+def test_generator_sanitizes_generated_output_when_enabled():
+    repo_root = Path(__file__).resolve().parents[1]
+    config_dir = repo_root / "SynthChat" / "config"
+    scenarios_dir = repo_root / "SynthChat" / "scenarios"
+    rubrics_dir = repo_root / "SynthChat" / "rubrics"
+
+    fake_preprocessor = _FakeOutputPreprocessor()
+
+    def _factory(*, profile_name, profiles_registry):
+        return fake_preprocessor
+
+    client = _FakeLLMClient(
+        responses=[
+            "Ask Jane Roe to confirm the account update.",
+            "Jane Roe has already confirmed the update.",
+        ]
+    )
+    generator = SynthChatGenerator(
+        config_dir=config_dir,
+        scenarios_dir=scenarios_dir,
+        rubrics_dir=rubrics_dir,
+        llm_client=client,
+        engine=None,
+        enable_stage_validation=False,
+        privacy_settings={"enabled": False, "apply_to": {"generated_output": True}},
+        privacy_preprocessor_factory=_factory,
+    )
+
+    scenario = {
+        "type": "behavioral",
+        "system": False,
+        "seed_data": {"preprocess_profile": "mask_only"},
+        "prompts": {
+            "user": "Create a user request about an account update.",
+            "assistant": "Reply briefly to the user.",
+        },
+    }
+
+    result = generator.generate_single(
+        scenario_key="privacy_output_test",
+        scenario=scenario,
+        max_iterations=1,
+        randomize_params=False,
+    )
+
+    rendered = json.dumps(result.example["conversations"])
+    assert "Jane Roe" not in rendered
+    assert "[PRIVATE_PERSON]" in rendered
+    assert result.example["metadata"]["generated_output_privacy"]["changed"] is True
+    assert "privacy_label:private_person" in result.example["metadata"]["labels"]["flat"]

--- a/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/input.jsonl
+++ b/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/input.jsonl
@@ -1,0 +1,2 @@
+{"_meta": {"version": 1}}
+{"conversations": [{"role": "user", "content": "Contact Jane Roe at jane.roe@example.com"}]}

--- a/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/input.jsonl
+++ b/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/input.jsonl
@@ -1,2 +1,0 @@
-{"_meta": {"version": 1}}
-{"conversations": [{"role": "user", "content": "Contact Jane Roe at jane.roe@example.com"}]}

--- a/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/output.jsonl
+++ b/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/output.jsonl
@@ -1,0 +1,2 @@
+{"_meta": {"version": 1, "privacy_preprocess": {"profile": "mask_only"}}}
+{"conversations": [{"role": "user", "content": "Contact [PRIVATE_PERSON] at [PRIVATE_EMAIL]"}], "metadata": {"privacy_preprocess": {"profile": "mask_only", "changed": true, "report_count": 1, "reports": [{"path": "conversations[0].content", "profile": "mask_only", "changed": true}]}}}

--- a/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/output.jsonl
+++ b/tmp/test_privacy_preprocess/614aaa366212417da24df4bc9c2271b1/output.jsonl
@@ -1,2 +1,0 @@
-{"_meta": {"version": 1, "privacy_preprocess": {"profile": "mask_only"}}}
-{"conversations": [{"role": "user", "content": "Contact [PRIVATE_PERSON] at [PRIVATE_EMAIL]"}], "metadata": {"privacy_preprocess": {"profile": "mask_only", "changed": true, "report_count": 1, "reports": [{"path": "conversations[0].content", "profile": "mask_only", "changed": true}]}}}


### PR DESCRIPTION
## Summary
- add OPF-backed privacy preprocessing and programmatic pseudonymization to SynthChat
- add sanitize mode, ingress/egress privacy hooks, metadata labels, fixtures, and tests
- document offline/local OPF setup and privacy smoke workflows in the SynthChat skill docs
