### PR TITLE
Add LLM-judge reward to GRPO

### DIFF
--- a/Trainers/grpo/configs/rewards/README.md
+++ b/Trainers/grpo/configs/rewards/README.md
@@ -15,9 +15,13 @@ rewards/
 
 ## How It Works
 
-1. **Schema Reference**: All rubrics reference `tool_schema.yaml` for structure definitions
+1. **Schema Reference**: Rule-based rubrics reference `tool_schema.yaml` for structure definitions
 2. **StructureValidator**: Uses `shared/validation` for extraction and validation
-3. **Deterministic Scoring**: No LLM judge - pure rule-based scoring
+3. **Two scoring paths**:
+   - **Deterministic**: rule-based scoring against ground truth (default — see `args_match.yaml`, `format.yaml`, etc.)
+   - **LLM-judge**: see `judge_rubric.yaml` — opt-in path that scores completions
+     via `shared/judge` for non-verifiable criteria (instruction following,
+     formatting, safety). Used by setting `type: judge_rubric` in the YAML.
 
 ## Adding a New Reward
 

--- a/Trainers/grpo/configs/rewards/judge_rubric.yaml
+++ b/Trainers/grpo/configs/rewards/judge_rubric.yaml
@@ -1,0 +1,52 @@
+# LLM-as-judge reward — scores completions against atomic rubrics
+# via the shared/judge service.
+#
+# This is a TEMPLATE. To activate:
+#   1. Author rubric YAMLs matching shared.judge.RubricDef schema.
+#      Required fields per rubric: name, description, scope, pass_threshold,
+#      judge_prompt, output_schema. The judge_prompt may use template vars
+#      {prompt} / {user_prompt} (the user prompt) and {response} (the model
+#      completion).
+#   2. Set rubrics_dir below to that directory and list rubric_keys
+#      (filename stems without .yaml).
+#   3. Configure the judge LLM under `judge:` — any backend supported by
+#      shared.llm.create_client (openrouter | lmstudio | ollama | unsloth).
+#   4. Pick an aggregation strategy.
+#   5. Add this rubric to rewards.items in configs/config.yaml with a weight.
+#
+# All per-completion judging is one structured-output LLM call covering every
+# rubric (multi-rubric schema), regardless of how many rubrics are listed.
+
+name: judge_rubric
+description: LLM-judge reward scoring completions against atomic rubrics
+type: judge_rubric
+
+# Directory containing rubric YAMLs (RubricLoader format).
+# Paths may be absolute or relative to Trainers/grpo/.
+rubrics_dir: "../../Datasets/judge_rubrics"
+
+# Rubric filename stems (without .yaml) to load from rubrics_dir.
+# Activation requires at least one entry — leaving this empty fails fast at
+# trainer startup with a clear error.
+rubric_keys: []
+
+# Judge LLM. Resolved through shared.llm.create_client.
+judge:
+  backend: openrouter        # openrouter | lmstudio | ollama | unsloth
+  model: openai/gpt-5-mini
+  temperature: 0.3
+  max_tokens: 2048
+  # Provider-specific overrides (only used by the matching backend):
+  # lmstudio_host: localhost
+  # lmstudio_port: 1234
+  # ollama_host: localhost
+  # ollama_port: 11434
+  # provider_routing: { order: [Groq] }
+
+# How to reduce per-rubric scores into a single scalar reward in [0, 1].
+# Options:
+#   mean_score   — mean of [0,1] per-rubric scores
+#   mean_passed  — mean of `passed` booleans (rubric passes if score >= pass_threshold)
+#   min_score    — bottleneck score across rubrics
+#   all_pass     — 1.0 only if every rubric passes, else 0.0
+aggregation: mean_passed

