### PR TITLE
docs(plans): add POLAR-inspired token-faithful GRPO plans

### DIFF
--- a/.agents/skills/fine-tuning/SKILL.md
+++ b/.agents/skills/fine-tuning/SKILL.md
@@ -501,6 +501,7 @@ Provider-native storage defaults:
 - SFT with `packing: true` is much faster.
 - KTO datasets must be interleaved True/False.
 - GRPO rewards are YAML-driven; edit `configs/rewards/`, not Python.
+- Env-GRPO multi-turn rollouts are token-faithful by default (`env_training.token_faithful: true`, requires `trl>=0.28.0`); it emits a per-token `env_mask` so GRPO trains only on sampled tokens. See `reference/grpo-training.md` → "Token-Faithful Multi-Turn Rollout".
 - `fitness.yaml` uses `FitnessEvaluator` for structural validation.
 - After training, use surgery only after you have a stable baseline and evaluation scenario.
 - `training_lineage.json` tracks full provenance for reproducibility.

--- a/.agents/skills/fine-tuning/reference/grpo-training.md
+++ b/.agents/skills/fine-tuning/reference/grpo-training.md
@@ -294,6 +294,64 @@ Normalization handles: argument key reordering, type coercion (`"true"` → `tru
 
 ---
 
+## Token-Faithful Multi-Turn Rollout (Env-GRPO)
+
+Environment-backed GRPO (`train_env_grpo.py`) rolls out multi-turn episodes: the
+model emits a tool call, the environment executes it, the result is fed back, the
+model responds again, and so on. By default the trainer now serializes these
+episodes **token-faithfully** (POLAR-style, arXiv:2605.24220): GRPO trains on
+exactly the tokens the model sampled while still conditioning on the real
+tool-result / user-feedback context.
+
+**Why it matters.** The legacy serialization flattened every assistant turn's
+tokens into one contiguous completion and dropped the intermediate tool-result /
+user-feedback tokens entirely. GRPO then optimized a fictional stream that never
+existed at sampling time — a train/inference mismatch. Faithful mode keeps the
+full interleaved sequence and supplies a per-token `env_mask` (model token = 1,
+external context token = 0) that TRL multiplies into the completion loss mask: the
+model attends to the real context but is trained only on its own tokens.
+
+### Config
+
+In `Trainers/grpo/configs/env_config.yaml` under `env_training:`:
+
+```yaml
+env_training:
+  token_faithful: true          # emit faithful sequence + env_mask (default)
+  context_token_policy: mask     # "mask" = faithful; "drop" = legacy flattened (A/B only)
+```
+
+- **Single-turn episodes are byte-identical** under either policy — the change
+  only affects episodes with more than one assistant turn.
+- Requires **`trl>=0.28.0`** (when `env_mask` became a real loss mask). The rollout
+  builder probes the installed TRL via `detect_openenv_runtime_support()['has_env_mask']`
+  and, if the runtime can't honor `env_mask`, **auto-falls back to the legacy
+  flattened path** (with a warning) rather than train on context tokens.
+- Use `context_token_policy: drop` only to A/B against the old behavior.
+
+### How the sequence is built
+
+For each episode the rollout records per-turn `(prompt_ids, completion_ids,
+logprobs)` from `generate_rollout_completions`, then assembles:
+
+- `prompt_ids` = the first turn's rendered prompt.
+- `completion_ids` = assistant turn 1 ++ context(1→2) ++ assistant turn 2 ++ …,
+  where context tokens are the tail of the next turn's rendered prompt (the same
+  length-delta slicing TRL's internal tool loop uses). Assistant spans use the raw
+  sampled token ids, so trained tokens stay byte-faithful.
+- `env_mask` = 1 on assistant tokens, 0 on context tokens (same length as
+  `completion_ids`).
+- `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
+
+### Verifying
+
+`tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the
+interleaved multi-turn sequence, mask/logprob length alignment, the capability
+gate, and the rollout_func output contract. Before a full launch, run a short
+env-GRPO smoke job and confirm the run does not raise a length/logprob mismatch.
+
+---
+
 ## Platform Note
 
 GRPO requires **WSL/Linux only** — native Windows is not supported.

--- a/.agents/skills/fine-tuning/reference/grpo-training.md
+++ b/.agents/skills/fine-tuning/reference/grpo-training.md
@@ -343,6 +343,29 @@ logprobs)` from `generate_rollout_completions`, then assembles:
   `completion_ids`).
 - `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
 
+### What TRL does with it (verified against trl source)
+
+`completion_mask` is all-ones over `completion_ids`, so the full interleaved
+sequence (assistant + context) is **attended** — the model, the `old`/reference
+logprobs, and the importance-sampling ratio are all computed conditioned on the
+real context. The loss uses `mask = completion_mask * tool_mask`, and every loss
+variant normalizes by `mask.sum()`, so context tokens contribute **zero to the
+loss and are excluded from the denominator** (no dilution). Our supplied per-token
+`logprobs` only feed the vLLM importance-sampling correction and are themselves
+multiplied by the mask, so the `0.0` placeholders on context tokens are inert.
+Reward grouping is unchanged (one record per episode → `rewards.view(-1,
+num_generations)`), and length metrics count only model tokens (`sum(env_mask)`).
+
+### Caveat — sequence-length budget
+
+In faithful mode the tool-result / user-feedback tokens live **inside**
+`completion_ids` (masked), so the trained completion spans all turns *plus* their
+context. `max_completion_length` caps each turn's generation, not the episode
+total, so the full sequence can be several times `max_completion_length`. Size
+`max_seq_length` / VRAM for the whole interleaved episode. (Legacy `drop` mode
+already concatenated assistant turns; faithful mode adds the context tokens on
+top.)
+
 ### Verifying
 
 `tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the

--- a/.claude/skills/fine-tuning/SKILL.md
+++ b/.claude/skills/fine-tuning/SKILL.md
@@ -501,6 +501,7 @@ Provider-native storage defaults:
 - SFT with `packing: true` is much faster.
 - KTO datasets must be interleaved True/False.
 - GRPO rewards are YAML-driven; edit `configs/rewards/`, not Python.
+- Env-GRPO multi-turn rollouts are token-faithful by default (`env_training.token_faithful: true`, requires `trl>=0.28.0`); it emits a per-token `env_mask` so GRPO trains only on sampled tokens. See `reference/grpo-training.md` → "Token-Faithful Multi-Turn Rollout".
 - `fitness.yaml` uses `FitnessEvaluator` for structural validation.
 - After training, use surgery only after you have a stable baseline and evaluation scenario.
 - `training_lineage.json` tracks full provenance for reproducibility.

--- a/.claude/skills/fine-tuning/reference/grpo-training.md
+++ b/.claude/skills/fine-tuning/reference/grpo-training.md
@@ -294,6 +294,64 @@ Normalization handles: argument key reordering, type coercion (`"true"` → `tru
 
 ---
 
+## Token-Faithful Multi-Turn Rollout (Env-GRPO)
+
+Environment-backed GRPO (`train_env_grpo.py`) rolls out multi-turn episodes: the
+model emits a tool call, the environment executes it, the result is fed back, the
+model responds again, and so on. By default the trainer now serializes these
+episodes **token-faithfully** (POLAR-style, arXiv:2605.24220): GRPO trains on
+exactly the tokens the model sampled while still conditioning on the real
+tool-result / user-feedback context.
+
+**Why it matters.** The legacy serialization flattened every assistant turn's
+tokens into one contiguous completion and dropped the intermediate tool-result /
+user-feedback tokens entirely. GRPO then optimized a fictional stream that never
+existed at sampling time — a train/inference mismatch. Faithful mode keeps the
+full interleaved sequence and supplies a per-token `env_mask` (model token = 1,
+external context token = 0) that TRL multiplies into the completion loss mask: the
+model attends to the real context but is trained only on its own tokens.
+
+### Config
+
+In `Trainers/grpo/configs/env_config.yaml` under `env_training:`:
+
+```yaml
+env_training:
+  token_faithful: true          # emit faithful sequence + env_mask (default)
+  context_token_policy: mask     # "mask" = faithful; "drop" = legacy flattened (A/B only)
+```
+
+- **Single-turn episodes are byte-identical** under either policy — the change
+  only affects episodes with more than one assistant turn.
+- Requires **`trl>=0.28.0`** (when `env_mask` became a real loss mask). The rollout
+  builder probes the installed TRL via `detect_openenv_runtime_support()['has_env_mask']`
+  and, if the runtime can't honor `env_mask`, **auto-falls back to the legacy
+  flattened path** (with a warning) rather than train on context tokens.
+- Use `context_token_policy: drop` only to A/B against the old behavior.
+
+### How the sequence is built
+
+For each episode the rollout records per-turn `(prompt_ids, completion_ids,
+logprobs)` from `generate_rollout_completions`, then assembles:
+
+- `prompt_ids` = the first turn's rendered prompt.
+- `completion_ids` = assistant turn 1 ++ context(1→2) ++ assistant turn 2 ++ …,
+  where context tokens are the tail of the next turn's rendered prompt (the same
+  length-delta slicing TRL's internal tool loop uses). Assistant spans use the raw
+  sampled token ids, so trained tokens stay byte-faithful.
+- `env_mask` = 1 on assistant tokens, 0 on context tokens (same length as
+  `completion_ids`).
+- `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
+
+### Verifying
+
+`tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the
+interleaved multi-turn sequence, mask/logprob length alignment, the capability
+gate, and the rollout_func output contract. Before a full launch, run a short
+env-GRPO smoke job and confirm the run does not raise a length/logprob mismatch.
+
+---
+
 ## Platform Note
 
 GRPO requires **WSL/Linux only** — native Windows is not supported.

--- a/.claude/skills/fine-tuning/reference/grpo-training.md
+++ b/.claude/skills/fine-tuning/reference/grpo-training.md
@@ -343,6 +343,29 @@ logprobs)` from `generate_rollout_completions`, then assembles:
   `completion_ids`).
 - `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
 
+### What TRL does with it (verified against trl source)
+
+`completion_mask` is all-ones over `completion_ids`, so the full interleaved
+sequence (assistant + context) is **attended** — the model, the `old`/reference
+logprobs, and the importance-sampling ratio are all computed conditioned on the
+real context. The loss uses `mask = completion_mask * tool_mask`, and every loss
+variant normalizes by `mask.sum()`, so context tokens contribute **zero to the
+loss and are excluded from the denominator** (no dilution). Our supplied per-token
+`logprobs` only feed the vLLM importance-sampling correction and are themselves
+multiplied by the mask, so the `0.0` placeholders on context tokens are inert.
+Reward grouping is unchanged (one record per episode → `rewards.view(-1,
+num_generations)`), and length metrics count only model tokens (`sum(env_mask)`).
+
+### Caveat — sequence-length budget
+
+In faithful mode the tool-result / user-feedback tokens live **inside**
+`completion_ids` (masked), so the trained completion spans all turns *plus* their
+context. `max_completion_length` caps each turn's generation, not the episode
+total, so the full sequence can be several times `max_completion_length`. Size
+`max_seq_length` / VRAM for the whole interleaved episode. (Legacy `drop` mode
+already concatenated assistant turns; faithful mode adds the context tokens on
+top.)
+
 ### Verifying
 
 `tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the

--- a/.skills/fine-tuning/SKILL.md
+++ b/.skills/fine-tuning/SKILL.md
@@ -501,6 +501,7 @@ Provider-native storage defaults:
 - SFT with `packing: true` is much faster.
 - KTO datasets must be interleaved True/False.
 - GRPO rewards are YAML-driven; edit `configs/rewards/`, not Python.
+- Env-GRPO multi-turn rollouts are token-faithful by default (`env_training.token_faithful: true`, requires `trl>=0.28.0`); it emits a per-token `env_mask` so GRPO trains only on sampled tokens. See `reference/grpo-training.md` → "Token-Faithful Multi-Turn Rollout".
 - `fitness.yaml` uses `FitnessEvaluator` for structural validation.
 - After training, use surgery only after you have a stable baseline and evaluation scenario.
 - `training_lineage.json` tracks full provenance for reproducibility.

