### PR TITLE
fix: lazy-import sync_bucket to unblock CLI

### DIFF
--- a/shared/utilities/bucket_artifacts.py
+++ b/shared/utilities/bucket_artifacts.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from typing import Any, Iterable, TextIO
 
 from huggingface_hub import HfFileSystem
-from huggingface_hub import sync_bucket
 
 from shared.cloud_artifacts import sync_directory_to_hf_bucket, sync_file_to_hf_bucket
 from shared.utilities.env import get_hf_token
@@ -178,6 +177,8 @@ def pull_artifacts(
     target.parent.mkdir(parents=True, exist_ok=True)
 
     if artifact_path.startswith("hf://"):
+        from huggingface_hub import sync_bucket
+
         sync_bucket(artifact_path, str(target), token=get_hf_token())
         return target
 


### PR DESCRIPTION
## Summary
- Move `sync_bucket` import from top-level to inside `pull_artifacts()` where it's actually used
- Fixes: the entire CLI (TUI, local-run, cloud-run) was killed in conda envs where `huggingface_hub` doesn't export `sync_bucket` (e.g., `unsloth_latest` with `huggingface_hub` 0.36.0)
- Only cloud bucket operations need this function — local/TUI workflows should never fail on it

## Test plan
- [x] `conda run -n unsloth_latest python -c "from tuner.cli.router import route_command; print('OK')"` passes
- [x] `python tuner.py --help` prints full usage without error
- [x] Cloud bucket operations still work (import happens at call time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)