--- a/Trainers/grpo/src/judge_reward.py
+++ b/Trainers/grpo/src/judge_reward.py
@@ -1,0 +1,212 @@
+"""GRPO/GSPO reward backed by the shared LLM-as-judge service.
+
+Wires shared/judge into the GRPO reward pipeline. Each completion is sent to a
+configured judge LLM with a list of user-supplied rubrics, and the per-rubric
+scores are aggregated into a single scalar reward via a configurable strategy.
+
+Activated from `configs/rewards/judge_rubric.yaml` (type: judge_rubric) and
+dispatched in `Trainers/grpo/src/rewards.py::build_combined_reward_function`.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from shared.judge import (
+    JudgeConfig,
+    JudgeResult,
+    JudgeService,
+    RubricDef,
+    RubricLoader,
+)
+from shared.llm import LLMConfig, create_client
+
+logger = logging.getLogger(__name__)
+
+_AGGREGATIONS = ("mean_score", "mean_passed", "min_score", "all_pass")
+
+
+def _aggregate(result: JudgeResult, strategy: str) -> float:
+    if not result.scores:
+        return 0.0
+    if strategy == "mean_score":
+        return sum(s.score for s in result.scores) / len(result.scores)
+    if strategy == "mean_passed":
+        return sum(1.0 if s.passed else 0.0 for s in result.scores) / len(result.scores)
+    if strategy == "min_score":
+        return min(s.score for s in result.scores)
+    if strategy == "all_pass":
+        return 1.0 if all(s.passed for s in result.scores) else 0.0
+    raise ValueError(
+        f"Unknown aggregation '{strategy}'. Must be one of: {', '.join(_AGGREGATIONS)}"
+    )
+
+
+def _coerce_completion_text(completion: Any) -> str:
+    if isinstance(completion, str):
+        return completion
+    if isinstance(completion, list) and completion:
+        first = completion[0]
+        if isinstance(first, dict) and "content" in first:
+            return str(first.get("content") or "")
+    if isinstance(completion, dict) and "content" in completion:
+        return str(completion.get("content") or "")
+    return str(completion)
+
+
+def _coerce_prompt_text(prompt: Any) -> str:
+    if prompt is None:
+        return ""
+    if isinstance(prompt, str):
+        return prompt
+    if isinstance(prompt, list) and prompt:
+        last = prompt[-1]
+        if isinstance(last, dict) and "content" in last:
+            return str(last.get("content") or "")
+    return str(prompt)
+
+
+def _resolve_dir(value: str, base_dir: Path) -> Path:
+    p = Path(value)
+    return p if p.is_absolute() else (base_dir / p).resolve()
+
+
+def _build_judge_service(judge_cfg: Dict[str, Any]) -> JudgeService:
+    backend = judge_cfg.get("backend")
+    model = judge_cfg.get("model")
+    if not backend or not model:
+        raise ValueError(
+            "judge_rubric reward requires 'judge.backend' and 'judge.model' in YAML"
+        )
+
+    llm_config = LLMConfig.from_env(env_prefix="IMPROVEMENT")
+    llm_config.provider = str(backend).lower()
+    llm_config.model = str(model)
+
+    for key in (
+        "lmstudio_host",
+        "lmstudio_port",
+        "ollama_host",
+        "ollama_port",
+        "provider_routing",
+        "openrouter_timeout_seconds",
+        "unsloth_max_seq_length",
+        "unsloth_load_in_4bit",
+        "unsloth_top_p",
+    ):
+        if key in judge_cfg:
+            setattr(llm_config, key, judge_cfg[key])
+
+    llm_client = create_client(config=llm_config)
+
+    judge_config = JudgeConfig(
+        temperature=float(judge_cfg.get("temperature", 0.3)),
+        max_tokens=int(judge_cfg.get("max_tokens", 2048)),
+    )
+    return JudgeService(llm_client, judge_config)
+
+
+def _render_combined_prompt(
+    rubrics: List[RubricDef],
+    template_vars: Dict[str, str],
+) -> str:
+    """Concatenate per-rubric judge_prompt templates after substituting vars."""
+    parts: List[str] = []
+    for rubric in rubrics:
+        rendered = rubric.judge_prompt
+        for k, v in template_vars.items():
+            rendered = rendered.replace(f"{{{k}}}", str(v))
+        if len(rubrics) == 1:
+            parts.append(rendered)
+        else:
+            parts.append(f"=== {rubric.name} ===\n{rendered}")
+    return "\n\n".join(parts)
+
+
+def build_judge_rubric_reward(
+    rubric_config: Dict[str, Any],
+    base_dir: Path,
+) -> Callable:
+    """Build a TRL-compatible reward function that scores via shared/judge.
+
+    Args:
+        rubric_config: Loaded YAML config for the judge_rubric reward. Expected:
+            - rubrics_dir (str): Directory containing rubric YAMLs (compatible
+              with shared.judge.RubricLoader).
+            - rubric_keys (list[str]): Filename stems (without .yaml) to load.
+            - judge (dict): Judge LLM config; requires 'backend' and 'model'.
+              Optional: 'temperature', 'max_tokens', and any matching
+              shared.llm.LLMConfig field (e.g. 'lmstudio_host', 'ollama_port',
+              'provider_routing').
+            - aggregation (str): One of mean_score | mean_passed | min_score |
+              all_pass. Default: mean_passed.
+        base_dir: Base directory for resolving relative paths.
+
+    Returns:
+        Reward fn with signature (completions, prompts=None, **kwargs) -> List[float]
+    """
+    rubrics_dir_raw = rubric_config.get("rubrics_dir")
+    rubric_keys = rubric_config.get("rubric_keys") or []
+    judge_cfg = rubric_config.get("judge") or {}
+    aggregation = rubric_config.get("aggregation", "mean_passed")
+
+    if not rubrics_dir_raw:
+        raise ValueError("judge_rubric reward requires 'rubrics_dir' in YAML")
+    if not rubric_keys:
+        raise ValueError(
+            "judge_rubric reward requires non-empty 'rubric_keys' in YAML"
+        )
+    if aggregation not in _AGGREGATIONS:
+        raise ValueError(
+            f"judge_rubric 'aggregation' must be one of {_AGGREGATIONS}, "
+            f"got '{aggregation}'"
+        )
+
+    rubrics_dir = _resolve_dir(rubrics_dir_raw, base_dir)
+    loader = RubricLoader(rubrics_dir)
+    rubrics: List[RubricDef] = loader.load_many(list(rubric_keys))
+
+    judge_service = _build_judge_service(judge_cfg)
+
+    logger.info(
+        "judge_rubric reward initialized: %d rubric(s) from %s, backend=%s, "
+        "aggregation=%s",
+        len(rubrics),
+        rubrics_dir,
+        judge_cfg.get("backend"),
+        aggregation,
+    )
+
+    def _reward(completions, prompts=None, **kwargs):
+        rewards: List[float] = []
+        n = len(completions)
+        if isinstance(prompts, list):
+            prompts_list = prompts
+        else:
+            prompts_list = [prompts] * n
+
+        for i, completion in enumerate(completions):
+            response_text = _coerce_completion_text(completion)
+            prompt_value = prompts_list[i] if i < len(prompts_list) else prompts_list[-1]
+            prompt_text = _coerce_prompt_text(prompt_value)
+
+            template_vars = {
+                "prompt": prompt_text,
+                "user_prompt": prompt_text,
+                "response": response_text,
+            }
+            rendered = _render_combined_prompt(rubrics, template_vars)
+
+            result = judge_service.judge(prompt=rendered, rubrics=rubrics)
+            if result.error:
+                logger.warning("judge_rubric judge call failed: %s", result.error)
+                rewards.append(0.0)
+                continue
+
+            rewards.append(_aggregate(result, aggregation))
+
+        return rewards
+
+    return _reward

--- a/Trainers/grpo/src/rewards.py
+++ b/Trainers/grpo/src/rewards.py
@@ -686,6 +686,9 @@ def build_combined_reward_function(
                 if rubric_type == "fitness_evaluator":
                     fitness_config_path = rubric.config.get("config_path")
                     func = build_fitness_reward(config_path=fitness_config_path)
+                elif rubric_type == "judge_rubric":
+                    from .judge_reward import build_judge_rubric_reward
+                    func = build_judge_rubric_reward(rubric.config, base_dir)
                 else:
                     func = build_rubric_reward(rubric)
                 components.append((name, weight, func))


### PR DESCRIPTION
Wires shared/judge into the GRPO reward pipeline so non-verifiable prompts
can be scored against atomic rubrics (instruction following, formatting,
safety) — the rubric-as-reward path Perplexity describes for guardrail
prompts during RL.

- New module Trainers/grpo/src/judge_reward.py builds a TRL reward fn
  that judges each completion against a list of RubricLoader-format
  rubrics in one structured-output call, then aggregates per-rubric
  scores via mean_score | mean_passed | min_score | all_pass.
- New configs/rewards/judge_rubric.yaml template (type: judge_rubric)
  exposes rubrics_dir, rubric_keys, judge backend/model, and aggregation
  for user-driven configuration. Inactive until added to rewards.items.
- rewards.py dispatches type: judge_rubric to build_judge_rubric_reward.
- README updated to describe the deterministic vs LLM-judge paths.