--- a/.skills/fine-tuning/reference/grpo-training.md
+++ b/.skills/fine-tuning/reference/grpo-training.md
@@ -294,6 +294,64 @@ Normalization handles: argument key reordering, type coercion (`"true"` → `tru
 
 ---
 
+## Token-Faithful Multi-Turn Rollout (Env-GRPO)
+
+Environment-backed GRPO (`train_env_grpo.py`) rolls out multi-turn episodes: the
+model emits a tool call, the environment executes it, the result is fed back, the
+model responds again, and so on. By default the trainer now serializes these
+episodes **token-faithfully** (POLAR-style, arXiv:2605.24220): GRPO trains on
+exactly the tokens the model sampled while still conditioning on the real
+tool-result / user-feedback context.
+
+**Why it matters.** The legacy serialization flattened every assistant turn's
+tokens into one contiguous completion and dropped the intermediate tool-result /
+user-feedback tokens entirely. GRPO then optimized a fictional stream that never
+existed at sampling time — a train/inference mismatch. Faithful mode keeps the
+full interleaved sequence and supplies a per-token `env_mask` (model token = 1,
+external context token = 0) that TRL multiplies into the completion loss mask: the
+model attends to the real context but is trained only on its own tokens.
+
+### Config
+
+In `Trainers/grpo/configs/env_config.yaml` under `env_training:`:
+
+```yaml
+env_training:
+  token_faithful: true          # emit faithful sequence + env_mask (default)
+  context_token_policy: mask     # "mask" = faithful; "drop" = legacy flattened (A/B only)
+```
+
+- **Single-turn episodes are byte-identical** under either policy — the change
+  only affects episodes with more than one assistant turn.
+- Requires **`trl>=0.28.0`** (when `env_mask` became a real loss mask). The rollout
+  builder probes the installed TRL via `detect_openenv_runtime_support()['has_env_mask']`
+  and, if the runtime can't honor `env_mask`, **auto-falls back to the legacy
+  flattened path** (with a warning) rather than train on context tokens.
+- Use `context_token_policy: drop` only to A/B against the old behavior.
+
+### How the sequence is built
+
+For each episode the rollout records per-turn `(prompt_ids, completion_ids,
+logprobs)` from `generate_rollout_completions`, then assembles:
+
+- `prompt_ids` = the first turn's rendered prompt.
+- `completion_ids` = assistant turn 1 ++ context(1→2) ++ assistant turn 2 ++ …,
+  where context tokens are the tail of the next turn's rendered prompt (the same
+  length-delta slicing TRL's internal tool loop uses). Assistant spans use the raw
+  sampled token ids, so trained tokens stay byte-faithful.
+- `env_mask` = 1 on assistant tokens, 0 on context tokens (same length as
+  `completion_ids`).
+- `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
+
+### Verifying
+
+`tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the
+interleaved multi-turn sequence, mask/logprob length alignment, the capability
+gate, and the rollout_func output contract. Before a full launch, run a short
+env-GRPO smoke job and confirm the run does not raise a length/logprob mismatch.
+
+---
+
 ## Platform Note
 
 GRPO requires **WSL/Linux only** — native Windows is not supported.

--- a/.skills/fine-tuning/reference/grpo-training.md
+++ b/.skills/fine-tuning/reference/grpo-training.md
@@ -343,6 +343,29 @@ logprobs)` from `generate_rollout_completions`, then assembles:
   `completion_ids`).
 - `logprobs` = sampling log-probs on assistant tokens, 0.0 on context tokens.
 
+### What TRL does with it (verified against trl source)
+
+`completion_mask` is all-ones over `completion_ids`, so the full interleaved
+sequence (assistant + context) is **attended** — the model, the `old`/reference
+logprobs, and the importance-sampling ratio are all computed conditioned on the
+real context. The loss uses `mask = completion_mask * tool_mask`, and every loss
+variant normalizes by `mask.sum()`, so context tokens contribute **zero to the
+loss and are excluded from the denominator** (no dilution). Our supplied per-token
+`logprobs` only feed the vLLM importance-sampling correction and are themselves
+multiplied by the mask, so the `0.0` placeholders on context tokens are inert.
+Reward grouping is unchanged (one record per episode → `rewards.view(-1,
+num_generations)`), and length metrics count only model tokens (`sum(env_mask)`).
+
+### Caveat — sequence-length budget
+
+In faithful mode the tool-result / user-feedback tokens live **inside**
+`completion_ids` (masked), so the trained completion spans all turns *plus* their
+context. `max_completion_length` caps each turn's generation, not the episode
+total, so the full sequence can be several times `max_completion_length`. Size
+`max_seq_length` / VRAM for the whole interleaved episode. (Legacy `drop` mode
+already concatenated assistant turns; faithful mode adds the context tokens on
+top.)
+
 ### Verifying
 
 `tests/trainers/grpo/test_env_rollout_faithful.py` covers single-turn parity, the

--- a/Trainers/grpo/configs/env_config.yaml
+++ b/Trainers/grpo/configs/env_config.yaml
@@ -53,6 +53,19 @@ env_training:
   max_turns: 6
   max_tool_steps: 8
 
+  # Token-faithful (POLAR-style) multi-turn rollout serialization.
+  # When true, the rollout preserves the full interleaved token sequence and
+  # emits a per-token env_mask (model tokens=1, external context tokens=0) so
+  # GRPO trains on exactly the tokens the model sampled while still conditioning
+  # on the real tool-result / user-feedback context. Single-turn episodes are
+  # byte-identical either way. Requires trl>=0.28.0 (env_mask support); the
+  # rollout builder auto-falls back to the legacy flattened path otherwise.
+  token_faithful: true
+  # "mask" = faithful interleaved sequence + env_mask. "drop" = legacy flattened
+  # behavior (assistant turns concatenated, context tokens dropped). Use "drop"
+  # only for A/B comparison.
+  context_token_policy: mask
+
   runtime:
     # Keep using the shared Unsloth image for cloud jobs, but isolate modern
     # env-GRPO deps in a venv so we don't destabilize existing trainers.
@@ -67,7 +80,7 @@ env_training:
       - "datasets"
     python_packages:
       - "huggingface_hub<1.0"
-      - "trl>=0.24.0"
+      - "trl>=0.28.0"  # env_mask loss-mask support for token-faithful rollouts
       - "transformers>=4.56.0"
       - "accelerate>=1.6.0"
       - "peft>=0.15.0"

--- a/Trainers/grpo/src/env_rollout.py
+++ b/Trainers/grpo/src/env_rollout.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import inspect
-from dataclasses import dataclass
-from typing import Any, Dict, List, Mapping, Optional, Sequence
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
 
 from shared.environments import EnvironmentValidator
 from shared.environments.tool_executor import format_tool_results_message
@@ -32,6 +35,89 @@ class EpisodeRolloutResult:
     total_turns: int
     total_tool_calls: int
     final_text_satisfied: bool
+    # Token-faithful (POLAR-style) loss mask aligned 1:1 with completion_ids:
+    # 1 = model-sampled token (trainable), 0 = external context token (tool
+    # result / user feedback) that the model conditioned on but did not emit.
+    # Empty when the legacy flattened representation is used.
+    env_mask: List[int] = field(default_factory=list)
+
+
+# A single generated turn: (prompt_ids, completion_ids, logprobs). prompt_ids is
+# the re-tokenized conversation prefix rendered for that turn's generation;
+# completion_ids / logprobs are the actual sampled tokens and their sampling
+# log-probabilities.
+TurnSegment = Tuple[List[int], List[int], List[float]]
+
+
+def _assemble_flat_sequence(turn_segments: Sequence[TurnSegment]) -> Tuple[List[int], List[int], List[float]]:
+    """Legacy representation: first turn's prompt, all assistant turns concatenated.
+
+    Intermediate tool-result / user-feedback tokens are dropped entirely. This is
+    the historical behavior and is not token-faithful for multi-turn episodes, but
+    it is exactly correct (and identical to the faithful path) for single-turn
+    episodes.
+    """
+    if not turn_segments:
+        return [], [], []
+    base_prompt = list(turn_segments[0][0])
+    completion: List[int] = []
+    logprobs: List[float] = []
+    for _prompt_ids, completion_ids, turn_logprobs in turn_segments:
+        completion.extend(completion_ids)
+        logprobs.extend(turn_logprobs)
+    return base_prompt, completion, logprobs
+
+
+def _assemble_faithful_sequence(
+    turn_segments: Sequence[TurnSegment],
+) -> Tuple[List[int], List[int], List[int], List[float]]:
+    """Token-faithful representation: full interleaved sequence + per-token mask.
+
+    Returns ``(base_prompt_ids, completion_ids, env_mask, logprobs)`` where
+    ``completion_ids`` is everything after the initial prompt — assistant turns
+    interleaved with the exact tool-result / user-feedback context tokens the
+    model saw between turns. ``env_mask`` is 1 on assistant-sampled tokens and 0
+    on external context tokens; ``logprobs`` carries the sampling log-prob on
+    assistant tokens and 0.0 on context tokens. All three lists are the same
+    length, matching TRL's ``env_mask`` contract (mask is multiplied into the
+    completion loss mask, so context tokens contribute nothing to the loss while
+    still being attended to).
+
+    Context tokens for the transition into turn ``t`` are recovered as the tail of
+    turn ``t``'s rendered prompt that extends past ``prompt(t-1) + completion(t-1)``
+    — the same length-delta slicing TRL's own internal tool loop uses. Assistant
+    spans use the raw sampled token ids (not re-templated text) so the trained
+    tokens stay byte-faithful to what was sampled.
+    """
+    if not turn_segments:
+        return [], [], [], []
+
+    base_prompt = list(turn_segments[0][0])
+    completion: List[int] = []
+    env_mask: List[int] = []
+    logprobs: List[float] = []
+
+    _first_prompt, first_completion, first_logprobs = turn_segments[0]
+    completion.extend(first_completion)
+    env_mask.extend([1] * len(first_completion))
+    logprobs.extend(first_logprobs)
+
+    for idx in range(1, len(turn_segments)):
+        prev_prompt, prev_completion, _prev_logprobs = turn_segments[idx - 1]
+        cur_prompt, cur_completion, cur_logprobs = turn_segments[idx]
+
+        ext_len = len(cur_prompt) - len(prev_prompt) - len(prev_completion)
+        if ext_len > 0:
+            ext_ids = list(cur_prompt[-ext_len:])
+            completion.extend(ext_ids)
+            env_mask.extend([0] * ext_len)
+            logprobs.extend([0.0] * ext_len)
+
+        completion.extend(cur_completion)
+        env_mask.extend([1] * len(cur_completion))
+        logprobs.extend(cur_logprobs)
+
+    return base_prompt, completion, env_mask, logprobs
 
 
 def build_prompt_registry(dataset) -> Dict[str, EpisodeSpec]:
@@ -53,13 +139,44 @@ def build_prompt_registry(dataset) -> Dict[str, EpisodeSpec]:
     return registry
 
 
+def _resolve_faithful_mode(
+    env_training_cfg: Mapping[str, Any],
+    runtime_support: Optional[Mapping[str, Any]],
+) -> bool:
+    """Decide whether to emit the token-faithful representation + env_mask.
+
+    Faithful mode requires (a) the config opting in (default on), (b) the mask
+    policy, and (c) the installed TRL actually honoring ``env_mask`` as a loss
+    mask. If faithful is requested but the runtime cannot honor the mask, we fall
+    back to the safe legacy flattened path rather than silently stuffing
+    untrainable context tokens into ``completion_ids`` (which an older TRL would
+    train on). This is the Phase 0 capability gate.
+    """
+    token_faithful = bool(env_training_cfg.get("token_faithful", True))
+    context_policy = str(env_training_cfg.get("context_token_policy", "mask"))
+    if not token_faithful or context_policy != "mask":
+        return False
+
+    supports_env_mask = bool((runtime_support or {}).get("has_env_mask"))
+    if not supports_env_mask:
+        logger.warning(
+            "token_faithful requested but the installed TRL does not honor "
+            "env_mask (requires trl>=0.28.0). Falling back to the legacy "
+            "flattened rollout representation to avoid training on context tokens."
+        )
+        return False
+    return True
+
+
 def build_rollout_func(
     *,
     registry: Dict[str, EpisodeSpec],
     env_training_cfg: Dict[str, Any],
+    runtime_support: Optional[Mapping[str, Any]] = None,
 ) -> Any:
     openenv_module = _import_openenv_helpers()
     generate_rollout_completions = getattr(openenv_module, "generate_rollout_completions")
+    faithful = _resolve_faithful_mode(env_training_cfg, runtime_support)
 
     def rollout_func(prompts: List[str], trainer) -> Dict[str, List[Any]]:
         results: List[EpisodeRolloutResult] = []
@@ -73,10 +190,11 @@ def build_rollout_func(
                     generate_rollout_completions=generate_rollout_completions,
                     spec=spec,
                     env_training_cfg=env_training_cfg,
+                    faithful=faithful,
                 )
             )
 
-        return {
+        output: Dict[str, List[Any]] = {
             "prompt_ids": [item.prompt_ids for item in results],
             "completion_ids": [item.completion_ids for item in results],
             "logprobs": [item.logprobs for item in results],
@@ -88,6 +206,11 @@ def build_rollout_func(
             "final_text_satisfied": [item.final_text_satisfied for item in results],
             "completion_text": [item.completion_text for item in results],
         }
+        if faithful:
+            # TRL pops env_mask from the rollout output and multiplies it into the
+            # completion loss mask (model tokens=1, external context tokens=0).
+            output["env_mask"] = [item.env_mask for item in results]
+        return output
 
     return rollout_func
 
@@ -98,6 +221,7 @@ def _run_single_episode(
     generate_rollout_completions,
     spec: EpisodeSpec,
     env_training_cfg: Dict[str, Any],
+    faithful: bool = False,
 ) -> EpisodeRolloutResult:
     tokenizer = trainer.processing_class
     env_backend = str(env_training_cfg.get("env_backend") or "local")
@@ -119,9 +243,7 @@ def _run_single_episode(
         or "The task is complete. Reply to the user with a brief final text-only response. Do not call any more tools."
     )
 
-    all_completion_ids: List[int] = []
-    all_logprobs: List[float] = []
-    first_prompt_ids: Optional[List[int]] = None
+    turn_segments: List[TurnSegment] = []
     completion_text_parts: List[str] = []
     stop_reason = "max_turns_reached"
     awaiting_final_text = False
@@ -144,10 +266,12 @@ def _run_single_episode(
             logprobs = [float(value) for value in (outputs.get("logprobs") or [])]
             completion_text = tokenizer.decode(completion_ids, skip_special_tokens=True)
 
-            if first_prompt_ids is None:
-                first_prompt_ids = prompt_ids
-            all_completion_ids.extend(completion_ids)
-            all_logprobs.extend(logprobs)
+            # Keep logprobs aligned 1:1 with completion_ids. TRL pads/uses the
+            # sampling logprobs positionally, so a per-turn mismatch would
+            # corrupt downstream alignment. Pad short, truncate long.
+            logprobs = _align_logprobs(logprobs, len(completion_ids))
+
+            turn_segments.append((prompt_ids, completion_ids, logprobs))
             completion_text_parts.append(completion_text)
 
             parsed = parse_response(completion_text)
@@ -219,10 +343,16 @@ def _run_single_episode(
     env_reward = 1.0 if env_passed else 0.0
     completion_text = "\n".join(part for part in completion_text_parts if part.strip())
 
+    if faithful:
+        prompt_ids, completion_ids, env_mask, logprobs = _assemble_faithful_sequence(turn_segments)
+    else:
+        prompt_ids, completion_ids, logprobs = _assemble_flat_sequence(turn_segments)
+        env_mask = []
+
     return EpisodeRolloutResult(
-        prompt_ids=first_prompt_ids or [],
-        completion_ids=all_completion_ids,
-        logprobs=all_logprobs,
+        prompt_ids=prompt_ids,
+        completion_ids=completion_ids,
+        logprobs=logprobs,
         completion_text=completion_text,
         env_passed=env_passed,
         env_reward=env_reward,
@@ -230,7 +360,17 @@ def _run_single_episode(
         total_turns=len(session.steps),
         total_tool_calls=len(session.executed_tools),
         final_text_satisfied=final_text_satisfied,
+        env_mask=env_mask,
     )
+
+
+def _align_logprobs(logprobs: List[float], target_len: int) -> List[float]:
+    """Force ``logprobs`` to length ``target_len`` (pad with 0.0, truncate excess)."""
+    if len(logprobs) == target_len:
+        return logprobs
+    if len(logprobs) < target_len:
+        return logprobs + [0.0] * (target_len - len(logprobs))
+    return logprobs[:target_len]
 
 
 def _generate_one_completion(*, trainer, generate_rollout_completions, prompt_text: str) -> Dict[str, Any]:

--- a/Trainers/grpo/src/env_runtime.py
+++ b/Trainers/grpo/src/env_runtime.py
@@ -52,6 +52,7 @@ def detect_openenv_runtime_support() -> Dict[str, Any]:
         "has_rollout_func": False,
         "has_environment_factory": False,
         "has_generate_rollout_completions": False,
+        "has_env_mask": False,
         "errors": [],
     }
 
@@ -62,6 +63,7 @@ def detect_openenv_runtime_support() -> Dict[str, Any]:
             signature = inspect.signature(trainer_cls.__init__)
             support["has_rollout_func"] = "rollout_func" in signature.parameters
             support["has_environment_factory"] = "environment_factory" in signature.parameters
+        support["has_env_mask"] = _detect_env_mask_support()
     except Exception as exc:
         support["errors"].append(f"trl import failed: {exc}")
         return support
@@ -125,6 +127,22 @@ def ensure_local_openenv_runtime(
     return str(venv_python)
 
 
+def _detect_env_mask_support() -> bool:
+    """True when the installed TRL GRPO trainer honors a custom ``env_mask``.
+
+    ``env_mask`` (from a rollout_func output) is multiplied into the completion
+    loss mask, which is what makes token-faithful multi-turn rollouts trainable.
+    It landed in trl 0.28.0. We probe the trainer source directly rather than
+    trusting a version string, so the capability flag tracks the real runtime.
+    """
+    try:
+        from trl.trainer import grpo_trainer as _grpo_trainer
+
+        return "env_mask" in inspect.getsource(_grpo_trainer)
+    except Exception:
+        return False
+
+
 def _safe_version(package_name: str) -> str | None:
     try:
         return version(package_name)
@@ -171,6 +189,7 @@ support = {
     "has_rollout_func": False,
     "has_environment_factory": False,
     "has_generate_rollout_completions": False,
+    "has_env_mask": False,
     "errors": [],
 }
 
@@ -181,6 +200,11 @@ try:
         signature = inspect.signature(trainer_cls.__init__)
         support["has_rollout_func"] = "rollout_func" in signature.parameters
         support["has_environment_factory"] = "environment_factory" in signature.parameters
+    try:
+        from trl.trainer import grpo_trainer as _grpo_trainer
+        support["has_env_mask"] = "env_mask" in inspect.getsource(_grpo_trainer)
+    except Exception:
+        support["has_env_mask"] = False
 except Exception as exc:
     support["errors"].append(f"trl import failed: {exc}")
 
@@ -213,6 +237,7 @@ print(json.dumps(support))
             "has_rollout_func": False,
             "has_environment_factory": False,
             "has_generate_rollout_completions": False,
+            "has_env_mask": False,
             "errors": [result.stderr.strip() or result.stdout.strip() or "probe failed"],
         }
     return json.loads(result.stdout)

--- a/Trainers/grpo/train_env_grpo.py
+++ b/Trainers/grpo/train_env_grpo.py
@@ -211,6 +211,7 @@ def run(args: argparse.Namespace) -> Dict[str, Any]:
     rollout_func = build_rollout_func(
         registry=registry,
         env_training_cfg=env_cfg,
+        runtime_support=runtime_support,
     )
     reward_func = build_env_reward_function(config.get("rewards") or {})
 

--- a/configs/flywheel/default.yaml
+++ b/configs/flywheel/default.yaml
@@ -34,6 +34,16 @@ vllm_host: localhost
 vllm_port: 8000
 proxy_timeout_seconds: 120
 
+# Token-faithful rollout capture (off by default)
+# capture_token_ids: persist completion token ids + per-token logprobs from the
+#   vLLM response (when present) into the JSONL, for a future GRPO/rollout feed.
+# proxy_inject_logprobs: have the proxy add logprobs + return_tokens_as_token_ids
+#   to forwarded chat-completion requests so capture has data to read. Requires a
+#   vLLM that supports return_tokens_as_token_ids. Adds payload/latency, so off
+#   unless you are actively collecting rollouts.
+capture_token_ids: false
+proxy_inject_logprobs: false
+
 # vLLM
 vllm_adapter_name: current-adapter
 vllm_max_lora_rank: 64

--- a/docs/architecture/enterprise-data-flywheel-arch.md
+++ b/docs/architecture/enterprise-data-flywheel-arch.md
@@ -148,6 +148,11 @@ class InferenceLogRecord:
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
+    # Token-faithful rollout capture (optional; off by default)
+    prompt_token_ids: list[int] | None = None
+    completion_token_ids: list[int] | None = None
+    completion_logprobs: list[float] | None = None
+
     # Pipeline metadata (populated during processing)
     latency_ms: float = 0.0
     fitness_score: float | None = None   # Set by DataCleaner
@@ -168,6 +173,19 @@ class InferenceLogRecord:
         """Deserialize from dict, ignoring unknown fields."""
         ...
 ```
+
+**Token-faithful rollout capture (optional).** When `capture_token_ids: true`,
+the logger records the completion's per-token logprobs (and token ids when vLLM
+was asked with `return_tokens_as_token_ids`) into the JSONL — enabling a future
+token-faithful GRPO/replay feed (POLAR-style; see
+`docs/plans/proxy-token-capture-grpo-feed-plan.md`). The three fields are **omitted
+from `to_json()` when unset**, so existing log lines and readers are unaffected,
+and the catalog index is unchanged (token data lives only in the JSONL). Set
+`proxy_inject_logprobs: true` to have the proxy add `logprobs` +
+`return_tokens_as_token_ids` to forwarded chat-completion requests so capture has
+data to read; both flags default off to avoid changing latency/payload for normal
+SFT/KTO logging. The stager passes any captured token fields through the GRPO
+training example. Consuming these as on-policy/replay GRPO is future work.
 
 #### LogFilter
 

--- a/docs/plans/proxy-token-capture-grpo-feed-plan.md
+++ b/docs/plans/proxy-token-capture-grpo-feed-plan.md
@@ -1,9 +1,42 @@
 # Proxy Token Capture → GRPO Feed Plan
 
 **Date:** 2026-05-29
-**Status:** Proposed (secondary; depends on `token-faithful-grpo-rollout-plan.md` landing first)
+**Status:** Implemented (capture path); consumer-side GRPO replay is future work
 **Paper / Prior Art:** NVIDIA POLAR — [arXiv:2605.24220](https://arxiv.org/html/2605.24220v1) ([MarkTechPost writeup](https://www.marktechpost.com/2026/05/27/nvidia-releases-polar-a-token-faithful-rollout-framework-for-grpo-training-across-codex-claude-code-and-qwen-code/))
 **Branch:** `claude/polar-token-rollout-MTzCp`
+
+---
+
+## Findings from the codebase (revise the plan)
+
+Investigating the real flywheel code changed two plan assumptions:
+
+- **No catalog migration needed.** `catalog.py` only *indexes* lightweight fields
+  (`log_id`, `model_id`, `has_tool_calls`, score, tag, `source_file`/`line_number`,
+  …) — it never stored `messages` or `response_content`. Full content (and now
+  token ids/logprobs) lives in the date-partitioned JSONL; the stager reads it
+  back via `read_log_content()` using `source_file`/`line_number`. So token
+  capture is purely additive JSONL fields — Phase 1's catalog work is dropped.
+- **A GRPO staging path already exists.** `stager._write_grpo` /
+  `_format_grpo_example` already emit `{conversations, reward}`. Rather than a
+  parallel rollout file, token fields are passed through that existing example
+  when present — additive and back-compatible.
+
+## Phase 0 — vLLM capture contract (resolved by reading vLLM behavior)
+
+- **Logprobs:** request `logprobs: true`; vLLM returns
+  `choices[].logprobs.content[]` with per-token `{token, logprob, bytes}`. We read
+  `logprob` directly.
+- **Token ids:** the OpenAI schema has no token-id field. vLLM's
+  `return_tokens_as_token_ids: true` renders each `token` as `"token_id:<int>"`,
+  which we parse. If any token isn't in that form, token ids are reported `None`
+  (logprobs may still be captured).
+- **Prompt token ids:** not reliably returned by chat-completions; left `None`
+  for now (a downstream consumer can re-tokenize the logged messages, accepting
+  drift — documented as future work, design fallback B).
+- **Caveat:** exact `return_tokens_as_token_ids` behavior is vLLM-version
+  dependent and must be confirmed against the running server (like Plan #1's GPU
+  smoke). The capture is best-effort and never fails the request.
 
 ---
 

--- a/docs/plans/proxy-token-capture-grpo-feed-plan.md
+++ b/docs/plans/proxy-token-capture-grpo-feed-plan.md
@@ -1,0 +1,247 @@
+# Proxy Token Capture → GRPO Feed Plan
+
+**Date:** 2026-05-29
+**Status:** Proposed (secondary; depends on `token-faithful-grpo-rollout-plan.md` landing first)
+**Paper / Prior Art:** NVIDIA POLAR — [arXiv:2605.24220](https://arxiv.org/html/2605.24220v1) ([MarkTechPost writeup](https://www.marktechpost.com/2026/05/27/nvidia-releases-polar-a-token-faithful-rollout-framework-for-grpo-training-across-codex-claude-code-and-qwen-code/))
+**Branch:** `claude/polar-token-rollout-MTzCp`
+
+---
+
+## Goal
+
+Teach the flywheel logging proxy to capture **token-faithful rollout data** — the actual completion token
+IDs and per-token logprobs — so logged production inference can eventually feed GRPO, not just the current
+SFT/KTO auto-retrain path. Today `shared/flywheel/inference_logger.py` records messages, tool calls,
+finish reason, and token *counts* (`usage.prompt_tokens` / `usage.completion_tokens`) but throws away the
+token IDs and logprobs. That is enough for SFT/KTO (which re-tokenize text) but **not** for token-faithful
+GRPO, which — per POLAR — needs the exact sampled tokens and their sampling logprobs.
+
+**Design principle:** Additive and opt-in. New optional fields on the log record, populated only when the
+upstream request asks vLLM for logprobs and the response includes them. Zero behavior change for existing
+SFT/KTO consumers; the catalog and JSONL stay readable by current code.
+
+---
+
+## Why This Fits
+
+The proxy is already structurally what POLAR calls a "model API proxy" — it just doesn't keep the tokens.
+
+| POLAR Concept | Existing Infrastructure | Gap |
+|---|---|---|
+| API proxy in front of the model | `services/proxy/app.py` — OpenAI-compatible, forwards to vLLM, logs chat completions | None — the proxy exists |
+| Record token-level interactions | `inference_logger._build_record()` captures `prompt_tokens`/`completion_tokens` counts | No token IDs, no logprobs |
+| Token-faithful trajectory for RL | `InferenceLogRecord` + date-partitioned JSONL + `LogCatalog` | Record schema has no token-ID/logprob fields |
+| Reward → sampled tokens (GRPO feed) | `shared/flywheel/stager.py` routes logs to SFT/KTO datasets | No GRPO/rollout staging path |
+| Reconstruct faithful sequence | `token-faithful-grpo-rollout-plan.md` assembly logic | Reuse the same assembly once token IDs are available |
+
+---
+
+## What Gets Built
+
+| # | Artifact | Type | Est. Lines | Purpose |
+|---|----------|------|-----------|---------|
+| 0 | vLLM logprob/token-id capability spike | Investigation | — | Confirm what vLLM's chat-completions response exposes (token IDs, logprobs) and under which request flags |
+| 1 | `shared/flywheel/catalog.py` (`InferenceLogRecord`) | Edit | +~25 | Optional `completion_token_ids`, `completion_logprobs`, `prompt_token_ids` fields + schema migration |
+| 2 | `shared/flywheel/inference_logger.py` | Edit | +~40 | Extract token IDs/logprobs from response when present; never fail if absent |
+| 3 | `services/proxy/app.py` | Edit | +~10 | Pass through `logprobs` request flag handling; no forced injection |
+| 4 | `shared/flywheel/stager.py` | Edit | +~70 | New `rollout`/GRPO staging path that emits token-faithful rollout records |
+| 5 | `configs/flywheel/*.yaml` | Edit | +~12 | `capture_token_ids` + `rollout_staging` config |
+| 6 | `tests/flywheel/test_token_capture.py` | New test | ~150 | Capture-present, capture-absent, schema back-compat, GRPO staging shape |
+| 7 | `.skills/fine-tuning/` + flywheel docs | Skill update | +~40 | Token-capture + GRPO-feed section |
+
+**Total: ~145 net lines Python, ~12 lines YAML, ~150 lines tests, ~40 lines docs. 4 modules edited, 1 new test, config + skill updates.**
+
+No new service. No new dependency. No change to the SFT/KTO staging paths.
+
+---
+
+## Data Flow
+
+```
+Agent / client → POST /v1/chat/completions (logprobs: true)
+       │
+       ▼
+┌────────────────────────────┐
+│ services/proxy/app.py      │  Forward transparently to vLLM (unchanged).
+│  proxy() catch-all          │  Fire-and-forget log on 200.
+└──────────┬─────────────────┘
+           │ request + response JSON
+           ▼
+┌────────────────────────────┐
+│ inference_logger            │  _build_record(): extract token IDs +
+│  ._build_record()           │  logprobs from response.choices[].logprobs
+│                             │  when present; leave None otherwise.
+└──────────┬─────────────────┘
+           │ InferenceLogRecord (+ token fields)
+           ▼
+┌────────────────────────────┐
+│ date-partitioned JSONL      │  Same files; new optional keys. Old
+│  + LogCatalog index         │  readers ignore unknown fields.
+└──────────┬─────────────────┘
+           │ (offline)
+           ▼
+┌────────────────────────────┐
+│ stager.py  rollout path     │  Select records WHERE token_ids present
+│                             │  AND tool/reward signal qualifies. Emit
+│                             │  token-faithful rollout JSONL for GRPO.
+└──────────┬─────────────────┘
+           │
+           ▼
+   GRPO dataset (reuses token-faithful assembly from companion plan)
+```
+
+---
+
+## Config Schema
+
+### `flywheel` config additions
+
+```yaml
+flywheel:
+  logging:
+    # Persist completion token IDs + per-token logprobs when the upstream
+    # response includes them. Required for any future GRPO/rollout feed.
+    # Off by default — SFT/KTO do not need it and it grows log size.
+    capture_token_ids: false
+
+  staging:
+    # New rollout staging target alongside sft/kto.
+    rollout:
+      enabled: false
+      # Only records with captured token IDs qualify.
+      require_token_ids: true
+      # Minimum signal to include a record as a rollout sample.
+      require_tool_call: true
+      output_path: Datasets/flywheel/rollouts/
+```
+
+**Backward compatibility:** all new fields default off/false. With them off, the proxy, logger, catalog,
+and stager behave exactly as today. SFT/KTO staging is untouched.
+
+---
+
+## Implementation Phases
+
+### Phase 0: vLLM Capability Spike
+
+**Delegate to:** `pact-architect`
+
+| Task | Details |
+|------|---------|
+| Inspect vLLM response | Confirm the shape of `choices[].logprobs` from the deployed vLLM build: token strings, `logprob` values, `bytes`, and whether token **IDs** are available (directly or via a vLLM `extra_body` flag). |
+| Determine request flags | Identify what the client/proxy must send (`logprobs: true`, `top_logprobs`, any `extra_body`) for IDs/logprobs to appear. |
+| Decide capture surface | If token IDs are not natively returned, decide whether to (A) capture logprob+token-string sequences only, or (B) re-tokenize server-side at stage time. Document the tradeoff. |
+| Record findings | Append a "vLLM capture contract" note to this plan before Phase 1. |
+
+**Gate:** Phase 1 schema design follows from what vLLM actually exposes. Do not guess field availability.
+
+---
+
+### Phase 1: Record Schema + Migration
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Extend `InferenceLogRecord` | Add optional `completion_token_ids: list[int] | None`, `completion_logprobs: list[float] | None`, `prompt_token_ids: list[int] | None`. Default `None`. Update `to_json()` to omit when `None` (keep JSONL compact). |
+| Catalog migration | Add columns / index handling in `catalog.py` for both sqlite and postgres backends. Migration must be additive and tolerate existing rows (NULL). |
+| Back-compat assertion | Existing records (no token fields) must still deserialize and index. |
+
+---
+
+### Phase 2: Capture in Logger + Proxy Pass-Through
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| `inference_logger._build_record()` | When `response.choices[].logprobs` (and IDs, per Phase 0) are present, populate the new fields; otherwise leave `None`. Never raise if absent — capture is best-effort. |
+| Credential scrubbing | Token-ID/logprob arrays carry no credentials, but keep `_scrub_*` on text fields unchanged. Confirm scrubbing is not accidentally applied to numeric arrays. |
+| `services/proxy/app.py` | Honor a client-sent `logprobs` flag transparently (already forwarded as part of the body). Do **not** force-inject `logprobs: true` — capture only what the caller requested, to avoid changing latency/cost for callers that didn't ask. |
+| Config gate | `capture_token_ids: false` → skip population even if present, to keep log size down when GRPO feed is not in use. |
+
+---
+
+### Phase 3: GRPO/Rollout Staging
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| `stager.py` rollout path | New staging target that selects records with token IDs + qualifying signal (`require_tool_call`, reward/fitness hooks reused from existing tagger). Emit a rollout JSONL whose schema matches what the env-GRPO faithful assembly expects (`prompt_ids`, `completion_ids`, `logprobs`, mask metadata). |
+| Reuse faithful assembly | Where multi-turn logs exist, reuse the sequence/mask assembly defined in `token-faithful-grpo-rollout-plan.md` rather than re-implementing. (Hard dependency on that plan landing.) |
+| Interleave invariant | If the rollout feed ever crosses into KTO, preserve the existing interleaving rule (see CLAUDE.md / `_write_kto`). Rollout staging itself does not interleave. |
+
+---
+
+### Phase 4: Tests
+
+**Delegate to:** `pact-test-engineer`
+
+| Test | Type | What |
+|------|------|------|
+| `test_capture_present` | Unit | Response with logprobs/token IDs → fields populated correctly. |
+| `test_capture_absent` | Unit | Response without logprobs → fields `None`, no error, SFT/KTO record unchanged. |
+| `test_schema_backcompat` | Unit | Old JSONL row (no token fields) deserializes and indexes in both catalog backends. |
+| `test_rollout_staging_shape` | Integration | Stager emits rollout JSONL matching env-GRPO faithful-assembly schema. |
+| `test_capture_disabled` | Unit | `capture_token_ids: false` → fields stay `None` even when present in response. |
+| Existing flywheel tests | Regression | SFT/KTO staging + proxy passthrough unaffected. |
+
+---
+
+### Phase 5: Documentation
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Flywheel + fine-tuning skill | Document `capture_token_ids`, `rollout` staging, the vLLM request flags, and the dependency on the token-faithful rollout assembly. |
+| Sync mirrors | `python3 .skills/scripts/sync_skill_trees.py` after edits. |
+
+---
+
+## Risk Mitigation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| vLLM does not return token IDs | High | Phase 0 gate. Fallback (B): capture logprob+token-string sequences, re-tokenize at stage time with the served tokenizer (accept minor drift, documented). |
+| Log size blowup | Medium | Capture is opt-in (`capture_token_ids: false` default); `to_json()` omits `None`; arrays only kept for qualifying rollout candidates downstream. |
+| Catalog migration breaks existing rows | Medium | Additive NULL-tolerant columns; `test_schema_backcompat` on both backends. |
+| Latency/cost change for unrelated callers | Medium | Never force `logprobs: true`; capture only what the caller requested. |
+| Stale tokenizer at stage time (fallback B) | Low | Pin tokenizer to `model_id` recorded on the log; refuse staging on tokenizer mismatch. |
+| Scope creep into harness-agnostic RL | Medium | Explicitly out of scope (below). This plan only enriches the existing on-vLLM logging path. |
+
+---
+
+## Connection to Existing Systems
+
+| Existing System | Relationship |
+|---|---|
+| **Flywheel proxy** (`services/proxy/app.py`) | Direct target. Already proxies + logs; this adds optional token capture. |
+| **Inference logger** (`inference_logger.py`) | Direct target. New optional fields; existing scrubbing/queue/writer untouched. |
+| **Catalog** (`catalog.py`) | Additive schema migration on sqlite + postgres. |
+| **Stager** (`stager.py`) | New `rollout` target alongside existing `sft`/`kto`. |
+| **Token-faithful rollout** (`token-faithful-grpo-rollout-plan.md`) | **Hard dependency** — Phase 3 reuses its sequence/mask assembly. Land that plan first. |
+| **Experiment loop** (`experiment_loop.py`) | Future: a captured-rollout dataset could become an input the loop selects. Not in scope. |
+
+---
+
+## Out of Scope (explicitly)
+
+- **Native multi-API proxying (Anthropic Messages / OpenAI Responses / Google generateContent).** POLAR
+  speaks all four to be harness-agnostic. Our proxy is OpenAI-compatible in front of our own vLLM; adding
+  the other API surfaces is only worthwhile if we pursue full harness-agnostic RL (also out of scope).
+- **RL training through external agent harnesses.** Same reasoning as the companion plan — a generation-path
+  re-architecture, deferred unless we commit to RL-ing real coding agents.
+
+---
+
+## Success Criteria
+
+1. Phase 0 produces a written vLLM capture-contract decision appended to this plan.
+2. With `capture_token_ids: true` and a `logprobs`-requesting client, logged records carry `completion_token_ids` + `completion_logprobs`.
+3. With capture off or logprobs absent, records are byte-compatible with today's SFT/KTO consumers.
+4. Catalog migration applies cleanly to existing sqlite and postgres rows (NULL token fields).
+5. Stager emits a rollout JSONL whose schema is consumable by the env-GRPO token-faithful assembly.
+6. All existing flywheel/proxy tests pass unchanged.
+7. Skill + flywheel docs updated and mirrors synced.

--- a/docs/plans/token-faithful-grpo-rollout-plan.md
+++ b/docs/plans/token-faithful-grpo-rollout-plan.md
@@ -1,0 +1,231 @@
+# Token-Faithful Multi-Turn GRPO Rollout Plan
+
+**Date:** 2026-05-29
+**Status:** Proposed
+**Paper / Prior Art:** NVIDIA POLAR — [arXiv:2605.24220](https://arxiv.org/html/2605.24220v1) ([MarkTechPost writeup](https://www.marktechpost.com/2026/05/27/nvidia-releases-polar-a-token-faithful-rollout-framework-for-grpo-training-across-codex-claude-code-and-qwen-code/))
+**Branch:** `claude/polar-token-rollout-MTzCp`
+
+---
+
+## Goal
+
+Make our environment-backed GRPO rollout **token-faithful**: train on the exact token sequence the model actually produced and consumed during a multi-turn episode, with a per-token loss mask that trains only the assistant-sampled tokens and keeps tool-result / user-feedback tokens as masked context.
+
+Today `Trainers/grpo/src/env_rollout.py` flattens every assistant turn's `completion_ids` into one continuous completion and keeps only the **first** turn's `prompt_ids`. The interleaved tool-result and user-feedback tokens that the model genuinely saw between turns are dropped from the trained sequence entirely. This is exactly the train/inference mismatch POLAR was built to eliminate: GRPO ends up optimizing a fictional contiguous assistant stream that never existed at sampling time.
+
+**Design principle:** Minimal new code, no new entrypoint, no new dependency. Fix the faithfulness gap inside the existing `rollout_func` path and assert the contract with TRL. Behavior for single-turn episodes (the common case) stays byte-identical; the change only adds correct handling for multi-turn episodes.
+
+---
+
+## Why This Fits
+
+We already have most of POLAR's token-faithful machinery — we just discard part of it on the prompt side:
+
+| POLAR Concept | Existing Infrastructure | Gap |
+|---|---|---|
+| Record actual sampled token IDs | `_generate_one_completion()` already returns `completion_ids` + per-token `logprobs` per turn | None for completions — we keep them |
+| Reward attached to sampled tokens | `EpisodeRolloutResult.completion_ids` → TRL `GRPOTrainer` | Sequence is flattened; intermediate context missing |
+| Token-faithful trajectory stitching | Per-turn `prompt_ids` available from `_generate_one_completion()` | We keep only `first_prompt_ids`; tool-result/user tokens never enter the sequence |
+| Loss masking (train assistant, not context) | TRL GRPO completion-mask mechanism | Not used — all `all_completion_ids` are treated as trainable |
+| Multi-turn episode loop | `_run_single_episode()` already drives turns + env feedback | Loop is correct; only the *serialization* of its result is unfaithful |
+
+The episode loop, env execution, and reward path are all sound. The defect is localized to how `_run_single_episode()` assembles its `EpisodeRolloutResult` and how `build_rollout_func()` hands it to TRL.
+
+---
+
+## What Gets Built
+
+| # | Artifact | Type | Est. Lines | Purpose |
+|---|----------|------|-----------|---------|
+| 0 | TRL contract spike (notes in plan) | Investigation | — | Confirm `rollout_func` return schema supports a completion mask / masked context before coding |
+| 1 | `Trainers/grpo/src/env_rollout.py` | Edit | ~80 net | Faithful token-sequence assembly + per-token loss mask |
+| 2 | `Trainers/grpo/configs/env_config.yaml` | Edit | +~8 | `env_training.token_faithful` toggle + mask policy |
+| 3 | `tests/trainers/grpo/test_env_rollout_faithful.py` | New test | ~180 | Single-turn parity + multi-turn faithfulness + mask alignment |
+| 4 | `.skills/fine-tuning/reference/grpo-training.md` | Skill update | +~40 | Token-faithful rollout section |
+| 5 | `.skills/fine-tuning/SKILL.md` | Skill update | +~3 | Note in env-GRPO gotchas |
+
+**Total: ~80 net lines of Python, ~8 lines YAML, ~180 lines tests, ~43 lines docs. 1 module edited, 1 config edited, 1 new test, 2 skill files.**
+
+No new training entrypoint. No new dependency. No change to reward functions, dataset loader, or callbacks.
+
+---
+
+## The Faithfulness Gap (current vs. target)
+
+### Current (`env_rollout.py:122-233`)
+
+```
+first_prompt_ids  = prompt_ids(turn 1)            # only turn 1's prompt kept
+all_completion_ids = completion_ids(t1) ++ completion_ids(t2) ++ ...   # flattened
+all_logprobs       = logprobs(t1) ++ logprobs(t2) ++ ...
+
+return prompt_ids = first_prompt_ids
+       completion_ids = all_completion_ids        # contiguous assistant stream
+       logprobs = all_logprobs                    # sampling logprobs, flat
+```
+
+Problem: between `completion_ids(t1)` and `completion_ids(t2)` the model actually saw rendered
+tool-result + user-feedback tokens. Those are appended to `messages` (`env_rollout.py:157,188,193`)
+and re-rendered next turn via `apply_chat_template` (`env_rollout.py:132`), but they never appear in
+the trained sequence. When GRPO recomputes current-policy logprobs over `prompt_ids + completion_ids`,
+the positions no longer line up with the cached sampling `logprobs`, and the advantage is applied to a
+sequence the policy never generated in that form.
+
+### Target (token-faithful)
+
+```
+sequence_ids  = prompt_ids(t1)
+                ++ completion_ids(t1)        [mask=1, trainable]
+                ++ context_ids(t1→t2)        [mask=0, tool result + user feedback, as actually rendered]
+                ++ completion_ids(t2)        [mask=1]
+                ++ context_ids(t2→t3)        [mask=0]
+                ++ ...
+loss_mask     = aligned 0/1 per token (1 only on assistant-sampled tokens)
+old_logprobs  = sampling logprobs, placed at mask=1 positions
+```
+
+`context_ids(tN→tN+1)` are obtained by tokenizing the **delta** of the rendered chat between turns
+(render after appending the assistant+feedback messages, diff against the previous render's token
+prefix), so the masked context is the exact bytes the next turn's prompt contained — no re-tokenization
+drift on the trainable tokens.
+
+---
+
+## Config Schema
+
+### New `token_faithful` block under `env_training:` in `env_config.yaml`
+
+```yaml
+env_training:
+  # ... existing fields unchanged ...
+
+  # Token-faithful multi-turn serialization (POLAR-style).
+  # When true, the rollout preserves the full interleaved token sequence with a
+  # per-token loss mask instead of flattening assistant turns. Single-turn
+  # episodes are unaffected either way.
+  token_faithful: true
+
+  # How to treat tokens the model saw but did not generate (tool results,
+  # user feedback prompts). "mask" = keep as context, exclude from loss.
+  # "drop" = legacy flattened behavior (not faithful; kept only for A/B).
+  context_token_policy: mask   # "mask" | "drop"
+```
+
+**Backward compatibility:** `token_faithful: false` (or `context_token_policy: drop`) reproduces today's
+flattened behavior exactly, for A/B comparison. Default flips to faithful once Phase 0 confirms the TRL
+contract.
+
+---
+
+## Implementation Phases
+
+### Phase 0: TRL `rollout_func` Contract Spike
+
+**Delegate to:** `pact-architect`
+
+| Task | Details |
+|------|---------|
+| Confirm return schema | Inspect the installed `trl.experimental.openenv` / GRPO `rollout_func` contract: does TRL accept a per-sample `completion_mask` (or equivalent) alongside `completion_ids`, or does it derive the mask from `prompt_ids` length? |
+| Decide mask delivery | Two candidate designs: (A) extend the rollout dict with a `completion_mask` key TRL honors; (B) fold masked context into `prompt_ids` per-turn and emit one rollout record per assistant turn (turn-level GRPO). Pick based on what TRL actually supports. |
+| Verify logprob alignment | Confirm how TRL aligns supplied `logprobs` to `completion_ids` so masked positions don't corrupt the importance ratio. |
+| Record findings | Append a short "TRL contract" note to this plan before Phase 1 starts. |
+
+**Gate:** Do not start Phase 1 until the mask-delivery design is chosen and written down. If TRL exposes no
+mask hook, design (B) (turn-level records) becomes the implementation and the rest of the plan adjusts to
+emit N records per episode.
+
+---
+
+### Phase 1: Faithful Sequence Assembly (`env_rollout.py`)
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Capture per-turn `prompt_ids` | In `_run_single_episode()`, stop discarding non-first `prompt_ids`. Track the running rendered-token prefix so each turn's *new* context tokens can be isolated. |
+| Build interleaved sequence | Assemble `sequence_ids` = initial prompt + alternating (assistant completion, masked context) segments, using the exact tokens from `_generate_one_completion()` for assistant spans and the rendered delta for context spans. |
+| Build `loss_mask` | 1 on assistant-sampled token positions, 0 on prompt/context positions. Length must equal `len(sequence_ids)`. |
+| Align `old_logprobs` | Place per-turn sampling `logprobs` at their mask=1 positions; context positions carry no contribution. |
+| Extend `EpisodeRolloutResult` | Add `sequence_ids`, `loss_mask` (and keep `completion_ids`/`logprobs` for the legacy/`drop` path). |
+| Wire `build_rollout_func()` | Emit the mask per the Phase 0 design (extra dict key **or** turn-level records). Keep the existing metric keys (`env_reward`, `stop_reason`, `total_turns`, ...) untouched. |
+| Honor config toggle | `context_token_policy: drop` → current flattened path; `mask` → faithful path. |
+
+**Patterns to follow:**
+- Existing turn loop and env feedback (`env_rollout.py:131-209`) is reused as-is; only result assembly changes.
+- `parse_response` / `format_tool_results_message` usage stays identical.
+
+**Invariant to preserve (call out in review):** single-turn episodes must produce a byte-identical
+`(prompt_ids, completion_ids, logprobs)` to today. The faithful path only diverges when `total_turns > 1`.
+
+---
+
+### Phase 2: Tests
+
+**Delegate to:** `pact-test-engineer`
+
+| Test | Type | What |
+|------|------|------|
+| `test_single_turn_parity` | Unit | A 1-turn episode yields identical `prompt_ids`/`completion_ids`/`logprobs` under `mask` and `drop` policies (no regression for the common case). |
+| `test_multi_turn_sequence_faithful` | Unit | A 3-turn episode: assert `sequence_ids` == prompt ++ comp1 ++ ctx1 ++ comp2 ++ ctx2 ++ comp3, with stubbed tokenizer/generation. |
+| `test_loss_mask_alignment` | Unit | `len(loss_mask) == len(sequence_ids)`; mask=1 positions exactly cover assistant-sampled tokens; `old_logprobs` align to mask=1 count. |
+| `test_context_token_policy_drop` | Unit | `drop` reproduces the legacy flattened result. |
+| `test_rollout_func_contract` | Integration | `build_rollout_func()` output matches the Phase 0 TRL contract (key presence / per-record shape). |
+| Existing env-GRPO tests | Regression | Confirm no breakage in current suite. |
+
+Use stubbed `trainer` / `generate_rollout_completions` (as in current tests) so no model load is required.
+
+---
+
+### Phase 3: Skill Documentation
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| `.skills/fine-tuning/reference/grpo-training.md` | New "Token-Faithful Multi-Turn Rollout" section: what faithfulness means, the `token_faithful` / `context_token_policy` config, when to A/B against `drop`, and the single-turn-parity invariant. |
+| `.skills/fine-tuning/SKILL.md` | One gotcha line under env-GRPO notes pointing at the new section. |
+| Sync mirrors | `python3 .skills/scripts/sync_skill_trees.py` after edits. |
+
+---
+
+## Risk Mitigation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| TRL `rollout_func` exposes no mask hook | High | Phase 0 gate. Fallback design (B): emit one rollout record per assistant turn with masked context folded into `prompt_ids`. |
+| Re-tokenization drift on context deltas | Medium | Derive context tokens from rendered-string deltas, not independent re-tokenization of fragments; assert prefix-consistency in `test_multi_turn_sequence_faithful`. |
+| Silent regression for single-turn episodes | Medium | `test_single_turn_parity` + explicit invariant in review. Default could stay `drop` until parity test is green. |
+| Sequence length blowup on long episodes | Low | `max_completion_length` / `max_turns` already cap episode size; faithful path adds only the context tokens that were already rendered into prompts. |
+| logprob/length mismatch crashes TRL | Medium | `test_loss_mask_alignment` asserts counts before any training run; dry-run a 5-step smoke job before a full launch. |
+
+---
+
+## Connection to Existing Systems
+
+| Existing System | Relationship |
+|---|---|
+| **Env-GRPO** (`train_env_grpo.py`, `env_rollout.py`) | Direct target. This plan hardens the rollout serialization without touching the entrypoint or trainer wiring. |
+| **PivotRL** (`pivot_profiler.py`, `pivot_config.yaml`) | Orthogonal. PivotRL selects *which* turns to train on; this selects *how faithfully* a chosen episode is tokenized. They compose. |
+| **Flywheel proxy** (`services/proxy/`, `inference_logger.py`) | See companion plan `proxy-token-capture-grpo-feed-plan.md` — the proxy would supply faithful token IDs/logprobs for a future flywheel→GRPO feed; this plan fixes the on-policy trainer path first. |
+| **Reward system** (`env_rewards.py`) | Unchanged. Rewards still score the episode; only the token sequence the reward is attached to becomes faithful. |
+
+---
+
+## Out of Scope (explicitly)
+
+- **Harness-agnostic RL through external agents (Claude Code / Codex / Qwen Code).** POLAR's headline
+  capability — proxying a real coding-agent harness and RL-training through it — is a re-architecture of
+  our generation path (we use TRL colocate vLLM against SynthChat envs). Not pursued here; revisit only if
+  we decide to RL real coding agents.
+
+---
+
+## Success Criteria
+
+1. Phase 0 produces a written TRL-contract decision appended to this plan.
+2. A 1-turn episode yields byte-identical `prompt_ids`/`completion_ids`/`logprobs` under `mask` and `drop`.
+3. A multi-turn episode produces `sequence_ids` containing the rendered tool-result/user-feedback tokens between assistant turns, with a `loss_mask` that is 1 only on assistant-sampled tokens.
+4. `len(loss_mask) == len(sequence_ids)` and `old_logprobs` align to the mask=1 count.
+5. A 5-step env-GRPO smoke run completes with `token_faithful: true` and no length/logprob mismatch.
+6. `context_token_policy: drop` reproduces today's behavior; all existing env-GRPO tests pass.
+7. Skill docs updated and mirrors synced.

--- a/docs/plans/token-faithful-grpo-rollout-plan.md
+++ b/docs/plans/token-faithful-grpo-rollout-plan.md
@@ -1,9 +1,34 @@
 # Token-Faithful Multi-Turn GRPO Rollout Plan
 
 **Date:** 2026-05-29
-**Status:** Proposed
+**Status:** Implemented (Phases 0–3)
 **Paper / Prior Art:** NVIDIA POLAR — [arXiv:2605.24220](https://arxiv.org/html/2605.24220v1) ([MarkTechPost writeup](https://www.marktechpost.com/2026/05/27/nvidia-releases-polar-a-token-faithful-rollout-framework-for-grpo-training-across-codex-claude-code-and-qwen-code/))
 **Branch:** `claude/polar-token-rollout-MTzCp`
+
+---
+
+## Phase 0 — TRL Contract (RESOLVED)
+
+Verified directly against TRL wheels (no guessing):
+
+- **Hook:** TRL's GRPO `rollout_func` accepts an extra `env_mask` key in its
+  output dict. `grpo_trainer.py` does `tool_mask = extra_fields.pop("env_mask", None)`
+  ("marks model tokens (1) vs external tokens (0)") and the loss uses
+  `loss_mask = completion_mask if "tool_mask" not in inputs else completion_mask * inputs["tool_mask"]`.
+  So **design (A)** — one record per episode, full interleaved sequence in
+  `completion_ids`, masked via `env_mask` — is supported. Turn-level records
+  (design B) are unnecessary.
+- **Contract:** `rollout_func` must return `prompt_ids`, `completion_ids`,
+  `logprobs`; `env_mask` is an optional extra. `env_mask` and `logprobs` must each
+  be the same length as `completion_ids` (TRL pads `env_mask` with 1 and
+  `logprobs` with 0.0). Context tokens are still attended to (they sit in
+  `completion_ids` with `completion_mask=1`) but contribute nothing to the loss.
+- **Version floor:** `env_mask` is honored from **trl 0.28.0** (wired into the loss
+  at `grpo_trainer.py`). `0.24.0`–`0.27.x` have no `env_mask`. Config floor bumped
+  to `trl>=0.28.0`; the rollout builder also probes the live trainer source via
+  `detect_openenv_runtime_support()['has_env_mask']` and falls back to the legacy
+  flattened path (with a warning) on older runtimes, so it never trains on context
+  tokens.
 
 ---
 

--- a/services/proxy/app.py
+++ b/services/proxy/app.py
@@ -171,13 +171,19 @@ async def proxy(request: Request, path: str) -> Response:
     # Read request body (needed for forwarding and potentially logging)
     body = await request.body()
 
+    is_chat_completion = request.method == "POST" and path.strip("/") == _CHAT_COMPLETIONS_PATH
+
+    # Optionally enrich chat-completion requests so the logger can capture
+    # token-faithful rollouts (token ids + per-token logprobs).
+    if is_chat_completion and getattr(request.app.state.config, "inject_logprobs", False):
+        body = _inject_logprobs(body)
+
     # Build headers to forward (pass auth through, set content type)
     forward_headers = _build_forward_headers(request)
 
     # Determine if this is a loggable request
     should_log = (
-        request.method == "POST"
-        and path.strip("/") == _CHAT_COMPLETIONS_PATH
+        is_chat_completion
         and request.app.state.inference_logger is not None
     )
 
@@ -242,6 +248,28 @@ def _load_config() -> ProxyConfig:
     except ImportError:
         logger.info("FlywheelConfig not available, loading from environment")
         return ProxyConfig.from_env()
+
+
+def _inject_logprobs(body: bytes) -> bytes:
+    """Add logprobs + return_tokens_as_token_ids to a chat-completion body.
+
+    Enables token-faithful rollout capture without the caller opting in. Best
+    effort: if the body is not parseable JSON, it is forwarded unchanged. Does
+    not override values the caller already set.
+    """
+    import json
+
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return body
+    if not isinstance(payload, dict):
+        return body
+
+    payload.setdefault("logprobs", True)
+    # vLLM extension: renders each logprob token as "token_id:<int>".
+    payload.setdefault("return_tokens_as_token_ids", True)
+    return json.dumps(payload).encode("utf-8")
 
 
 def _build_forward_headers(request: Request) -> dict[str, str]:

--- a/services/proxy/config.py
+++ b/services/proxy/config.py
@@ -29,6 +29,9 @@ class ProxyConfig:
     proxy_port: int = 8080
     proxy_timeout_seconds: float = 120.0
     flush_interval_seconds: float = 1.0
+    # When true, inject logprobs + return_tokens_as_token_ids into forwarded
+    # chat-completion requests so the logger can capture token-faithful rollouts.
+    inject_logprobs: bool = False
 
     @classmethod
     def from_env(cls) -> ProxyConfig:
@@ -52,6 +55,8 @@ class ProxyConfig:
             flush_interval_seconds=float(
                 os.environ.get("FLYWHEEL_FLUSH_INTERVAL", "1.0")
             ),
+            inject_logprobs=os.environ.get("FLYWHEEL_INJECT_LOGPROBS", "0")
+            in ("1", "true", "True"),
         )
 
     @classmethod
@@ -73,4 +78,5 @@ class ProxyConfig:
             proxy_port=config.proxy_port,
             proxy_timeout_seconds=config.proxy_timeout_seconds,
             flush_interval_seconds=config.flush_interval_seconds,
+            inject_logprobs=getattr(config, "proxy_inject_logprobs", False),
         )

--- a/shared/flywheel/catalog.py
+++ b/shared/flywheel/catalog.py
@@ -47,6 +47,13 @@ class InferenceLogRecord:
     prompt_tokens: int = 0
     completion_tokens: int = 0
 
+    # Token-faithful rollout capture (optional; only populated when the proxy
+    # requested logprobs and the response carried them — see capture_token_ids).
+    # These ride in the JSONL only; the catalog index does not store them.
+    prompt_token_ids: list[int] | None = None
+    completion_token_ids: list[int] | None = None
+    completion_logprobs: list[float] | None = None
+
     # Pipeline metadata (populated during processing)
     latency_ms: float = 0.0
     fitness_score: float | None = None
@@ -62,9 +69,21 @@ class InferenceLogRecord:
     source_file: str = ""
     line_number: int = 0
 
+    # Optional token-capture fields are omitted from the JSONL when unset, so
+    # records without rollout capture stay byte-compatible with existing readers.
+    _OPTIONAL_TOKEN_FIELDS = (
+        "prompt_token_ids",
+        "completion_token_ids",
+        "completion_logprobs",
+    )
+
     def to_json(self) -> str:
-        """Serialize to JSON string."""
-        return json.dumps(asdict(self), ensure_ascii=False, separators=(",", ":"))
+        """Serialize to JSON string (omitting unset token-capture fields)."""
+        data = asdict(self)
+        for key in self._OPTIONAL_TOKEN_FIELDS:
+            if data.get(key) is None:
+                data.pop(key, None)
+        return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
 
     @classmethod
     def from_dict(cls, data: dict) -> InferenceLogRecord:

--- a/shared/flywheel/config.py
+++ b/shared/flywheel/config.py
@@ -64,6 +64,17 @@ class FlywheelConfig:
     proxy_timeout_seconds: float = 120.0
     flush_interval_seconds: float = 1.0
 
+    # -- Token-faithful rollout capture (off by default) --
+    # When true, the inference logger persists completion token ids + per-token
+    # logprobs from the vLLM response (when present). Required for any future
+    # GRPO/rollout feed; SFT/KTO do not need it and it grows log size.
+    capture_token_ids: bool = False
+    # When true, the proxy injects `logprobs: true` + `return_tokens_as_token_ids:
+    # true` into forwarded chat-completion requests so capture has data to read.
+    # Off by default to avoid changing latency/payload for callers that did not
+    # ask for logprobs.
+    proxy_inject_logprobs: bool = False
+
     # -- vLLM --
     vllm_adapter_name: str = "current-adapter"
     vllm_adapter_path: str | None = None

--- a/shared/flywheel/inference_logger.py
+++ b/shared/flywheel/inference_logger.py
@@ -55,6 +55,43 @@ def _scrub_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return scrubbed
 
 
+def _extract_completion_token_logprobs(
+    choice: dict[str, Any],
+) -> tuple[list[int] | None, list[float] | None]:
+    """Best-effort extraction of completion token ids + per-token logprobs.
+
+    Reads the OpenAI/vLLM chat-completions ``logprobs.content`` array. Per-token
+    logprobs are taken directly. Token ids are only available when vLLM was asked
+    with ``return_tokens_as_token_ids: true`` (then each ``token`` is rendered as
+    ``"token_id:<int>"``); if any token is not in that form, token ids are
+    reported as None (logprobs may still be returned). Never raises — capture is
+    best-effort and absence is normal.
+    """
+    logprobs_obj = choice.get("logprobs") or {}
+    content = logprobs_obj.get("content")
+    if not content:
+        return None, None
+
+    logprob_values: list[float] = []
+    token_ids: list[int] = []
+    token_ids_ok = True
+    for entry in content:
+        if not isinstance(entry, dict):
+            return None, None
+        lp = entry.get("logprob")
+        logprob_values.append(float(lp) if lp is not None else 0.0)
+        token = entry.get("token", "")
+        if isinstance(token, str) and token.startswith("token_id:"):
+            try:
+                token_ids.append(int(token.split(":", 1)[1]))
+            except ValueError:
+                token_ids_ok = False
+        else:
+            token_ids_ok = False
+
+    return (token_ids if token_ids_ok and token_ids else None), (logprob_values or None)
+
+
 class InferenceLogger:
     """Async JSONL writer for inference request/response pairs.
 
@@ -166,12 +203,16 @@ class InferenceLogger:
         tool_calls_list: list[dict] = []
         finish_reason = "stop"
 
+        completion_token_ids: list[int] | None = None
+        completion_logprobs: list[float] | None = None
         if choices:
             choice = choices[0]
             message = choice.get("message", {})
             response_content = message.get("content", "") or ""
             tool_calls_list = message.get("tool_calls", []) or []
             finish_reason = choice.get("finish_reason", "stop") or "stop"
+            if getattr(self._config, "capture_token_ids", False):
+                completion_token_ids, completion_logprobs = _extract_completion_token_logprobs(choice)
 
         # Extract usage
         usage = response.get("usage", {})
@@ -193,6 +234,8 @@ class InferenceLogger:
             finish_reason=finish_reason,
             prompt_tokens=prompt_toks,
             completion_tokens=completion_toks,
+            completion_token_ids=completion_token_ids,
+            completion_logprobs=completion_logprobs,
             latency_ms=latency_ms,
         )
 

--- a/shared/flywheel/stager.py
+++ b/shared/flywheel/stager.py
@@ -308,10 +308,23 @@ class DatasetStager:
     def _format_grpo_example(
         self, record: InferenceLogRecord, content: dict,
     ) -> dict:
-        """Format a log as a GRPO training example."""
+        """Format a log as a GRPO training example.
+
+        When the log carries token-faithful rollout capture (completion token
+        ids + per-token logprobs, from a logprobs-enabled proxy), those fields
+        are passed through alongside the conversational form so a downstream
+        token-faithful / replay GRPO consumer can use the exact sampled tokens.
+        Records without capture are unchanged.
+        """
         conversations = self._build_conversations(content)
         reward = (record.fitness_score or 0.0) * self._config.grpo_reward_scale
-        return {"conversations": conversations, "reward": reward}
+        example: dict[str, Any] = {"conversations": conversations, "reward": reward}
+
+        for key in ("prompt_token_ids", "completion_token_ids", "completion_logprobs"):
+            value = content.get(key)
+            if value is not None:
+                example[key] = value
+        return example
 
     @staticmethod
     def _build_conversations(content: dict) -> list[dict[str, str]]:

--- a/tests/flywheel/test_token_capture.py
+++ b/tests/flywheel/test_token_capture.py
@@ -1,0 +1,184 @@
+"""Tests for token-faithful rollout capture (proxy -> logger -> JSONL -> stager).
+
+Covers the optional completion token-id / logprob capture added for a future
+GRPO feed: extraction, record serialization back-compat, the capture config
+gate, proxy logprob injection, and stager pass-through.
+"""
+from __future__ import annotations
+
+import json
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from shared.flywheel.catalog import InferenceLogRecord
+from shared.flywheel.config import FlywheelConfig
+from shared.flywheel.inference_logger import (
+    InferenceLogger,
+    _extract_completion_token_logprobs,
+)
+from shared.flywheel.stager import DatasetStager
+from services.proxy.app import _inject_logprobs
+
+
+# ---------------------------------------------------------------------------
+# _extract_completion_token_logprobs
+# ---------------------------------------------------------------------------
+
+def _choice_with_logprobs(entries):
+    return {"message": {"content": "x"}, "finish_reason": "stop", "logprobs": {"content": entries}}
+
+
+def test_extract_token_ids_and_logprobs():
+    choice = _choice_with_logprobs(
+        [{"token": "token_id:101", "logprob": -0.5}, {"token": "token_id:202", "logprob": -1.5}]
+    )
+    ids, logps = _extract_completion_token_logprobs(choice)
+    assert ids == [101, 202]
+    assert logps == [-0.5, -1.5]
+
+
+def test_extract_logprobs_only_when_tokens_not_ids():
+    # Plain token strings (no return_tokens_as_token_ids) -> ids None, logprobs kept
+    choice = _choice_with_logprobs([{"token": "hello", "logprob": -0.2}, {"token": " world", "logprob": -0.3}])
+    ids, logps = _extract_completion_token_logprobs(choice)
+    assert ids is None
+    assert logps == [-0.2, -0.3]
+
+
+def test_extract_none_when_no_logprobs():
+    assert _extract_completion_token_logprobs({"message": {"content": "x"}}) == (None, None)
+    assert _extract_completion_token_logprobs(_choice_with_logprobs([])) == (None, None)
+
+
+def test_extract_handles_missing_logprob_value():
+    choice = _choice_with_logprobs([{"token": "token_id:5"}])  # no "logprob" key
+    ids, logps = _extract_completion_token_logprobs(choice)
+    assert ids == [5]
+    assert logps == [0.0]
+
+
+# ---------------------------------------------------------------------------
+# Record serialization / back-compat
+# ---------------------------------------------------------------------------
+
+def test_to_json_omits_unset_token_fields():
+    rec = InferenceLogRecord(log_id="a", timestamp="t", model_id="m")
+    data = json.loads(rec.to_json())
+    assert "completion_token_ids" not in data
+    assert "completion_logprobs" not in data
+    assert "prompt_token_ids" not in data
+
+
+def test_to_json_includes_token_fields_when_set():
+    rec = InferenceLogRecord(
+        log_id="a", timestamp="t", model_id="m",
+        completion_token_ids=[1, 2], completion_logprobs=[-0.1, -0.2],
+    )
+    data = json.loads(rec.to_json())
+    assert data["completion_token_ids"] == [1, 2]
+    assert data["completion_logprobs"] == [-0.1, -0.2]
+
+
+def test_from_dict_roundtrip_with_token_fields():
+    rec = InferenceLogRecord(
+        log_id="a", timestamp="t", model_id="m",
+        completion_token_ids=[7], completion_logprobs=[-0.9],
+    )
+    restored = InferenceLogRecord.from_dict(json.loads(rec.to_json()))
+    assert restored.completion_token_ids == [7]
+    assert restored.completion_logprobs == [-0.9]
+
+
+def test_from_dict_old_record_without_token_fields():
+    # A pre-capture JSONL row deserializes with token fields defaulting to None
+    old = {"log_id": "a", "timestamp": "t", "model_id": "m", "response_content": "hi"}
+    rec = InferenceLogRecord.from_dict(old)
+    assert rec.completion_token_ids is None
+    assert rec.completion_logprobs is None
+
+
+# ---------------------------------------------------------------------------
+# Capture config gate in _build_record
+# ---------------------------------------------------------------------------
+
+def _response_with_logprobs():
+    return {
+        "choices": [_choice_with_logprobs(
+            [{"token": "token_id:11", "logprob": -0.4}, {"token": "token_id:12", "logprob": -0.6}]
+        )],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2},
+    }
+
+
+def _request():
+    return {"model": "m", "messages": [{"role": "user", "content": "hi"}], "temperature": 0.5, "max_tokens": 64}
+
+
+def test_build_record_captures_when_enabled(tmp_path):
+    logger = InferenceLogger(tmp_path, AsyncMock(), FlywheelConfig(capture_token_ids=True))
+    rec = logger._build_record(_request(), _response_with_logprobs(), 10.0, "m", None)
+    assert rec.completion_token_ids == [11, 12]
+    assert rec.completion_logprobs == [-0.4, -0.6]
+
+
+def test_build_record_skips_capture_when_disabled(tmp_path):
+    logger = InferenceLogger(tmp_path, AsyncMock(), FlywheelConfig(capture_token_ids=False))
+    rec = logger._build_record(_request(), _response_with_logprobs(), 10.0, "m", None)
+    assert rec.completion_token_ids is None
+    assert rec.completion_logprobs is None
+
+
+# ---------------------------------------------------------------------------
+# Proxy logprob injection
+# ---------------------------------------------------------------------------
+
+def test_inject_logprobs_adds_flags():
+    body = json.dumps({"model": "m", "messages": []}).encode()
+    out = json.loads(_inject_logprobs(body))
+    assert out["logprobs"] is True
+    assert out["return_tokens_as_token_ids"] is True
+
+
+def test_inject_logprobs_respects_existing_values():
+    body = json.dumps({"model": "m", "logprobs": False}).encode()
+    out = json.loads(_inject_logprobs(body))
+    assert out["logprobs"] is False  # not overridden
+
+
+def test_inject_logprobs_passes_through_bad_json():
+    body = b"not json"
+    assert _inject_logprobs(body) == body
+
+
+# ---------------------------------------------------------------------------
+# Stager pass-through
+# ---------------------------------------------------------------------------
+
+def _stager():
+    return DatasetStager(catalog=AsyncMock(), config=FlywheelConfig())
+
+
+def test_grpo_example_includes_token_fields_when_present():
+    stager = _stager()
+    record = InferenceLogRecord(log_id="a", timestamp="t", model_id="m", fitness_score=0.7)
+    content = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "response_content": "ok",
+        "completion_token_ids": [3, 4],
+        "completion_logprobs": [-0.1, -0.2],
+    }
+    example = stager._format_grpo_example(record, content)
+    assert example["completion_token_ids"] == [3, 4]
+    assert example["completion_logprobs"] == [-0.1, -0.2]
+    assert "reward" in example and "conversations" in example
+
+
+def test_grpo_example_omits_token_fields_when_absent():
+    stager = _stager()
+    record = InferenceLogRecord(log_id="a", timestamp="t", model_id="m", fitness_score=0.5)
+    content = {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"}
+    example = stager._format_grpo_example(record, content)
+    assert "completion_token_ids" not in example
+    assert "completion_logprobs" not in example

--- a/tests/trainers/grpo/test_env_rollout_faithful.py
+++ b/tests/trainers/grpo/test_env_rollout_faithful.py
@@ -1,0 +1,210 @@
+"""Tests for token-faithful (POLAR-style) multi-turn env-GRPO rollout assembly.
+
+These cover the pure sequence-assembly helpers, the capability gate that decides
+whether to emit ``env_mask``, and the rollout_func output contract. They use only
+crafted token lists and stubs — no TRL, model, or environment runtime required.
+"""
+
+import sys
+import types
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
+
+import env_rollout
+from env_rollout import (
+    EpisodeRolloutResult,
+    _align_logprobs,
+    _assemble_faithful_sequence,
+    _assemble_flat_sequence,
+    _resolve_faithful_mode,
+    build_rollout_func,
+)
+
+
+# ---------------------------------------------------------------------------
+# Crafted multi-turn fixture
+# ---------------------------------------------------------------------------
+# Turn 0: prompt [1,2,3], assistant [10,11]
+# Turn 1: prompt = prompt0 + comp0 + ext1([20,21,22]), assistant [12,13]
+# Turn 2: prompt = prompt1 + comp1 + ext2([30]),        assistant [14]
+THREE_TURNS = [
+    ([1, 2, 3], [10, 11], [-0.1, -0.2]),
+    ([1, 2, 3, 10, 11, 20, 21, 22], [12, 13], [-0.3, -0.4]),
+    ([1, 2, 3, 10, 11, 20, 21, 22, 12, 13, 30], [14], [-0.5]),
+]
+SINGLE_TURN = [([1, 2, 3], [10, 11, 12], [-0.1, -0.2, -0.3])]
+
+
+# ---------------------------------------------------------------------------
+# _align_logprobs
+# ---------------------------------------------------------------------------
+
+def test_align_logprobs_exact():
+    assert _align_logprobs([-0.1, -0.2], 2) == [-0.1, -0.2]
+
+
+def test_align_logprobs_pads_short():
+    assert _align_logprobs([-0.1], 3) == [-0.1, 0.0, 0.0]
+
+
+def test_align_logprobs_truncates_long():
+    assert _align_logprobs([-0.1, -0.2, -0.3], 2) == [-0.1, -0.2]
+
+
+# ---------------------------------------------------------------------------
+# Single-turn parity: faithful and flat must agree exactly
+# ---------------------------------------------------------------------------
+
+def test_single_turn_parity():
+    base_f, comp_f, mask_f, lp_f = _assemble_faithful_sequence(SINGLE_TURN)
+    base_d, comp_d, lp_d = _assemble_flat_sequence(SINGLE_TURN)
+
+    assert base_f == base_d == [1, 2, 3]
+    assert comp_f == comp_d == [10, 11, 12]
+    assert lp_f == lp_d == [-0.1, -0.2, -0.3]
+    # env_mask is all-ones for a single assistant turn (no external context)
+    assert mask_f == [1, 1, 1]
+
+
+# ---------------------------------------------------------------------------
+# Multi-turn faithful assembly
+# ---------------------------------------------------------------------------
+
+def test_multi_turn_faithful_sequence():
+    base, completion, env_mask, logprobs = _assemble_faithful_sequence(THREE_TURNS)
+
+    assert base == [1, 2, 3]
+    # assistant0 ++ ext1 ++ assistant1 ++ ext2 ++ assistant2
+    assert completion == [10, 11, 20, 21, 22, 12, 13, 30, 14]
+    assert env_mask == [1, 1, 0, 0, 0, 1, 1, 0, 1]
+    assert logprobs == [-0.1, -0.2, 0.0, 0.0, 0.0, -0.3, -0.4, 0.0, -0.5]
+
+
+def test_multi_turn_lengths_aligned():
+    _base, completion, env_mask, logprobs = _assemble_faithful_sequence(THREE_TURNS)
+    assert len(completion) == len(env_mask) == len(logprobs)
+
+
+def test_multi_turn_mask_covers_only_assistant_tokens():
+    _base, completion, env_mask, _logprobs = _assemble_faithful_sequence(THREE_TURNS)
+    trained = [tok for tok, m in zip(completion, env_mask) if m == 1]
+    # exactly the sampled assistant tokens across all turns, in order
+    assert trained == [10, 11, 12, 13, 14]
+
+
+def test_multi_turn_flat_drops_context():
+    base, completion, logprobs = _assemble_flat_sequence(THREE_TURNS)
+    assert base == [1, 2, 3]
+    # only assistant tokens, context [20,21,22,30] dropped entirely
+    assert completion == [10, 11, 12, 13, 14]
+    assert logprobs == [-0.1, -0.2, -0.3, -0.4, -0.5]
+
+
+def test_assemble_handles_empty():
+    assert _assemble_faithful_sequence([]) == ([], [], [], [])
+    assert _assemble_flat_sequence([]) == ([], [], [])
+
+
+def test_faithful_negative_ext_len_is_safe():
+    # If a turn's prompt is shorter than prompt(t-1)+comp(t-1) (drift edge case),
+    # ext_len <= 0 and no context tokens are inserted — never crashes, never
+    # produces a negative-length slice.
+    segments = [
+        ([1, 2, 3], [10, 11], [-0.1, -0.2]),
+        ([1, 2], [12], [-0.3]),  # impossibly short prompt
+    ]
+    _base, completion, env_mask, logprobs = _assemble_faithful_sequence(segments)
+    assert completion == [10, 11, 12]
+    assert env_mask == [1, 1, 1]
+    assert len(completion) == len(env_mask) == len(logprobs)
+
+
+# ---------------------------------------------------------------------------
+# Capability gate
+# ---------------------------------------------------------------------------
+
+def test_resolve_faithful_requires_all_conditions():
+    on = {"token_faithful": True, "context_token_policy": "mask"}
+    assert _resolve_faithful_mode(on, {"has_env_mask": True}) is True
+
+
+def test_resolve_faithful_falls_back_without_env_mask_support():
+    on = {"token_faithful": True, "context_token_policy": "mask"}
+    assert _resolve_faithful_mode(on, {"has_env_mask": False}) is False
+    assert _resolve_faithful_mode(on, None) is False
+
+
+def test_resolve_faithful_respects_drop_policy():
+    cfg = {"token_faithful": True, "context_token_policy": "drop"}
+    assert _resolve_faithful_mode(cfg, {"has_env_mask": True}) is False
+
+
+def test_resolve_faithful_respects_disabled():
+    cfg = {"token_faithful": False, "context_token_policy": "mask"}
+    assert _resolve_faithful_mode(cfg, {"has_env_mask": True}) is False
+
+
+def test_resolve_faithful_defaults_on_when_supported():
+    # token_faithful defaults to True, policy defaults to "mask"
+    assert _resolve_faithful_mode({}, {"has_env_mask": True}) is True
+
+
+# ---------------------------------------------------------------------------
+# rollout_func output contract
+# ---------------------------------------------------------------------------
+
+def _patch_openenv(monkeypatch):
+    """Stub the TRL openenv import so build_rollout_func works without TRL."""
+    fake = types.SimpleNamespace(generate_rollout_completions=lambda *a, **k: None)
+    monkeypatch.setattr(env_rollout, "_import_openenv_helpers", lambda: fake)
+
+
+def _canned_result():
+    return EpisodeRolloutResult(
+        prompt_ids=[1, 2, 3],
+        completion_ids=[10, 11, 20, 12],
+        logprobs=[-0.1, -0.2, 0.0, -0.3],
+        completion_text="hi",
+        env_passed=True,
+        env_reward=1.0,
+        stop_reason="environment_passed",
+        total_turns=2,
+        total_tool_calls=1,
+        final_text_satisfied=True,
+        env_mask=[1, 1, 0, 1],
+    )
+
+
+def test_rollout_func_emits_env_mask_when_faithful(monkeypatch):
+    _patch_openenv(monkeypatch)
+    monkeypatch.setattr(env_rollout, "_run_single_episode", lambda **kw: _canned_result())
+
+    rollout = build_rollout_func(
+        registry={"p": object()},
+        env_training_cfg={"token_faithful": True, "context_token_policy": "mask"},
+        runtime_support={"has_env_mask": True},
+    )
+    out = rollout(["p"], trainer=None)
+
+    assert "env_mask" in out
+    assert out["env_mask"] == [[1, 1, 0, 1]]
+    assert out["completion_ids"] == [[10, 11, 20, 12]]
+    assert len(out["env_mask"][0]) == len(out["completion_ids"][0])
+
+
+def test_rollout_func_omits_env_mask_when_unsupported(monkeypatch):
+    _patch_openenv(monkeypatch)
+    monkeypatch.setattr(env_rollout, "_run_single_episode", lambda **kw: _canned_result())
+
+    rollout = build_rollout_func(
+        registry={"p": object()},
+        env_training_cfg={"token_faithful": True, "context_token_policy": "mask"},
+        runtime_support={"has_env_mask": False},  # older TRL
+    )
+    out = rollout(["p"], trainer=None)
+
+    # No env_mask key -> TRL trains on all completion tokens; safe because the
+    # fallback episode would use the flat (context-free) representation.
+    assert "env_mask" not in out


### PR DESCRIPTION
Add two proposed plans borrowing from NVIDIA POLAR (arXiv:2605.24220):

- token-faithful-grpo-rollout-plan.md: fix the multi-turn faithfulness
  gap in Trainers/grpo/src/env_rollout.py, where assistant turns are
  flattened and intermediate tool-result/user-feedback tokens are
  dropped from the trained sequence. Introduces an interleaved token
  sequence + per-token loss mask, gated by config, preserving
  single-turn parity.

- proxy-token-capture-grpo-feed-plan.md (secondary): capture completion
  token IDs + logprobs at the flywheel logging proxy so logged inference
  can feed GRPO, not just SFT/KTO. Additive, opt-in record fields.

Both document full harness-agnostic RL (POLAR's headline) as explicitly
out of scope.

https://claude.ai/code/session_01Ut2iNAz9qr7EJbAoNsmDuN