### PR TITLE
Unified verifier/reward contract (NeMo Gym-inspired consolidation)

### DIFF
--- a/Evaluator/__init__.py
+++ b/Evaluator/__init__.py
@@ -45,7 +45,7 @@ from .config import (
 from .prompt_sets import PromptCase, filter_prompts, load_prompt_cases
 
 # Validation
-from .assertions import CorrectnessResult, evaluate_correctness
+from shared.verifiers.builtins.assertion_verifier import CorrectnessResult, evaluate_correctness
 from .schema_validator import ValidationResult, validate_assistant_response
 from .rubric_validator import (
     RubricValidator,

--- a/Evaluator/judge_validator.py
+++ b/Evaluator/judge_validator.py
@@ -27,6 +27,7 @@ from shared.judge import (
 )
 from shared.llm import BaseLLMClient
 from shared.validation.parsing import ParsedResponse
+from shared.verifiers.builtins.llm_judge import render_combined_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -163,38 +164,12 @@ class JudgeValidator:
         """
         template_vars = self._build_template_vars(parsed_response, case_metadata)
 
-        if len(self.rubrics) == 1:
-            return self._render_single_prompt(self.rubrics[0], template_vars)
-
-        # Multiple rubrics: concatenate with separators
-        parts = []
-        for rubric in self.rubrics:
-            rendered = self._render_single_prompt(rubric, template_vars)
-            parts.append(f"=== {rubric.name} ===\n{rendered}")
-        return "\n\n".join(parts)
-
-    @staticmethod
-    def _render_single_prompt(
-        rubric: RubricDef,
-        template_vars: Dict[str, str],
-    ) -> str:
-        """Fill template variables in a single rubric's judge_prompt.
-
-        Uses simple string replacement (str.replace) for each known variable,
-        avoiding str.format_map which could allow Python attribute access via
-        format strings. Missing variables are left as-is.
-
-        Args:
-            rubric: The rubric whose prompt to render.
-            template_vars: Dict of variable name -> value.
-
-        Returns:
-            Rendered prompt string.
-        """
-        prompt = rubric.judge_prompt
-        for key, val in template_vars.items():
-            prompt = prompt.replace(f"{{{key}}}", str(val))
-        return prompt
+        # Delegate the per-rubric substitution + concatenation to the shared
+        # canonical helper. It is byte-identical to the previous inline logic:
+        # single rubric renders bare; multiple rubrics get `=== <name> ===`
+        # headers joined by blank lines. Both do `str.replace("{k}", str(v))`
+        # over the same template_vars dict, avoiding str.format_map for safety.
+        return render_combined_prompt(self.rubrics, template_vars)
 
     def _build_template_vars(
         self,

--- a/Evaluator/runner.py
+++ b/Evaluator/runner.py
@@ -12,7 +12,12 @@ from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
-from .assertions import CorrectnessResult, evaluate_correctness, has_correctness_config
+from shared.verifiers.builtins.assertion_verifier import (
+    CorrectnessResult,
+    evaluate_correctness,
+    has_correctness_config,
+)
+from shared.verifiers.builtins.tool_sequence import evaluate_tool_sequence
 from .prompt_sets import PromptCase
 from .protocols import BackendClient
 from .response_view import build_response_view
@@ -734,37 +739,7 @@ def _matches_scoring_path(
     environment_result: Optional["EnvironmentValidationResult"],
     judge_result: Optional["JudgeValidationResult"],
 ) -> tuple[bool, List[str]]:
-    reasons: List[str] = []
-
-    all_tools = _string_list(path_cfg.get("all_tools"))
-    if all_tools:
-        missing = [tool for tool in all_tools if tool not in tool_names]
-        if missing:
-            reasons.append(f"missing tools: {', '.join(missing)}")
-
-    any_tools = _string_list(path_cfg.get("any_tools"))
-    if any_tools and not any(tool in tool_names for tool in any_tools):
-        reasons.append(f"needs any of: {', '.join(any_tools)}")
-
-    ordered_tools = _string_list(path_cfg.get("ordered_tools"))
-    if ordered_tools and not _contains_subsequence(tool_names, ordered_tools):
-        reasons.append(f"ordered tools not matched: {', '.join(ordered_tools)}")
-
-    first_tool = str(path_cfg.get("first_tool", "")).strip()
-    if first_tool and (not tool_names or tool_names[0] != first_tool):
-        reasons.append(f"first tool should be {first_tool}")
-
-    first_tool_any_of = _string_list(path_cfg.get("first_tool_any_of"))
-    if first_tool_any_of and (not tool_names or tool_names[0] not in first_tool_any_of):
-        reasons.append(f"first tool should be one of: {', '.join(first_tool_any_of)}")
-
-    max_tool_calls = path_cfg.get("max_tool_calls")
-    if max_tool_calls is not None and len(tool_names) > int(max_tool_calls):
-        reasons.append(f"too many tool calls: {len(tool_names)} > {int(max_tool_calls)}")
-
-    min_tool_calls = path_cfg.get("min_tool_calls")
-    if min_tool_calls is not None and len(tool_names) < int(min_tool_calls):
-        reasons.append(f"too few tool calls: {len(tool_names)} < {int(min_tool_calls)}")
+    _matched, reasons = evaluate_tool_sequence(tool_names, path_cfg)
 
     if path_cfg.get("require_schema_pass") and not (validator_result and validator_result.passed):
         reasons.append("schema validation did not pass")
@@ -779,26 +754,3 @@ def _matches_scoring_path(
         reasons.append("judge validation did not pass")
 
     return len(reasons) == 0, reasons
-
-
-def _contains_subsequence(items: List[str], subsequence: List[str]) -> bool:
-    if not subsequence:
-        return True
-    pos = 0
-    for item in items:
-        if item == subsequence[pos]:
-            pos += 1
-            if pos == len(subsequence):
-                return True
-    return False
-
-
-def _string_list(value: Any) -> List[str]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        clean = value.strip()
-        return [clean] if clean else []
-    if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
-    return []

--- a/Trainers/grpo/src/functional_verifier.py
+++ b/Trainers/grpo/src/functional_verifier.py
@@ -8,36 +8,13 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 
 from shared.verifiers.extraction import extract
+from shared.verifiers.builtins.args_match import (
+    compare_args_overlap,
+    normalize_tool_call,
+    normalize_value,
+)
 
 logger = logging.getLogger(__name__)
-
-def _normalize_value(value: Any) -> Any:
-    """Normalise a scalar/collection for comparison."""
-    if isinstance(value, dict):
-        return {k: _normalize_value(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_normalize_value(v) for v in value]
-    if not isinstance(value, str):
-        return value
-    stripped = value.strip()
-    if stripped.lower() == "true":
-        return True
-    if stripped.lower() == "false":
-        return False
-    try:
-        return int(stripped)
-    except ValueError:
-        pass
-    try:
-        return float(stripped)
-    except ValueError:
-        pass
-    return stripped.replace("\\", "/")
-
-
-def _normalize_tool_call(tool_name: str, args: Dict) -> Tuple[str, Dict]:
-    """Return normalised (tool_name, sorted_args) tuple."""
-    return tool_name.strip().lower(), {k: _normalize_value(v) for k, v in sorted(args.items())}
 
 
 def _extract_tool_call(text: str) -> Optional[Tuple[str, Dict]]:
@@ -46,30 +23,6 @@ def _extract_tool_call(text: str) -> Optional[Tuple[str, Dict]]:
     if ea.found:
         return ea.tool_name, ea.arguments
     return None
-
-
-def _compare_args(predicted: Dict, expected: Dict) -> float:
-    """Compare argument dicts: ``key_overlap * 0.4 + value_match * 0.6``."""
-    if not predicted and not expected:
-        return 1.0
-    if not predicted or not expected:
-        return 0.0
-    pred_keys, exp_keys = set(predicted.keys()), set(expected.keys())
-    all_keys = pred_keys | exp_keys
-    common = pred_keys & exp_keys
-    key_overlap = len(common) / len(all_keys) if all_keys else 0.0
-    if not common:
-        return key_overlap * 0.4
-    value_scores: List[float] = []
-    for key in common:
-        pv, ev = _normalize_value(predicted[key]), _normalize_value(expected[key])
-        if pv == ev:
-            value_scores.append(1.0)
-        elif isinstance(pv, str) and isinstance(ev, str) and (pv in ev or ev in pv):
-            value_scores.append(0.5)
-        else:
-            value_scores.append(0.0)
-    return key_overlap * 0.4 + (sum(value_scores) / len(value_scores)) * 0.6
 
 
 def functional_equivalence_reward(
@@ -103,10 +56,10 @@ def functional_equivalence_reward(
                 gt_args = parsed if isinstance(parsed, dict) else {}
             except (json.JSONDecodeError, ValueError):
                 gt_args = {}
-        norm_pred_name, norm_pred_args = _normalize_tool_call(pred_name, pred_args)
-        norm_gt_name, norm_gt_args = _normalize_tool_call(gt_tool, gt_args)
+        norm_pred_name, norm_pred_args = normalize_tool_call(pred_name, pred_args)
+        norm_gt_name, norm_gt_args = normalize_tool_call(gt_tool, gt_args)
         if norm_pred_name != norm_gt_name:
             scores.append(0.0)
             continue
-        scores.append(_compare_args(norm_pred_args, norm_gt_args))
+        scores.append(compare_args_overlap(norm_pred_args, norm_gt_args))
     return scores

--- a/Trainers/grpo/src/functional_verifier.py
+++ b/Trainers/grpo/src/functional_verifier.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any, Dict, List, Optional, Tuple
+
+from shared.verifiers.extraction import extract
 
 logger = logging.getLogger(__name__)
 
@@ -39,50 +40,11 @@ def _normalize_tool_call(tool_name: str, args: Dict) -> Tuple[str, Dict]:
     return tool_name.strip().lower(), {k: _normalize_value(v) for k, v in sorted(args.items())}
 
 
-def _parse_args(raw: Any) -> Dict:
-    """Coerce raw arguments to dict."""
-    if isinstance(raw, dict):
-        return raw
-    if isinstance(raw, str):
-        try:
-            parsed = json.loads(raw)
-            return parsed if isinstance(parsed, dict) else {}
-        except (json.JSONDecodeError, ValueError):
-            return {}
-    return {}
-
-
 def _extract_tool_call(text: str) -> Optional[Tuple[str, Dict]]:
-    """Extract (tool_name, arguments_dict) from Qwen/Mistral/plain output."""
-    # Qwen format
-    m = re.search(r"<tool_call>\s*([\s\S]*?)\s*</tool_call>", text, re.IGNORECASE)
-    if m:
-        try:
-            obj = json.loads(m.group(1).strip())
-            if isinstance(obj, dict):
-                return obj.get("name", ""), _parse_args(obj.get("arguments", {}))
-        except (json.JSONDecodeError, ValueError):
-            pass
-    # Mistral format
-    if "[TOOL_CALLS]" in text:
-        m = re.search(r"\[TOOL_CALLS\]\s*(\[[\s\S]*?\])", text)
-        if m:
-            try:
-                calls = json.loads(m.group(1))
-                if isinstance(calls, list) and calls:
-                    tc = calls[0]
-                    return tc.get("name", ""), _parse_args(tc.get("arguments", {}))
-            except (json.JSONDecodeError, ValueError):
-                pass
-    # Plain format
-    m = re.search(r"tool_call:\s*(\S+)\s*\narguments:\s*(\{[\s\S]*?\})", text)
-    if m:
-        try:
-            args = json.loads(m.group(2).strip())
-            if isinstance(args, dict):
-                return m.group(1).strip(), args
-        except (json.JSONDecodeError, ValueError):
-            pass
+    """Extract (tool_name, arguments_dict) via the canonical tool-call parser."""
+    ea = extract(text, mode="tool_call")
+    if ea.found:
+        return ea.tool_name, ea.arguments
     return None
 
 

--- a/Trainers/grpo/src/judge_reward.py
+++ b/Trainers/grpo/src/judge_reward.py
@@ -16,32 +16,18 @@ from typing import Any, Callable, Dict, List
 
 from shared.judge import (
     JudgeConfig,
-    JudgeResult,
     JudgeService,
     RubricDef,
     RubricLoader,
 )
 from shared.llm import LLMConfig, create_client
+from shared.verifiers.builtins.llm_judge import (
+    AGGREGATIONS as _AGGREGATIONS,
+    aggregate,
+    render_combined_prompt,
+)
 
 logger = logging.getLogger(__name__)
-
-_AGGREGATIONS = ("mean_score", "mean_passed", "min_score", "all_pass")
-
-
-def _aggregate(result: JudgeResult, strategy: str) -> float:
-    if not result.scores:
-        return 0.0
-    if strategy == "mean_score":
-        return sum(s.score for s in result.scores) / len(result.scores)
-    if strategy == "mean_passed":
-        return sum(1.0 if s.passed else 0.0 for s in result.scores) / len(result.scores)
-    if strategy == "min_score":
-        return min(s.score for s in result.scores)
-    if strategy == "all_pass":
-        return 1.0 if all(s.passed for s in result.scores) else 0.0
-    raise ValueError(
-        f"Unknown aggregation '{strategy}'. Must be one of: {', '.join(_AGGREGATIONS)}"
-    )
 
 
 def _coerce_completion_text(completion: Any) -> str:
@@ -106,23 +92,6 @@ def _build_judge_service(judge_cfg: Dict[str, Any]) -> JudgeService:
         max_tokens=int(judge_cfg.get("max_tokens", 2048)),
     )
     return JudgeService(llm_client, judge_config)
-
-
-def _render_combined_prompt(
-    rubrics: List[RubricDef],
-    template_vars: Dict[str, str],
-) -> str:
-    """Concatenate per-rubric judge_prompt templates after substituting vars."""
-    parts: List[str] = []
-    for rubric in rubrics:
-        rendered = rubric.judge_prompt
-        for k, v in template_vars.items():
-            rendered = rendered.replace(f"{{{k}}}", str(v))
-        if len(rubrics) == 1:
-            parts.append(rendered)
-        else:
-            parts.append(f"=== {rubric.name} ===\n{rendered}")
-    return "\n\n".join(parts)
 
 
 def build_judge_rubric_reward(
@@ -197,7 +166,7 @@ def build_judge_rubric_reward(
                 "user_prompt": prompt_text,
                 "response": response_text,
             }
-            rendered = _render_combined_prompt(rubrics, template_vars)
+            rendered = render_combined_prompt(rubrics, template_vars)
 
             result = judge_service.judge(prompt=rendered, rubrics=rubrics)
             if result.error:
@@ -205,7 +174,7 @@ def build_judge_rubric_reward(
                 rewards.append(0.0)
                 continue
 
-            rewards.append(_aggregate(result, aggregation))
+            rewards.append(aggregate(result, aggregation))
 
         return rewards
 

--- a/Trainers/grpo/src/rewards.py
+++ b/Trainers/grpo/src/rewards.py
@@ -31,6 +31,11 @@ except ImportError:
     StructureValidator = None
 
 from shared.verifiers.extraction import extract
+from shared.verifiers.builtins.args_match import (
+    compare_values,
+    score_legacy_fields,
+    score_mappings,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -239,136 +244,38 @@ class RewardRubric:
         if not mappings:
             return self._score_weighted_legacy(data, gt_args, comparison, kwargs)
 
-        # Score based on explicit field mappings
-        total_score = 0.0
-        total_weight = 0.0
+        # Score based on explicit field mappings (delegated to canonical home).
         pred_args = data.get("parsed_args", {})
-
-        for mapping in mappings:
-            pred_path = mapping.get("pred_path", "")
-            gt_path = mapping.get("gt_path", "")
-            weight = float(mapping.get("weight", 1.0))
-            strategy = mapping.get("strategy", "equals")
-
-            # Special case: tool_name comparison uses different fields
-            if mapping.get("use_tool_name"):
-                pred_val = data.get("tool_name", "")
-                gt_val = kwargs.get("ground_truth_tool", "")
-            elif pred_path == "" and strategy == "key_overlap":
-                # Empty pred_path with key_overlap means compare all parsed args
-                pred_val = pred_args
-                gt_val = self._get_nested_value(gt_args, gt_path)
-            else:
-                # Extract values using paths
-                pred_val = self._get_nested_value(pred_args, pred_path)
-                gt_val = self._get_nested_value(gt_args, gt_path)
-
-            # Compare based on strategy
-            field_score = self._compare_values(pred_val, gt_val, strategy)
-            total_score += weight * field_score
-            total_weight += weight
-
-        # Normalize score
-        return total_score / total_weight if total_weight > 0 else 0.0
-
-    def _get_nested_value(self, obj: Any, path: str) -> Any:
-        """Get value from nested dict using dot notation path."""
-        if not path or not obj:
-            return None
-
-        parts = path.split(".")
-        current = obj
-
-        for part in parts:
-            if isinstance(current, dict):
-                current = current.get(part)
-            elif isinstance(current, list) and part.isdigit():
-                idx = int(part)
-                current = current[idx] if idx < len(current) else None
-            else:
-                return None
-
-            if current is None:
-                return None
-
-        return current
+        return score_mappings(
+            pred_args=pred_args,
+            pred_tool=data.get("tool_name", ""),
+            gt_args=gt_args,
+            gt_tool=kwargs.get("ground_truth_tool", ""),
+            mappings=mappings,
+        )
 
     def _compare_values(self, pred: Any, gt: Any, strategy: str) -> float:
-        """Compare two values using the specified strategy."""
-        if pred is None or gt is None:
-            return 0.0
+        """Compare two values using the specified strategy.
 
-        if strategy == "equals":
-            return 1.0 if str(pred) == str(gt) else 0.0
-
-        elif strategy == "contains":
-            return 1.0 if str(gt) in str(pred) else 0.0
-
-        elif strategy == "key_overlap":
-            if isinstance(pred, dict) and isinstance(gt, dict) and gt:
-                overlap = len(set(pred.keys()) & set(gt.keys()))
-                return overlap / len(gt)
-            return 0.0
-
-        elif strategy == "tool_name_match":
-            # Compare tool names (handle agent_tool format)
-            pred_str = str(pred)
-            gt_str = str(gt)
-            if pred_str == gt_str:
-                return 1.0
-            # Partial: same agent
-            if "_" in pred_str and "_" in gt_str:
-                if pred_str.split("_")[0] == gt_str.split("_")[0]:
-                    return 0.3
-            return 0.0
-
-        return 0.0
+        Thin delegation to the canonical implementation in
+        ``shared.verifiers.builtins.args_match.compare_values``.
+        """
+        return compare_values(pred, gt, strategy)
 
     def _score_weighted_legacy(self, data: Dict, gt_args: Dict, comparison: Dict, kwargs: Dict) -> float:
-        """Legacy weighted scoring using field lists (backwards compatible)."""
-        context_fields = comparison.get("context_fields", [])
-        call_fields = comparison.get("call_fields", [])
+        """Legacy weighted scoring using field lists (backwards compatible).
 
-        weights = self.scoring.get("weights", {})
-        context_weight = weights.get("context_match", 0.4)
-        tool_weight = weights.get("tool_match", 0.3)
-        params_weight = weights.get("params_match", 0.3)
-
-        total_score = 0.0
-        pred_args = data.get("parsed_args", {})
-
-        # Context field matching
-        if context_fields:
-            gt_context = gt_args.get("context", {}) if isinstance(gt_args, dict) else {}
-            if isinstance(gt_context, dict) and gt_context:
-                matches = sum(
-                    1 for f in context_fields
-                    if str(pred_args.get(f, "")) == str(gt_context.get(f, ""))
-                )
-                total_score += context_weight * (matches / len(context_fields))
-
-        # Tool name matching
-        pred_tool = data.get("tool_name", "")
-        gt_tool = kwargs.get("ground_truth_tool", "")
-        if pred_tool and gt_tool:
-            if pred_tool == gt_tool:
-                total_score += tool_weight * 1.0
-            elif "_" in pred_tool and "_" in gt_tool:
-                if pred_tool.split("_")[0] == gt_tool.split("_")[0]:
-                    total_score += tool_weight * 0.3
-
-        # Params matching (key overlap)
-        gt_calls = gt_args.get("calls", []) if isinstance(gt_args, dict) else []
-        if gt_calls and isinstance(gt_calls, list) and gt_calls:
-            gt_params = gt_calls[0].get("params", {}) if isinstance(gt_calls[0], dict) else {}
-            if isinstance(gt_params, dict) and gt_params:
-                gt_keys = set(gt_params.keys())
-                pred_keys = set(k for k in pred_args.keys() if k not in ["sessionId", "workspaceId"])
-                if gt_keys:
-                    overlap = len(gt_keys & pred_keys)
-                    total_score += params_weight * (overlap / len(gt_keys))
-
-        return total_score
+        Thin delegation to the canonical implementation in
+        ``shared.verifiers.builtins.args_match.score_legacy_fields``.
+        """
+        return score_legacy_fields(
+            pred_args=data.get("parsed_args", {}),
+            pred_tool=data.get("tool_name", ""),
+            gt_args=gt_args,
+            gt_tool=kwargs.get("ground_truth_tool", ""),
+            comparison=comparison,
+            weights=self.scoring.get("weights", {}),
+        )
 
     def _get_required_fields(self) -> List[str]:
         """Get required context fields from schema config."""

--- a/Trainers/grpo/src/rewards.py
+++ b/Trainers/grpo/src/rewards.py
@@ -30,6 +30,8 @@ except ImportError:
     # Fallback for standalone testing
     StructureValidator = None
 
+from shared.verifiers.extraction import extract
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,55 +101,17 @@ class RewardRubric:
         """
         Extract structured data from completion text.
 
-        Directly extracts from model's native format (e.g., Qwen's <tool_call> tags).
-        No unnecessary format conversion - just get the arguments and compare.
+        Delegates to the canonical tool-call parser via the shared
+        ``extract`` abstraction. The returned dict preserves the original
+        shape: ``tool_name`` / ``parsed_args`` keys are present only when a
+        tool call was found.
         """
         result = {"raw_text": text}
 
-        # Try Qwen format: <tool_call>{"name": "...", "arguments": {...}}</tool_call>
-        tool_call_match = re.search(
-            r'<tool_call>\s*([\s\S]*?)\s*</tool_call>',
-            text,
-            re.IGNORECASE
-        )
-
-        if tool_call_match:
-            json_content = tool_call_match.group(1).strip()
-            try:
-                tool_obj = json.loads(json_content)
-                if isinstance(tool_obj, dict):
-                    result["tool_name"] = tool_obj.get("name", "")
-                    args = tool_obj.get("arguments", {})
-                    # Arguments might be JSON string or dict
-                    if isinstance(args, str):
-                        try:
-                            args = json.loads(args)
-                        except json.JSONDecodeError:
-                            args = {}
-                    result["parsed_args"] = args if isinstance(args, dict) else {}
-                    return result
-            except json.JSONDecodeError:
-                pass
-
-        # Fallback: Try Mistral format [TOOL_CALLS] [...]
-        if "[TOOL_CALLS]" in text:
-            match = re.search(r'\[TOOL_CALLS\]\s*(\[[\s\S]*?\])', text)
-            if match:
-                try:
-                    tool_calls = json.loads(match.group(1))
-                    if isinstance(tool_calls, list) and tool_calls:
-                        tc = tool_calls[0]
-                        result["tool_name"] = tc.get("name", "")
-                        args = tc.get("arguments", {})
-                        if isinstance(args, str):
-                            try:
-                                args = json.loads(args)
-                            except json.JSONDecodeError:
-                                args = {}
-                        result["parsed_args"] = args if isinstance(args, dict) else {}
-                        return result
-                except json.JSONDecodeError:
-                    pass
+        ea = extract(text, mode="tool_call")
+        if ea.found:
+            result["tool_name"] = ea.tool_name
+            result["parsed_args"] = ea.arguments
 
         return result
 

--- a/shared/verifiers/__init__.py
+++ b/shared/verifiers/__init__.py
@@ -1,0 +1,24 @@
+"""Shared verifier package.
+
+Public surface:
+    - Contract types: ``VerifierInput``, ``VerifierOutput``, ``Verifier``.
+    - Registry: ``VERIFIER_FACTORIES``, ``register``, ``build_verifier``.
+    - Extraction: ``ExtractedAnswer``, ``extract``.
+"""
+
+from __future__ import annotations
+
+from .contract import Verifier, VerifierInput, VerifierOutput
+from .extraction import ExtractedAnswer, extract
+from .registry import VERIFIER_FACTORIES, build_verifier, register
+
+__all__ = [
+    "Verifier",
+    "VerifierInput",
+    "VerifierOutput",
+    "ExtractedAnswer",
+    "extract",
+    "VERIFIER_FACTORIES",
+    "build_verifier",
+    "register",
+]

--- a/shared/verifiers/__init__.py
+++ b/shared/verifiers/__init__.py
@@ -8,9 +8,14 @@ Public surface:
 
 from __future__ import annotations
 
+from .composite import CompositeVerifier, build_composite
 from .contract import Verifier, VerifierInput, VerifierOutput
 from .extraction import ExtractedAnswer, extract
 from .registry import VERIFIER_FACTORIES, build_verifier, register
+
+# Import the builtins package for its registration side-effects so that the
+# registry is populated on ``import shared.verifiers``.
+from . import builtins  # noqa: F401,E402  (registration side-effect)
 
 __all__ = [
     "Verifier",
@@ -21,4 +26,6 @@ __all__ = [
     "VERIFIER_FACTORIES",
     "build_verifier",
     "register",
+    "CompositeVerifier",
+    "build_composite",
 ]

--- a/shared/verifiers/builtins/__init__.py
+++ b/shared/verifiers/builtins/__init__.py
@@ -2,11 +2,12 @@
 
 Importing this package runs each module's ``@register(...)`` decorator as a
 side-effect, populating :data:`shared.verifiers.registry.VERIFIER_FACTORIES`
-with the built-in verifier types (``substring``, ``structure``, ``llm_judge``).
+with the built-in verifier types (``substring``, ``structure``, ``llm_judge``,
+``args_match``).
 """
 
 from __future__ import annotations
 
-from . import llm_judge, structure, substring  # noqa: F401  (registration side-effect)
+from . import args_match, llm_judge, structure, substring  # noqa: F401  (registration side-effect)
 
-__all__ = ["substring", "structure", "llm_judge"]
+__all__ = ["substring", "structure", "llm_judge", "args_match"]

--- a/shared/verifiers/builtins/__init__.py
+++ b/shared/verifiers/builtins/__init__.py
@@ -3,11 +3,25 @@
 Importing this package runs each module's ``@register(...)`` decorator as a
 side-effect, populating :data:`shared.verifiers.registry.VERIFIER_FACTORIES`
 with the built-in verifier types (``substring``, ``structure``, ``llm_judge``,
-``args_match``).
+``args_match``, ``assertions``, ``tool_sequence``).
 """
 
 from __future__ import annotations
 
-from . import args_match, llm_judge, structure, substring  # noqa: F401  (registration side-effect)
+from . import (  # noqa: F401  (registration side-effect)
+    args_match,
+    assertion_verifier,
+    llm_judge,
+    structure,
+    substring,
+    tool_sequence,
+)
 
-__all__ = ["substring", "structure", "llm_judge", "args_match"]
+__all__ = [
+    "substring",
+    "structure",
+    "llm_judge",
+    "args_match",
+    "assertion_verifier",
+    "tool_sequence",
+]

--- a/shared/verifiers/builtins/__init__.py
+++ b/shared/verifiers/builtins/__init__.py
@@ -1,0 +1,12 @@
+"""Built-in verifier implementations.
+
+Importing this package runs each module's ``@register(...)`` decorator as a
+side-effect, populating :data:`shared.verifiers.registry.VERIFIER_FACTORIES`
+with the built-in verifier types (``substring``, ``structure``, ``llm_judge``).
+"""
+
+from __future__ import annotations
+
+from . import llm_judge, structure, substring  # noqa: F401  (registration side-effect)
+
+__all__ = ["substring", "structure", "llm_judge"]

--- a/shared/verifiers/builtins/args_match.py
+++ b/shared/verifiers/builtins/args_match.py
@@ -1,0 +1,384 @@
+"""Argument/value comparison verifier and the canonical comparison toolkit.
+
+This module is the SINGLE HOME for the tool-call argument comparison logic that
+previously lived in three copies across the GRPO trainer
+(``rewards.RewardRubric._compare_values`` / ``_get_nested_value`` /
+``_score_weighted`` mapping loop / ``_score_weighted_legacy`` and
+``functional_verifier._normalize_value`` / ``_normalize_tool_call`` /
+``_compare_args``).
+
+The module exposes plain functions (the building blocks the GRPO reward paths
+delegate to) plus an ``args_match`` :class:`Verifier` that wires those building
+blocks into the shared verifier contract. Everything is config-driven; no tool
+formats or field names are hardcoded.
+
+``shared.verifiers`` MUST NOT import ``Trainers/`` or ``Evaluator/`` — this
+module keeps the comparison logic dependency-free so the GRPO code can depend on
+it (and not the reverse).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Mapping, Tuple
+
+from ..contract import VerifierInput, VerifierOutput
+from ..extraction import extract
+from ..registry import register
+
+
+# ---------------------------------------------------------------------------
+# Normalization (moved verbatim from functional_verifier)
+# ---------------------------------------------------------------------------
+
+def normalize_value(value: Any) -> Any:
+    """Normalise a scalar/collection for comparison."""
+    if isinstance(value, dict):
+        return {k: normalize_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [normalize_value(v) for v in value]
+    if not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    if stripped.lower() == "true":
+        return True
+    if stripped.lower() == "false":
+        return False
+    try:
+        return int(stripped)
+    except ValueError:
+        pass
+    try:
+        return float(stripped)
+    except ValueError:
+        pass
+    return stripped.replace("\\", "/")
+
+
+def normalize_tool_call(tool_name: str, args: Dict) -> Tuple[str, Dict]:
+    """Return normalised (tool_name, sorted_args) tuple."""
+    return tool_name.strip().lower(), {k: normalize_value(v) for k, v in sorted(args.items())}
+
+
+# ---------------------------------------------------------------------------
+# Nested access + per-value comparison (moved verbatim from RewardRubric)
+# ---------------------------------------------------------------------------
+
+def get_nested_value(obj: Any, path: str) -> Any:
+    """Get value from nested dict using dot notation path."""
+    if not path or not obj:
+        return None
+
+    parts = path.split(".")
+    current = obj
+
+    for part in parts:
+        if isinstance(current, dict):
+            current = current.get(part)
+        elif isinstance(current, list) and part.isdigit():
+            idx = int(part)
+            current = current[idx] if idx < len(current) else None
+        else:
+            return None
+
+        if current is None:
+            return None
+
+    return current
+
+
+def compare_values(pred: Any, gt: Any, strategy: str) -> float:
+    """Compare two values using the specified strategy."""
+    if pred is None or gt is None:
+        return 0.0
+
+    if strategy == "equals":
+        return 1.0 if str(pred) == str(gt) else 0.0
+
+    elif strategy == "contains":
+        return 1.0 if str(gt) in str(pred) else 0.0
+
+    elif strategy == "key_overlap":
+        if isinstance(pred, dict) and isinstance(gt, dict) and gt:
+            overlap = len(set(pred.keys()) & set(gt.keys()))
+            return overlap / len(gt)
+        return 0.0
+
+    elif strategy == "tool_name_match":
+        # Compare tool names (handle agent_tool format)
+        pred_str = str(pred)
+        gt_str = str(gt)
+        if pred_str == gt_str:
+            return 1.0
+        # Partial: same agent
+        if "_" in pred_str and "_" in gt_str:
+            if pred_str.split("_")[0] == gt_str.split("_")[0]:
+                return 0.3
+        return 0.0
+
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Overlap scheme (moved verbatim from functional_verifier._compare_args)
+# ---------------------------------------------------------------------------
+
+def compare_args_overlap(predicted: Dict, expected: Dict) -> float:
+    """Compare argument dicts: ``key_overlap * 0.4 + value_match * 0.6``."""
+    if not predicted and not expected:
+        return 1.0
+    if not predicted or not expected:
+        return 0.0
+    pred_keys, exp_keys = set(predicted.keys()), set(expected.keys())
+    all_keys = pred_keys | exp_keys
+    common = pred_keys & exp_keys
+    key_overlap = len(common) / len(all_keys) if all_keys else 0.0
+    if not common:
+        return key_overlap * 0.4
+    value_scores: List[float] = []
+    for key in common:
+        pv, ev = normalize_value(predicted[key]), normalize_value(expected[key])
+        if pv == ev:
+            value_scores.append(1.0)
+        elif isinstance(pv, str) and isinstance(ev, str) and (pv in ev or ev in pv):
+            value_scores.append(0.5)
+        else:
+            value_scores.append(0.0)
+    return key_overlap * 0.4 + (sum(value_scores) / len(value_scores)) * 0.6
+
+
+# ---------------------------------------------------------------------------
+# Mapping-based weighted scheme (the loop body of RewardRubric._score_weighted,
+# after ground-truth parsing)
+# ---------------------------------------------------------------------------
+
+def score_mappings(
+    pred_args: Dict,
+    pred_tool: str,
+    gt_args: Any,
+    gt_tool: str,
+    mappings: List[Mapping[str, Any]],
+) -> float:
+    """Score predicted args against ground truth using explicit field mappings.
+
+    This is the mapping loop from ``RewardRubric._score_weighted`` (the part
+    AFTER ground-truth parsing), verbatim. Returns the normalized
+    ``total_score / total_weight`` (``0.0`` if no positive weight).
+
+    Args:
+        pred_args: Predicted parsed arguments.
+        pred_tool: Predicted tool name (used by ``use_tool_name`` mappings).
+        gt_args: Parsed ground-truth args object (dict-like for nested lookups).
+        gt_tool: Ground-truth tool name (used by ``use_tool_name`` mappings).
+        mappings: List of mapping configs (``pred_path``/``gt_path``/``weight``/
+            ``strategy``/``use_tool_name``).
+    """
+    total_score = 0.0
+    total_weight = 0.0
+
+    for mapping in mappings:
+        pred_path = mapping.get("pred_path", "")
+        gt_path = mapping.get("gt_path", "")
+        weight = float(mapping.get("weight", 1.0))
+        strategy = mapping.get("strategy", "equals")
+
+        # Special case: tool_name comparison uses different fields
+        if mapping.get("use_tool_name"):
+            pred_val = pred_tool
+            gt_val = gt_tool
+        elif pred_path == "" and strategy == "key_overlap":
+            # Empty pred_path with key_overlap means compare all parsed args
+            pred_val = pred_args
+            gt_val = get_nested_value(gt_args, gt_path)
+        else:
+            # Extract values using paths
+            pred_val = get_nested_value(pred_args, pred_path)
+            gt_val = get_nested_value(gt_args, gt_path)
+
+        # Compare based on strategy
+        field_score = compare_values(pred_val, gt_val, strategy)
+        total_score += weight * field_score
+        total_weight += weight
+
+    # Normalize score
+    return total_score / total_weight if total_weight > 0 else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Legacy field-list weighted scheme (moved verbatim from
+# RewardRubric._score_weighted_legacy)
+# ---------------------------------------------------------------------------
+
+def score_legacy_fields(
+    pred_args: Dict,
+    pred_tool: str,
+    gt_args: Any,
+    gt_tool: str,
+    comparison: Mapping[str, Any],
+    weights: Mapping[str, Any],
+) -> float:
+    """Legacy weighted scoring using field lists (backwards compatible).
+
+    Verbatim port of ``RewardRubric._score_weighted_legacy``.
+
+    Args:
+        pred_args: Predicted parsed arguments.
+        pred_tool: Predicted tool name.
+        gt_args: Parsed ground-truth args (expects ``context`` / ``calls``).
+        gt_tool: Ground-truth tool name.
+        comparison: Rubric ``comparison`` config (``context_fields`` /
+            ``call_fields``).
+        weights: Scoring ``weights`` config (``context_match`` / ``tool_match`` /
+            ``params_match``).
+    """
+    context_fields = comparison.get("context_fields", [])
+    call_fields = comparison.get("call_fields", [])
+
+    context_weight = weights.get("context_match", 0.4)
+    tool_weight = weights.get("tool_match", 0.3)
+    params_weight = weights.get("params_match", 0.3)
+
+    total_score = 0.0
+
+    # Context field matching
+    if context_fields:
+        gt_context = gt_args.get("context", {}) if isinstance(gt_args, dict) else {}
+        if isinstance(gt_context, dict) and gt_context:
+            matches = sum(
+                1 for f in context_fields
+                if str(pred_args.get(f, "")) == str(gt_context.get(f, ""))
+            )
+            total_score += context_weight * (matches / len(context_fields))
+
+    # Tool name matching
+    if pred_tool and gt_tool:
+        if pred_tool == gt_tool:
+            total_score += tool_weight * 1.0
+        elif "_" in pred_tool and "_" in gt_tool:
+            if pred_tool.split("_")[0] == gt_tool.split("_")[0]:
+                total_score += tool_weight * 0.3
+
+    # Params matching (key overlap)
+    gt_calls = gt_args.get("calls", []) if isinstance(gt_args, dict) else []
+    if gt_calls and isinstance(gt_calls, list) and gt_calls:
+        gt_params = gt_calls[0].get("params", {}) if isinstance(gt_calls[0], dict) else {}
+        if isinstance(gt_params, dict) and gt_params:
+            gt_keys = set(gt_params.keys())
+            pred_keys = set(k for k in pred_args.keys() if k not in ["sessionId", "workspaceId"])
+            if gt_keys:
+                overlap = len(gt_keys & pred_keys)
+                total_score += params_weight * (overlap / len(gt_keys))
+
+    return total_score
+
+
+# ---------------------------------------------------------------------------
+# Verifier wiring
+# ---------------------------------------------------------------------------
+
+class ArgsMatchVerifier:
+    """Verifier that scores predicted tool-call args against ground truth.
+
+    The predicted tool/args are extracted from ``sample.completion_text`` via
+    :func:`shared.verifiers.extraction.extract` (``mode="tool_call"``). The
+    expected tool/args come from ``sample.ground_truth``.
+
+    The ``scheme`` selects the comparison building block:
+    - ``"overlap"``: normalized tool-call equality + :func:`compare_args_overlap`
+      (the functional-equivalence scheme).
+    - ``"mappings"``: :func:`score_mappings` driven by ``params.mappings``.
+    - ``"legacy"``: :func:`score_legacy_fields` driven by ``params.comparison``
+      and ``params.weights``.
+
+    Ground-truth field names are config-driven via ``gt_tool_field`` /
+    ``gt_args_field``; nothing is hardcoded.
+    """
+
+    def __init__(
+        self,
+        name: str = "args_match",
+        scheme: str = "overlap",
+        gt_tool_field: str = "tool_name",
+        gt_args_field: str = "arguments",
+        mappings: List[Mapping[str, Any]] | None = None,
+        comparison: Mapping[str, Any] | None = None,
+        weights: Mapping[str, Any] | None = None,
+        pass_threshold: float = 0.5,
+    ):
+        if scheme not in ("overlap", "mappings", "legacy"):
+            raise ValueError(
+                f"args_match 'scheme' must be one of "
+                f"('overlap', 'mappings', 'legacy'), got {scheme!r}"
+            )
+        self.name = name
+        self.scheme = scheme
+        self.gt_tool_field = gt_tool_field
+        self.gt_args_field = gt_args_field
+        self.mappings = list(mappings) if mappings else []
+        self.comparison = dict(comparison) if comparison else {}
+        self.weights = dict(weights) if weights else {}
+        self.pass_threshold = pass_threshold
+
+    def _expected(self, sample: VerifierInput) -> Tuple[str, Any]:
+        gt = sample.ground_truth or {}
+        gt_tool = gt.get(self.gt_tool_field, "") or ""
+        gt_args_raw = gt.get(self.gt_args_field)
+        gt_args: Any = {}
+        if gt_args_raw is not None:
+            if isinstance(gt_args_raw, str):
+                try:
+                    gt_args = json.loads(gt_args_raw)
+                except (json.JSONDecodeError, ValueError):
+                    gt_args = {}
+            else:
+                gt_args = gt_args_raw
+        return str(gt_tool), gt_args
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        ea = extract(sample.completion_text, mode="tool_call")
+        pred_tool = ea.tool_name if ea.found else ""
+        pred_args = ea.arguments if ea.found else {}
+
+        gt_tool, gt_args = self._expected(sample)
+
+        if self.scheme == "overlap":
+            norm_pred_name, norm_pred_args = normalize_tool_call(pred_tool, pred_args)
+            gt_args_dict = gt_args if isinstance(gt_args, dict) else {}
+            norm_gt_name, norm_gt_args = normalize_tool_call(gt_tool, gt_args_dict)
+            if not gt_tool or not ea.found or norm_pred_name != norm_gt_name:
+                score = 0.0
+            else:
+                score = compare_args_overlap(norm_pred_args, norm_gt_args)
+        elif self.scheme == "mappings":
+            score = score_mappings(
+                pred_args, pred_tool, gt_args, gt_tool, self.mappings
+            )
+        else:  # legacy
+            score = score_legacy_fields(
+                pred_args, pred_tool, gt_args, gt_tool, self.comparison, self.weights
+            )
+
+        return VerifierOutput(
+            score=score,
+            passed=score >= self.pass_threshold,
+            detail={
+                "scheme": self.scheme,
+                "pred_tool": pred_tool,
+                "gt_tool": gt_tool,
+            },
+        )
+
+
+@register("args_match")
+def _build_args_match(spec: Mapping) -> ArgsMatchVerifier:
+    params = spec.get("params", spec)
+    return ArgsMatchVerifier(
+        name=spec.get("name", "args_match"),
+        scheme=params.get("scheme", "overlap"),
+        gt_tool_field=params.get("gt_tool_field", "tool_name"),
+        gt_args_field=params.get("gt_args_field", "arguments"),
+        mappings=params.get("mappings"),
+        comparison=params.get("comparison"),
+        weights=params.get("weights"),
+        pass_threshold=params.get("pass_threshold", 0.5),
+    )

--- a/shared/verifiers/builtins/assertion_verifier.py
+++ b/shared/verifiers/builtins/assertion_verifier.py
@@ -1,9 +1,26 @@
-"""Generic config-driven assertion engine for evaluator correctness."""
+"""Generic config-driven assertion engine, wired as an ``assertions`` verifier.
+
+This module is the canonical home for the assertion engine (moved verbatim from
+``Evaluator/assertions.py``): the result dataclasses, ``evaluate_correctness``,
+``select_path`` and the small JSONPath-subset helpers. The Evaluator CONSUMES
+these symbols; it no longer owns them.
+
+The :class:`AssertionsVerifier` (registered under ``assertions``) wires the
+engine into the shared verifier contract. It is fully config-driven: the
+``correct`` config block and the field paths it references come from the spec /
+sample, nothing is hardcoded.
+
+``shared.verifiers`` MUST NOT import ``Evaluator/`` or ``Trainers/`` — the
+engine here is stdlib-only so consumers can depend on it (and not the reverse).
+"""
 from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from ..contract import VerifierInput, VerifierOutput
+from ..registry import register
 
 
 _MISSING = object()
@@ -423,4 +440,67 @@ def _is_subset(expected: Any, actual: Any) -> bool:
             return False
         return all(any(_is_subset(expected_item, actual_item) for actual_item in actual) for expected_item in expected)
     return expected == actual
+
+
+# ---------------------------------------------------------------------------
+# Verifier wiring
+# ---------------------------------------------------------------------------
+
+def _minimal_response_view(sample: VerifierInput) -> Mapping[str, Any]:
+    """Build a minimal response view from ``parsed`` / ``completion_text``.
+
+    Used only when no ``response_view`` signal is supplied. The Evaluator's own
+    ``build_response_view`` produces a richer view; this fallback keeps the
+    shared package free of any Evaluator import while still exposing the common
+    ``content`` / ``tool_calls`` fields config assertions reference.
+    """
+    parsed = sample.parsed
+    content = getattr(parsed, "text_content", None)
+    if content is None:
+        content = sample.completion_text
+    tool_calls = getattr(parsed, "tool_calls", None)
+    return {
+        "content": content if isinstance(content, str) else str(content or ""),
+        "tool_calls": list(tool_calls) if isinstance(tool_calls, list) else [],
+    }
+
+
+class AssertionsVerifier:
+    """Verifier that evaluates a config-driven ``correct`` block.
+
+    The ``correct`` config (the same structure consumed by
+    :func:`evaluate_correctness`) is read from the spec ``params`` under the
+    ``correct`` key. The response view is read from
+    ``sample.signals['response_view']`` when present, falling back to a minimal
+    view built from ``sample.parsed`` / ``sample.completion_text``.
+
+    Scoring follows :class:`CorrectnessResult`: ``passed`` maps to ``1.0`` /
+    ``0.0`` (``CorrectnessResult`` carries no numeric score of its own).
+    """
+
+    def __init__(self, name: str = "assertions", correct: Mapping[str, Any] | None = None):
+        self.name = name
+        self.correct = dict(correct) if correct else {}
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        response_view = sample.signals.get("response_view")
+        if not isinstance(response_view, Mapping):
+            response_view = _minimal_response_view(sample)
+
+        result = evaluate_correctness(self.correct, response_view)
+        score = 1.0 if result.passed else 0.0
+        return VerifierOutput(
+            score=score,
+            passed=result.passed,
+            detail=result.to_dict(),
+        )
+
+
+@register("assertions")
+def _build_assertions(spec: Mapping) -> AssertionsVerifier:
+    params = spec.get("params", spec)
+    return AssertionsVerifier(
+        name=spec.get("name", "assertions"),
+        correct=params.get("correct"),
+    )
 

--- a/shared/verifiers/builtins/llm_judge.py
+++ b/shared/verifiers/builtins/llm_judge.py
@@ -1,0 +1,192 @@
+"""LLM-judge verifier: score completions via the shared judge service.
+
+Registered under the ``llm_judge`` type. This module is the CANONICAL home for
+two pieces of logic that currently also live (as a copy to be deleted in a
+later phase) in ``Trainers/grpo/src/judge_reward.py``:
+
+- :func:`aggregate` — collapse a :class:`shared.judge.JudgeResult` into a single
+  scalar via one of ``mean_score`` / ``mean_passed`` / ``min_score`` /
+  ``all_pass``.
+- :func:`render_combined_prompt` — concatenate per-rubric judge prompts after
+  template-variable substitution.
+
+The verifier loads rubrics via :class:`shared.judge.RubricLoader`, renders the
+combined prompt, runs a :class:`shared.judge.JudgeService`, and returns the
+aggregated score. The ``JudgeService`` (or any object exposing a compatible
+``judge(prompt, rubrics, ...)`` method) may be INJECTED via params so tests do
+not hit the network; no LLM client is constructed at import time.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping
+
+from shared.judge import JudgeResult, RubricDef, RubricLoader
+
+from ..contract import VerifierInput, VerifierOutput
+from ..registry import register
+
+AGGREGATIONS = ("mean_score", "mean_passed", "min_score", "all_pass")
+
+
+def aggregate(result: JudgeResult, strategy: str) -> float:
+    """Collapse a :class:`JudgeResult` into a single scalar.
+
+    This is the single source of truth for judge aggregation. It reproduces,
+    exactly, the four strategies from ``judge_reward._aggregate``.
+
+    Args:
+        result: The judge result whose ``scores`` are aggregated.
+        strategy: One of ``mean_score``, ``mean_passed``, ``min_score``,
+            ``all_pass``.
+
+    Returns:
+        Aggregated score in ``[0.0, 1.0]``. Returns ``0.0`` when there are no
+        scores.
+
+    Raises:
+        ValueError: If ``strategy`` is unknown.
+    """
+    if not result.scores:
+        return 0.0
+    if strategy == "mean_score":
+        return sum(s.score for s in result.scores) / len(result.scores)
+    if strategy == "mean_passed":
+        return sum(1.0 if s.passed else 0.0 for s in result.scores) / len(result.scores)
+    if strategy == "min_score":
+        return min(s.score for s in result.scores)
+    if strategy == "all_pass":
+        return 1.0 if all(s.passed for s in result.scores) else 0.0
+    raise ValueError(
+        f"Unknown aggregation '{strategy}'. Must be one of: {', '.join(AGGREGATIONS)}"
+    )
+
+
+def render_combined_prompt(
+    rubrics: List[RubricDef],
+    template_vars: Dict[str, str],
+) -> str:
+    """Concatenate per-rubric ``judge_prompt`` templates after substituting vars.
+
+    Mirrors ``judge_reward._render_combined_prompt``: a single rubric renders
+    bare; multiple rubrics are separated with ``=== <name> ===`` headers.
+    """
+    parts: List[str] = []
+    for rubric in rubrics:
+        rendered = rubric.judge_prompt
+        for k, v in template_vars.items():
+            rendered = rendered.replace(f"{{{k}}}", str(v))
+        if len(rubrics) == 1:
+            parts.append(rendered)
+        else:
+            parts.append(f"=== {rubric.name} ===\n{rendered}")
+    return "\n\n".join(parts)
+
+
+def _resolve_dir(value: str, base_dir: Path) -> Path:
+    p = Path(value)
+    return p if p.is_absolute() else (base_dir / p).resolve()
+
+
+class LLMJudgeVerifier:
+    """Verifier that scores completions via an LLM judge.
+
+    Args:
+        name: Verifier name.
+        rubrics: Loaded rubric definitions.
+        judge_service: An object exposing ``judge(prompt, rubrics)`` returning a
+            :class:`JudgeResult`. Injected so tests avoid network calls.
+        aggregation: Aggregation strategy (see :func:`aggregate`).
+        pass_threshold: Threshold for the ``passed`` flag.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        rubrics: List[RubricDef],
+        judge_service: Any,
+        aggregation: str = "mean_passed",
+        pass_threshold: float = 0.5,
+    ):
+        if aggregation not in AGGREGATIONS:
+            raise ValueError(
+                f"llm_judge 'aggregation' must be one of {AGGREGATIONS}, "
+                f"got '{aggregation}'"
+            )
+        self.name = name
+        self.rubrics = rubrics
+        self.judge_service = judge_service
+        self.aggregation = aggregation
+        self.pass_threshold = pass_threshold
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        template_vars = {
+            "prompt": sample.prompt_text,
+            "user_prompt": sample.prompt_text,
+            "response": sample.completion_text,
+        }
+        rendered = render_combined_prompt(self.rubrics, template_vars)
+
+        result = self.judge_service.judge(prompt=rendered, rubrics=self.rubrics)
+
+        if getattr(result, "error", None):
+            return VerifierOutput(
+                score=0.0,
+                passed=False,
+                detail={"error": result.error, "aggregation": self.aggregation},
+            )
+
+        score = aggregate(result, self.aggregation)
+        return VerifierOutput(
+            score=score,
+            passed=score >= self.pass_threshold,
+            detail={
+                "aggregation": self.aggregation,
+                "scores": [
+                    {
+                        "rubric_key": s.rubric_key,
+                        "score": s.score,
+                        "passed": s.passed,
+                    }
+                    for s in result.scores
+                ],
+            },
+        )
+
+
+@register("llm_judge")
+def _build_llm_judge(spec: Mapping) -> LLMJudgeVerifier:
+    params = spec.get("params", spec)
+
+    judge_service = params.get("judge_service")
+    if judge_service is None:
+        raise ValueError(
+            "llm_judge verifier requires an injected 'judge_service'. "
+            "Constructing an LLM client at build time is not supported here; "
+            "build the JudgeService externally and inject it."
+        )
+
+    rubrics = params.get("rubrics")
+    if rubrics is None:
+        rubrics_dir_raw = params.get("rubrics_dir")
+        rubric_keys = params.get("rubric_keys") or []
+        if not rubrics_dir_raw:
+            raise ValueError(
+                "llm_judge verifier requires either inline 'rubrics' or "
+                "'rubrics_dir' + 'rubric_keys'"
+            )
+        if not rubric_keys:
+            raise ValueError("llm_judge verifier requires non-empty 'rubric_keys'")
+        base_dir = Path(params.get("base_dir", "."))
+        rubrics_dir = _resolve_dir(str(rubrics_dir_raw), base_dir)
+        loader = RubricLoader(rubrics_dir)
+        rubrics = loader.load_many(list(rubric_keys))
+
+    return LLMJudgeVerifier(
+        name=spec.get("name", "llm_judge"),
+        rubrics=list(rubrics),
+        judge_service=judge_service,
+        aggregation=params.get("aggregation", "mean_passed"),
+        pass_threshold=params.get("pass_threshold", 0.5),
+    )

--- a/shared/verifiers/builtins/structure.py
+++ b/shared/verifiers/builtins/structure.py
@@ -1,0 +1,63 @@
+"""Structure verifier: wrap the shared FitnessEvaluator.
+
+Registered under the ``structure`` type. This builtin adapts
+:class:`shared.validation.fitness.FitnessEvaluator` to the verifier contract:
+the FitnessEvaluator is constructed once at build time and reused per call.
+``FitnessResult.score`` maps to ``VerifierOutput.score``,
+``FitnessResult.is_valid`` to ``passed``, and the validation errors are placed
+in ``detail``.
+
+The evaluator can be configured from a ``config_path`` YAML or from inline
+``validations`` + ``scoring_method`` (+ ``max_errors``), mirroring
+:func:`shared.validation.fitness.create_fitness_evaluator`.
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from shared.validation.fitness import FitnessEvaluator, create_fitness_evaluator
+
+from ..contract import VerifierInput, VerifierOutput
+from ..registry import register
+
+
+class StructureVerifier:
+    """Verifier backed by a :class:`FitnessEvaluator`.
+
+    Args:
+        name: Verifier name.
+        evaluator: A constructed :class:`FitnessEvaluator` to reuse per call.
+    """
+
+    def __init__(self, name: str, evaluator: FitnessEvaluator):
+        self.name = name
+        self._evaluator = evaluator
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        result = self._evaluator.evaluate(sample.completion_text)
+        return VerifierOutput(
+            score=result.score,
+            passed=result.is_valid,
+            detail={
+                "errors": list(result.errors),
+                "scoring_method": result.scoring_method,
+            },
+        )
+
+
+@register("structure")
+def _build_structure(spec: Mapping) -> StructureVerifier:
+    params = spec.get("params", spec)
+    config_path = params.get("config_path")
+    validations = params.get("validations")
+    scoring_method = params.get("scoring_method", "error_count")
+    max_errors = params.get("max_errors", 5)
+
+    evaluator = create_fitness_evaluator(
+        config_path=config_path,
+        validations=validations,
+        scoring_method=scoring_method,
+        max_errors=max_errors,
+    )
+    return StructureVerifier(name=spec.get("name", "structure"), evaluator=evaluator)

--- a/shared/verifiers/builtins/substring.py
+++ b/shared/verifiers/builtins/substring.py
@@ -1,0 +1,106 @@
+"""Substring verifier: check that a needle appears in an extracted haystack.
+
+Registered under the ``substring`` type. The haystack is pulled from the model
+completion via :func:`shared.verifiers.extraction.extract` (text modes use
+``ExtractedAnswer.answer_text``, falling back to the raw completion when the
+extractor finds nothing). The needle comes from a literal ``target`` or from a
+field of the sample's ``ground_truth`` named by ``target_field``.
+
+Scoring is binary: ``1.0`` when the needle is contained in the haystack, else
+``0.0``. An empty needle scores ``1.0`` (vacuously contained).
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..contract import VerifierInput, VerifierOutput
+from ..extraction import extract
+from ..registry import register
+
+
+class SubstringVerifier:
+    """Verifier that scores by substring containment.
+
+    Args:
+        name: Verifier name.
+        target: Literal needle string (takes precedence over ``target_field``).
+        target_field: ``ground_truth`` key to read the needle from when
+            ``target`` is not supplied.
+        mode: Extraction mode for resolving the haystack (see
+            :func:`shared.verifiers.extraction.extract`).
+        output_regex: Optional regex override for haystack extraction.
+        case_sensitive: When ``False`` (default), comparison is lowercased.
+    """
+
+    def __init__(
+        self,
+        name: str = "substring",
+        target: str | None = None,
+        target_field: str | None = None,
+        mode: str = "verbatim",
+        output_regex: str | None = None,
+        case_sensitive: bool = False,
+    ):
+        self.name = name
+        self.target = target
+        self.target_field = target_field
+        self.mode = mode
+        self.output_regex = output_regex
+        self.case_sensitive = case_sensitive
+
+    def _resolve_haystack(self, sample: VerifierInput) -> str:
+        extracted = extract(
+            sample.completion_text,
+            mode=self.mode,
+            output_regex=self.output_regex,
+        )
+        if extracted.found and extracted.answer_text:
+            return extracted.answer_text
+        # Fall back to the raw completion when no text answer was extracted.
+        return sample.completion_text
+
+    def _resolve_needle(self, sample: VerifierInput) -> str:
+        if self.target is not None:
+            return self.target
+        if self.target_field is not None:
+            value = sample.ground_truth.get(self.target_field)
+            return "" if value is None else str(value)
+        return ""
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        haystack = self._resolve_haystack(sample)
+        needle = self._resolve_needle(sample)
+
+        if needle == "":
+            # Vacuously contained.
+            return VerifierOutput(
+                score=1.0,
+                passed=True,
+                detail={"needle": needle, "haystack": haystack, "vacuous": True},
+            )
+
+        if self.case_sensitive:
+            contained = needle in haystack
+        else:
+            contained = needle.lower() in haystack.lower()
+
+        score = 1.0 if contained else 0.0
+        return VerifierOutput(
+            score=score,
+            passed=score == 1.0,
+            detail={"needle": needle, "haystack": haystack, "contained": contained},
+        )
+
+
+@register("substring")
+def _build_substring(spec: Mapping) -> SubstringVerifier:
+    params = spec.get("params", spec)
+    return SubstringVerifier(
+        name=spec.get("name", "substring"),
+        target=params.get("target"),
+        target_field=params.get("target_field"),
+        mode=params.get("mode", "verbatim"),
+        output_regex=params.get("output_regex"),
+        case_sensitive=params.get("case_sensitive", False),
+    )

--- a/shared/verifiers/builtins/tool_sequence.py
+++ b/shared/verifiers/builtins/tool_sequence.py
@@ -1,0 +1,165 @@
+"""Tool-sequence verifier: pure tool-name predicates over a call sequence.
+
+Registered under the ``tool_sequence`` type. This module is the canonical home
+for the pure tool-name predicates extracted (verbatim) from the Evaluator's
+``_matches_scoring_path``: ``all_tools``, ``any_tools``, ``ordered_tools``,
+``first_tool``, ``first_tool_any_of``, ``max_tool_calls`` and
+``min_tool_calls`` — plus the ``_contains_subsequence`` and ``_string_list``
+helpers they depend on.
+
+These predicates are pure: they reference only the observed tool-name list and
+the path config. The ``require_*_pass`` gates (which reference Evaluator result
+objects) deliberately stay in ``Evaluator/runner.py``; only the tool portion
+lives here so it can be reused without importing Evaluator.
+
+``shared.verifiers`` MUST NOT import ``Evaluator/`` or ``Trainers/``.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Mapping
+
+from ..contract import VerifierInput, VerifierOutput
+from ..registry import register
+
+
+def evaluate_tool_sequence(
+    tool_names: List[str],
+    path_cfg: Mapping[str, Any],
+) -> tuple[bool, List[str]]:
+    """Evaluate the pure tool-name predicates of a scoring path.
+
+    Reproduces, exactly, the tool portion of the Evaluator's
+    ``_matches_scoring_path``: the order of checks and the exact reason strings
+    are preserved so that callers accumulating reasons see identical output.
+
+    Args:
+        tool_names: Observed tool-call names, in call order.
+        path_cfg: Path config carrying any of ``all_tools``, ``any_tools``,
+            ``ordered_tools``, ``first_tool``, ``first_tool_any_of``,
+            ``max_tool_calls``, ``min_tool_calls``.
+
+    Returns:
+        ``(matched, reasons)`` where ``matched`` is ``True`` iff no predicate
+        produced a reason, and ``reasons`` is the accumulated failure reasons.
+    """
+    reasons: List[str] = []
+
+    all_tools = _string_list(path_cfg.get("all_tools"))
+    if all_tools:
+        missing = [tool for tool in all_tools if tool not in tool_names]
+        if missing:
+            reasons.append(f"missing tools: {', '.join(missing)}")
+
+    any_tools = _string_list(path_cfg.get("any_tools"))
+    if any_tools and not any(tool in tool_names for tool in any_tools):
+        reasons.append(f"needs any of: {', '.join(any_tools)}")
+
+    ordered_tools = _string_list(path_cfg.get("ordered_tools"))
+    if ordered_tools and not _contains_subsequence(tool_names, ordered_tools):
+        reasons.append(f"ordered tools not matched: {', '.join(ordered_tools)}")
+
+    first_tool = str(path_cfg.get("first_tool", "")).strip()
+    if first_tool and (not tool_names or tool_names[0] != first_tool):
+        reasons.append(f"first tool should be {first_tool}")
+
+    first_tool_any_of = _string_list(path_cfg.get("first_tool_any_of"))
+    if first_tool_any_of and (not tool_names or tool_names[0] not in first_tool_any_of):
+        reasons.append(f"first tool should be one of: {', '.join(first_tool_any_of)}")
+
+    max_tool_calls = path_cfg.get("max_tool_calls")
+    if max_tool_calls is not None and len(tool_names) > int(max_tool_calls):
+        reasons.append(f"too many tool calls: {len(tool_names)} > {int(max_tool_calls)}")
+
+    min_tool_calls = path_cfg.get("min_tool_calls")
+    if min_tool_calls is not None and len(tool_names) < int(min_tool_calls):
+        reasons.append(f"too few tool calls: {len(tool_names)} < {int(min_tool_calls)}")
+
+    return len(reasons) == 0, reasons
+
+
+def _contains_subsequence(items: List[str], subsequence: List[str]) -> bool:
+    if not subsequence:
+        return True
+    pos = 0
+    for item in items:
+        if item == subsequence[pos]:
+            pos += 1
+            if pos == len(subsequence):
+                return True
+    return False
+
+
+def _string_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        clean = value.strip()
+        return [clean] if clean else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Verifier wiring
+# ---------------------------------------------------------------------------
+
+def _derive_tool_names(sample: VerifierInput) -> List[str]:
+    """Derive tool-call names from ``sample.parsed`` when no signal is given.
+
+    Used only when no ``tool_names`` signal is supplied. Keeps the shared
+    package free of any Evaluator import while reading the common
+    ``tool_calls[*].name`` shape that parsed responses expose.
+    """
+    parsed = sample.parsed
+    tool_calls = getattr(parsed, "tool_calls", None)
+    if not isinstance(tool_calls, list):
+        return []
+    names: List[str] = []
+    for call in tool_calls:
+        name = getattr(call, "name", None)
+        if name is None and isinstance(call, Mapping):
+            name = call.get("name")
+        if name is not None:
+            names.append(str(name))
+    return names
+
+
+class ToolSequenceVerifier:
+    """Verifier that scores by the pure tool-name predicates of a scoring path.
+
+    The path config is read from the spec ``params`` (the spec itself, minus the
+    ``type``/``name`` keys, also serves as the config). The observed tool names
+    are read from ``sample.signals['tool_names']`` when present, falling back to
+    names derived from ``sample.parsed``.
+
+    Scoring is binary: ``1.0`` when all configured predicates match, else
+    ``0.0``.
+    """
+
+    def __init__(self, name: str = "tool_sequence", path_cfg: Mapping[str, Any] | None = None):
+        self.name = name
+        self.path_cfg = dict(path_cfg) if path_cfg else {}
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        signal_names = sample.signals.get("tool_names")
+        if isinstance(signal_names, list):
+            tool_names = [str(n) for n in signal_names]
+        else:
+            tool_names = _derive_tool_names(sample)
+
+        matched, reasons = evaluate_tool_sequence(tool_names, self.path_cfg)
+        return VerifierOutput(
+            score=1.0 if matched else 0.0,
+            passed=matched,
+            detail={"reasons": reasons, "tool_names": tool_names},
+        )
+
+
+@register("tool_sequence")
+def _build_tool_sequence(spec: Mapping) -> ToolSequenceVerifier:
+    params = spec.get("params", spec)
+    return ToolSequenceVerifier(
+        name=spec.get("name", "tool_sequence"),
+        path_cfg=params,
+    )

--- a/shared/verifiers/composite.py
+++ b/shared/verifiers/composite.py
@@ -1,0 +1,159 @@
+"""CompositeVerifier: combine child verifiers into a single score.
+
+A :class:`CompositeVerifier` runs a list of child verifiers and combines their
+:class:`VerifierOutput` scores into one according to a ``combine`` mode. The
+five supported modes reproduce — exactly — the three score-combination
+semantics that already exist in the codebase:
+
+- ``weighted_sum`` matches GRPO ``combined_reward`` (``rewards.py:706-715``):
+  ``Σ weightᵢ · childᵢ.score`` with no normalization by total weight.
+- ``max_tier`` matches the Evaluator "highest score among matched paths"
+  behavior (``runner.py:714``): the score of the highest-scoring *passing*
+  child, or ``0.0`` when none passed.
+- ``mean`` / ``min`` / ``all_pass`` match the judge aggregation strategies
+  ``mean_score`` / ``min_score`` / ``all_pass`` (see
+  ``shared.verifiers.builtins.llm_judge.aggregate``).
+
+Children are supplied as ``(verifier, weight)`` tuples; the weight is only
+consulted by ``weighted_sum``.
+"""
+
+from __future__ import annotations
+
+from typing import List, Mapping, Sequence, Tuple
+
+from .contract import Verifier, VerifierInput, VerifierOutput
+
+_COMBINE_MODES = ("weighted_sum", "max_tier", "mean", "min", "all_pass")
+
+
+class CompositeVerifier:
+    """Combine several child verifiers into one composite score.
+
+    Args:
+        name: Human-readable name for this composite.
+        children: List of ``(verifier, weight)`` tuples. The weight is used
+            only by the ``weighted_sum`` combine mode.
+        combine: Combination mode; one of ``weighted_sum``, ``max_tier``,
+            ``mean``, ``min``, ``all_pass``.
+        pass_threshold: Threshold used to decide ``passed`` for the
+            threshold-based modes (``weighted_sum``, ``mean``, ``min``).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        children: Sequence[Tuple[Verifier, float]],
+        combine: str,
+        pass_threshold: float = 0.5,
+    ):
+        if combine not in _COMBINE_MODES:
+            raise ValueError(
+                f"unknown combine mode: {combine!r}; "
+                f"must be one of {', '.join(_COMBINE_MODES)}"
+            )
+        self.name = name
+        self.children: List[Tuple[Verifier, float]] = list(children)
+        self.combine = combine
+        self.pass_threshold = pass_threshold
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        """Run every child and combine their outputs by ``self.combine``."""
+        outputs: List[Tuple[Verifier, float, VerifierOutput]] = [
+            (verifier, weight, verifier.verify(sample))
+            for verifier, weight in self.children
+        ]
+
+        child_details = [
+            {
+                "name": verifier.name,
+                "score": out.score,
+                "passed": out.passed,
+                "weight": weight,
+            }
+            for verifier, weight, out in outputs
+        ]
+
+        score, passed = self._combine(outputs)
+
+        return VerifierOutput(
+            score=score,
+            passed=passed,
+            detail={"children": child_details, "combine": self.combine},
+        )
+
+    def _combine(
+        self,
+        outputs: List[Tuple[Verifier, float, VerifierOutput]],
+    ) -> Tuple[float, bool]:
+        mode = self.combine
+
+        if mode == "weighted_sum":
+            # GRPO combined_reward: Σ weightᵢ · scoreᵢ, no normalization.
+            score = sum(weight * out.score for _, weight, out in outputs)
+            return score, score >= self.pass_threshold
+
+        if mode == "max_tier":
+            # Evaluator: highest score among children whose .passed is True.
+            best: float | None = None
+            for _, _, out in outputs:
+                if out.passed and (best is None or out.score >= best):
+                    best = out.score
+            if best is None:
+                return 0.0, False
+            return best, True
+
+        scores = [out.score for _, _, out in outputs]
+
+        if mode == "mean":
+            score = sum(scores) / len(scores) if scores else 0.0
+            return score, score >= self.pass_threshold
+
+        if mode == "min":
+            score = min(scores) if scores else 0.0
+            return score, score >= self.pass_threshold
+
+        if mode == "all_pass":
+            score = 1.0 if outputs and all(out.passed for _, _, out in outputs) else 0.0
+            return score, score == 1.0
+
+        # Unreachable: __init__ validates the mode.
+        raise ValueError(f"unknown combine mode: {mode!r}")
+
+
+def build_composite(
+    specs: List[Mapping],
+    combine: str,
+    pass_threshold: float = 0.5,
+    name: str = "composite",
+) -> CompositeVerifier:
+    """Build a :class:`CompositeVerifier` from child specs.
+
+    Each child verifier is constructed via :func:`build_verifier`; its weight
+    is read from ``spec.get("weight", 1.0)``.
+
+    Args:
+        specs: List of child verifier spec mappings (each carrying a ``type``).
+        combine: Combine mode for the composite.
+        pass_threshold: Pass threshold forwarded to the composite.
+        name: Name for the composite verifier.
+
+    Returns:
+        A constructed :class:`CompositeVerifier`.
+    """
+    # Imported here to avoid a circular import at module load (registry imports
+    # nothing from composite, builtins import registry).
+    from .registry import build_verifier
+
+    children: List[Tuple[Verifier, float]] = []
+    for spec in specs:
+        child = build_verifier(spec)
+        weight = float(spec.get("weight", 1.0))
+        children.append((child, weight))
+
+    return CompositeVerifier(
+        name=name,
+        children=children,
+        combine=combine,
+        pass_threshold=pass_threshold,
+    )

--- a/shared/verifiers/contract.py
+++ b/shared/verifiers/contract.py
@@ -1,0 +1,69 @@
+"""Verifier contract: input/output dataclasses and the Verifier protocol.
+
+This module defines the small, stable interface that all verifiers share.
+A verifier consumes a :class:`VerifierInput` (the model completion plus any
+parsed/contextual signals) and produces a :class:`VerifierOutput` (a numeric
+score, a pass/fail flag, and an optional detail mapping).
+
+Typing is deliberately kept light: ``VerifierInput.parsed`` is annotated as
+``Any`` (with a ``TYPE_CHECKING`` hint pointing at ``ParsedResponse``) so this
+contract module never triggers a heavy import of the parsing package.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Mapping, Protocol, runtime_checkable
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from shared.validation.parsing import ParsedResponse
+
+
+@dataclass(frozen=True)
+class VerifierInput:
+    """Normalized input handed to a verifier.
+
+    Attributes:
+        completion_text: Raw model completion text being scored.
+        parsed: A ``ParsedResponse`` for ``completion_text``. Typed as ``Any``
+            to keep this module import-light; see the ``TYPE_CHECKING`` hint.
+        prompt_text: The prompt that produced the completion, if available.
+        ground_truth: Reference answer / expected tool call data.
+        signals: Arbitrary extra context (e.g. flags from upstream stages).
+    """
+
+    completion_text: str
+    parsed: Any
+    prompt_text: str = ""
+    ground_truth: Mapping[str, Any] = field(default_factory=dict)
+    signals: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class VerifierOutput:
+    """Result produced by a verifier.
+
+    Attributes:
+        score: Numeric score, typically in ``[0.0, 1.0]``.
+        passed: Boolean pass/fail decision for the verifier.
+        detail: Optional structured detail describing how the score was derived.
+    """
+
+    score: float
+    passed: bool
+    detail: Mapping[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class Verifier(Protocol):
+    """Structural protocol for a verifier.
+
+    A verifier exposes a human-readable ``name`` and a ``verify`` method that
+    maps a :class:`VerifierInput` to a :class:`VerifierOutput`.
+    """
+
+    name: str
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        """Score ``sample`` and return a :class:`VerifierOutput`."""
+        ...

--- a/shared/verifiers/extraction.py
+++ b/shared/verifiers/extraction.py
@@ -1,0 +1,189 @@
+"""Answer extraction abstraction shared by verifiers and GRPO rewards.
+
+This module centralizes the various ways an "answer" can be pulled out of a
+model completion so that callers don't reimplement format-specific regexes.
+The canonical tool-call parsing lives in ``shared.validation.parsing`` and is
+reused here for the ``tool_call`` / ``tool_call_args`` modes.
+
+Resolution order in :func:`extract`:
+    1. ``output_regex`` (when provided) always wins.
+    2. Otherwise, dispatch by ``mode``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from shared.validation.parsing import parse_response
+
+
+@dataclass(frozen=True)
+class ExtractedAnswer:
+    """A normalized extraction result.
+
+    Attributes:
+        found: Whether anything was extracted.
+        tool_name: Tool/function name (for tool-call modes).
+        arguments: Structured payload (tool arguments, or parsed JSON block).
+        answer_text: Free-text answer (for text modes / regex matches).
+        raw: Raw string the answer was derived from.
+    """
+
+    found: bool
+    tool_name: str = ""
+    arguments: Dict[str, Any] = field(default_factory=dict)
+    answer_text: str = ""
+    raw: str = ""
+
+
+def extract(
+    text: str,
+    *,
+    mode: str = "tool_call",
+    output_regex: str | None = None,
+) -> ExtractedAnswer:
+    """Extract an answer from ``text``.
+
+    Args:
+        text: The model completion to extract from.
+        mode: Extraction strategy when ``output_regex`` is not supplied. One of
+            ``tool_call``, ``tool_call_args``, ``last_line``, ``boxed``,
+            ``json_block``, ``verbatim``.
+        output_regex: If provided, takes priority over ``mode``. Matched against
+            ``text``; the extracted answer is the named group ``answer`` if the
+            pattern defines one, else group(1) if present, else group(0).
+
+    Returns:
+        An :class:`ExtractedAnswer`.
+
+    Raises:
+        ValueError: If ``mode`` is unknown (and no ``output_regex`` is given).
+    """
+    if output_regex is not None:
+        return _extract_by_regex(text, output_regex)
+
+    if mode == "tool_call" or mode == "tool_call_args":
+        return _extract_tool_call(text)
+    if mode == "last_line":
+        return _extract_last_line(text)
+    if mode == "boxed":
+        return _extract_boxed(text)
+    if mode == "json_block":
+        return _extract_json_block(text)
+    if mode == "verbatim":
+        return ExtractedAnswer(found=bool(text), answer_text=text, raw=text)
+
+    raise ValueError(f"unknown extraction mode: {mode}")
+
+
+def _extract_by_regex(text: str, output_regex: str) -> ExtractedAnswer:
+    """Resolve an answer via ``output_regex`` (highest priority)."""
+    match = re.search(output_regex, text)
+    if not match:
+        return ExtractedAnswer(found=False, raw=text)
+
+    groupdict = match.groupdict()
+    if "answer" in groupdict and groupdict["answer"] is not None:
+        answer = groupdict["answer"]
+    elif match.lastindex:
+        answer = match.group(1)
+    else:
+        answer = match.group(0)
+
+    return ExtractedAnswer(found=True, answer_text=answer, raw=text)
+
+
+def _extract_tool_call(text: str) -> ExtractedAnswer:
+    """Extract the first tool call using the canonical parser."""
+    parsed = parse_response(text)
+    first = parsed.first_tool_call
+    if first is None:
+        return ExtractedAnswer(found=False, raw=text)
+    return ExtractedAnswer(
+        found=True,
+        tool_name=first.name,
+        arguments=first.arguments,
+        raw=first.raw or "",
+    )
+
+
+def _extract_last_line(text: str) -> ExtractedAnswer:
+    """Last non-empty, stripped line as the answer."""
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return ExtractedAnswer(found=False, raw=text)
+    return ExtractedAnswer(found=True, answer_text=lines[-1], raw=text)
+
+
+def _extract_boxed(text: str) -> ExtractedAnswer:
+    """Content of the last LaTeX ``\\boxed{...}`` (one level of nesting)."""
+    marker = r"\boxed{"
+    start = text.rfind(marker)
+    if start == -1:
+        return ExtractedAnswer(found=False, raw=text)
+
+    content_start = start + len(marker)
+    depth = 1
+    i = content_start
+    while i < len(text):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return ExtractedAnswer(
+                    found=True,
+                    answer_text=text[content_start:i],
+                    raw=text,
+                )
+        i += 1
+
+    # Unbalanced — fall back to a simple flat match.
+    flat = re.search(r"\\boxed\{([^{}]*)\}", text)
+    if flat:
+        return ExtractedAnswer(found=True, answer_text=flat.group(1), raw=text)
+    return ExtractedAnswer(found=False, raw=text)
+
+
+def _extract_json_block(text: str) -> ExtractedAnswer:
+    """First ```json fenced block, else first balanced ``{...}`` parsed as JSON."""
+    fenced = re.search(r"```json\s*([\s\S]*?)\s*```", text, re.IGNORECASE)
+    candidate: Optional[str] = None
+    if fenced:
+        candidate = fenced.group(1).strip()
+    else:
+        candidate = _first_balanced_object(text)
+
+    if candidate is None:
+        return ExtractedAnswer(found=False, raw=text)
+
+    try:
+        parsed = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return ExtractedAnswer(found=False, raw=text)
+
+    if not isinstance(parsed, dict):
+        return ExtractedAnswer(found=False, raw=text)
+
+    return ExtractedAnswer(found=True, arguments=parsed, raw=text)
+
+
+def _first_balanced_object(text: str) -> Optional[str]:
+    """Return the first balanced ``{...}`` substring, or None."""
+    start = text.find("{")
+    if start == -1:
+        return None
+    depth = 0
+    for i in range(start, len(text)):
+        ch = text[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None

--- a/shared/verifiers/registry.py
+++ b/shared/verifiers/registry.py
@@ -1,0 +1,70 @@
+"""Verifier registry: factory registration and construction by spec.
+
+Verifier implementations register a factory under a ``type`` name via the
+:func:`register` decorator. :func:`build_verifier` then constructs a verifier
+from a spec mapping that carries a ``"type"`` key.
+
+Built-in verifiers and a ``CompositeVerifier`` are intentionally NOT defined
+here yet — they arrive in a later phase. This module is the minimal, functional
+scaffold those builtins will plug into.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Mapping
+
+from .contract import Verifier
+
+# Maps a verifier ``type`` name -> factory that builds a Verifier from a spec.
+VERIFIER_FACTORIES: Dict[str, Callable[[Mapping], Verifier]] = {}
+
+
+def register(type_name: str) -> Callable[[Callable[[Mapping], Verifier]], Callable[[Mapping], Verifier]]:
+    """Decorator that registers a verifier factory under ``type_name``.
+
+    Args:
+        type_name: The ``type`` value used in a spec to select this factory.
+
+    Returns:
+        A decorator that registers the wrapped factory and returns it unchanged.
+
+    Raises:
+        ValueError: If ``type_name`` is empty or already registered.
+    """
+    if not type_name:
+        raise ValueError("verifier type_name must be a non-empty string")
+
+    def _decorator(factory: Callable[[Mapping], Verifier]) -> Callable[[Mapping], Verifier]:
+        if type_name in VERIFIER_FACTORIES:
+            raise ValueError(f"verifier type already registered: {type_name!r}")
+        VERIFIER_FACTORIES[type_name] = factory
+        return factory
+
+    return _decorator
+
+
+def build_verifier(spec: Mapping) -> Verifier:
+    """Build a verifier from ``spec``.
+
+    Args:
+        spec: A mapping containing at least a ``"type"`` key naming a registered
+            verifier factory. The full spec is passed through to the factory.
+
+    Returns:
+        The constructed :class:`Verifier`.
+
+    Raises:
+        ValueError: If ``spec`` has no ``"type"`` key.
+        KeyError: If the ``"type"`` is not a registered factory.
+    """
+    try:
+        type_name = spec["type"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError("verifier spec must include a 'type' key") from exc
+
+    factory = VERIFIER_FACTORIES.get(type_name)
+    if factory is None:
+        known = ", ".join(sorted(VERIFIER_FACTORIES)) or "<none registered>"
+        raise KeyError(f"unknown verifier type: {type_name!r}; known types: {known}")
+
+    return factory(spec)

--- a/tests/shared/test_verifier_extraction.py
+++ b/tests/shared/test_verifier_extraction.py
@@ -1,0 +1,187 @@
+"""Tests for the shared answer-extraction abstraction (``shared.verifiers.extraction``)."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from shared.verifiers.extraction import ExtractedAnswer, extract
+from shared.validation.parsing import parse_response
+
+
+# ---------------------------------------------------------------------------
+# output_regex priority
+# ---------------------------------------------------------------------------
+
+class TestOutputRegexPriority:
+
+    def test_regex_wins_over_tool_call(self):
+        # Both a parseable tool call AND a regex-matchable token are present.
+        text = 'ANSWER=42 <tool_call>{"name": "foo", "arguments": {"a": 1}}</tool_call>'
+        ea = extract(text, mode="tool_call", output_regex=r"ANSWER=(\d+)")
+        assert ea.found is True
+        # Regex result wins: answer_text comes from the regex, NOT the tool call.
+        assert ea.answer_text == "42"
+        assert ea.tool_name == ""
+        assert ea.arguments == {}
+
+    def test_named_group(self):
+        ea = extract("the answer is <<7>>", output_regex=r"<<(?P<answer>\d+)>>")
+        assert ea.found is True
+        assert ea.answer_text == "7"
+
+    def test_group_one_when_no_named_group(self):
+        ea = extract("result: foo", output_regex=r"result: (\w+)")
+        assert ea.found is True
+        assert ea.answer_text == "foo"
+
+    def test_group_zero_when_no_capture_group(self):
+        ea = extract("hello world", output_regex=r"\w+")
+        assert ea.found is True
+        assert ea.answer_text == "hello"
+
+    def test_no_match_returns_not_found(self):
+        ea = extract("nothing here", output_regex=r"ZZZ(\d+)")
+        assert ea.found is False
+        assert ea.answer_text == ""
+        assert ea.raw == "nothing here"
+
+
+# ---------------------------------------------------------------------------
+# tool_call parity with the canonical parser
+# ---------------------------------------------------------------------------
+
+class TestToolCallParity:
+
+    QWEN = '<tool_call>{"name": "search", "arguments": {"q": "cats", "limit": 5}}</tool_call>'
+    MISTRAL = '[TOOL_CALLS] [{"name": "search", "arguments": {"q": "cats", "limit": 5}}]'
+    CHATML = 'tool_call: search\narguments: {"q": "cats", "limit": 5}'
+
+    @pytest.mark.parametrize("text", [QWEN, MISTRAL, CHATML])
+    def test_parity_with_parse_response(self, text):
+        ea = extract(text, mode="tool_call")
+        first = parse_response(text).first_tool_call
+        assert first is not None
+        assert ea.found is True
+        assert ea.tool_name == first.name
+        assert ea.arguments == first.arguments
+
+    @pytest.mark.parametrize("text", [QWEN, MISTRAL, CHATML])
+    def test_tool_call_args_mode_parity(self, text):
+        ea = extract(text, mode="tool_call_args")
+        first = parse_response(text).first_tool_call
+        assert ea.found is True
+        assert ea.arguments == first.arguments
+
+    def test_no_tool_call_found_false(self):
+        ea = extract("just some plain prose, no tool calls", mode="tool_call")
+        assert ea.found is False
+        assert ea.tool_name == ""
+        assert ea.arguments == {}
+
+
+# ---------------------------------------------------------------------------
+# boxed
+# ---------------------------------------------------------------------------
+
+class TestBoxed:
+
+    def test_simple(self):
+        ea = extract(r"The result is \boxed{42}.", mode="boxed")
+        assert ea.found is True
+        assert ea.answer_text == "42"
+
+    def test_last_box_wins(self):
+        ea = extract(r"\boxed{1} then \boxed{2}", mode="boxed")
+        assert ea.found is True
+        assert ea.answer_text == "2"
+
+    def test_nested_braces(self):
+        ea = extract(r"\boxed{\frac{1}{2}}", mode="boxed")
+        assert ea.found is True
+        assert ea.answer_text == r"\frac{1}{2}"
+
+    def test_empty_input(self):
+        ea = extract("", mode="boxed")
+        assert ea.found is False
+
+    def test_no_box(self):
+        ea = extract("no box at all", mode="boxed")
+        assert ea.found is False
+
+
+# ---------------------------------------------------------------------------
+# last_line
+# ---------------------------------------------------------------------------
+
+class TestLastLine:
+
+    def test_happy_path(self):
+        ea = extract("first\nsecond\n\n  third  \n", mode="last_line")
+        assert ea.found is True
+        assert ea.answer_text == "third"
+
+    def test_single_line(self):
+        ea = extract("only", mode="last_line")
+        assert ea.found is True
+        assert ea.answer_text == "only"
+
+    def test_empty_input(self):
+        ea = extract("   \n  \n", mode="last_line")
+        assert ea.found is False
+
+
+# ---------------------------------------------------------------------------
+# verbatim
+# ---------------------------------------------------------------------------
+
+class TestVerbatim:
+
+    def test_happy_path(self):
+        ea = extract("hello world", mode="verbatim")
+        assert ea.found is True
+        assert ea.answer_text == "hello world"
+
+    def test_empty_input(self):
+        ea = extract("", mode="verbatim")
+        assert ea.found is False
+        assert ea.answer_text == ""
+
+
+# ---------------------------------------------------------------------------
+# json_block
+# ---------------------------------------------------------------------------
+
+class TestJsonBlock:
+
+    def test_fenced_block(self):
+        text = 'prose\n```json\n{"a": 1, "b": [2, 3]}\n```\nmore'
+        ea = extract(text, mode="json_block")
+        assert ea.found is True
+        assert ea.arguments == {"a": 1, "b": [2, 3]}
+
+    def test_balanced_object_fallback(self):
+        ea = extract('here: {"x": {"y": 1}} done', mode="json_block")
+        assert ea.found is True
+        assert ea.arguments == {"x": {"y": 1}}
+
+    def test_empty_input(self):
+        ea = extract("", mode="json_block")
+        assert ea.found is False
+        assert ea.arguments == {}
+
+    def test_no_json(self):
+        ea = extract("no braces here", mode="json_block")
+        assert ea.found is False
+
+
+# ---------------------------------------------------------------------------
+# unknown mode
+# ---------------------------------------------------------------------------
+
+def test_unknown_mode_raises():
+    with pytest.raises(ValueError, match="unknown extraction mode"):
+        extract("x", mode="nope")

--- a/tests/shared/test_verifiers.py
+++ b/tests/shared/test_verifiers.py
@@ -1,0 +1,397 @@
+"""Tests for the shared verifier package: CompositeVerifier, builtins, registry.
+
+These tests prove:
+- CompositeVerifier reproduces each of the five combine semantics exactly.
+- The three builtins (substring/structure/llm_judge) behave per contract and
+  hold parity with the existing source logic they consolidate:
+    * structure  -> parity with FitnessEvaluator directly.
+    * llm_judge  -> aggregate() parity with judge_reward._aggregate (the copy
+      that Phase 3 will delete in favor of this canonical one).
+- The registry builds verifiers by spec and rejects unknown types.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+# judge_reward._aggregate lives under the GRPO src tree; add it for the ONE
+# allowed cross-import (parity assertion only).
+sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
+
+from shared.verifiers import (
+    CompositeVerifier,
+    VerifierInput,
+    VerifierOutput,
+    build_composite,
+    build_verifier,
+)
+from shared.verifiers.builtins.llm_judge import aggregate as canonical_aggregate
+from shared.validation.fitness import create_fitness_evaluator
+from shared.judge.models import JudgeResult, JudgeScore, RubricDef
+
+
+# ---------------------------------------------------------------------------
+# Stub children
+# ---------------------------------------------------------------------------
+
+class StubVerifier:
+    """A fixed-output child verifier for composite tests."""
+
+    def __init__(self, name: str, score: float, passed: bool):
+        self.name = name
+        self._score = score
+        self._passed = passed
+
+    def verify(self, sample: VerifierInput) -> VerifierOutput:
+        return VerifierOutput(score=self._score, passed=self._passed)
+
+
+def _sample(text: str = "x", ground_truth=None, prompt: str = "") -> VerifierInput:
+    return VerifierInput(
+        completion_text=text,
+        parsed=None,
+        prompt_text=prompt,
+        ground_truth=ground_truth or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# CompositeVerifier — one test per combine mode
+# ---------------------------------------------------------------------------
+
+class TestCompositeVerifier:
+
+    def test_weighted_sum(self):
+        # Σ wᵢ·sᵢ = 1.0*0.5 + 0.3*1.0 + 0.5*0.2 = 0.5 + 0.3 + 0.1 = 0.9
+        children = [
+            (StubVerifier("a", 0.5, True), 1.0),
+            (StubVerifier("b", 1.0, True), 0.3),
+            (StubVerifier("c", 0.2, False), 0.5),
+        ]
+        cv = CompositeVerifier("cw", children, combine="weighted_sum", pass_threshold=0.5)
+        out = cv.verify(_sample())
+        assert out.score == pytest.approx(0.9)
+        assert out.passed is True  # 0.9 >= 0.5
+        assert out.detail["combine"] == "weighted_sum"
+        assert len(out.detail["children"]) == 3
+
+    def test_weighted_sum_below_threshold(self):
+        children = [(StubVerifier("a", 0.1, True), 1.0)]
+        cv = CompositeVerifier("cw", children, combine="weighted_sum", pass_threshold=0.5)
+        out = cv.verify(_sample())
+        assert out.score == pytest.approx(0.1)
+        assert out.passed is False
+
+    def test_max_tier_skips_non_passing_highest(self):
+        # Highest score (0.9) has passed=False, so it must be skipped.
+        # Among passing children {0.7, 0.4}, max is 0.7.
+        children = [
+            (StubVerifier("hi", 0.9, False), 1.0),
+            (StubVerifier("mid", 0.7, True), 1.0),
+            (StubVerifier("lo", 0.4, True), 1.0),
+        ]
+        cv = CompositeVerifier("ct", children, combine="max_tier")
+        out = cv.verify(_sample())
+        assert out.score == pytest.approx(0.7)
+        assert out.passed is True
+
+    def test_max_tier_none_passed(self):
+        children = [
+            (StubVerifier("a", 0.9, False), 1.0),
+            (StubVerifier("b", 0.8, False), 1.0),
+        ]
+        cv = CompositeVerifier("ct", children, combine="max_tier")
+        out = cv.verify(_sample())
+        assert out.score == 0.0
+        assert out.passed is False
+
+    def test_mean(self):
+        children = [
+            (StubVerifier("a", 0.2, True), 1.0),
+            (StubVerifier("b", 0.8, True), 1.0),
+        ]
+        cv = CompositeVerifier("cm", children, combine="mean", pass_threshold=0.5)
+        out = cv.verify(_sample())
+        assert out.score == pytest.approx(0.5)
+        assert out.passed is True  # 0.5 >= 0.5
+
+    def test_min(self):
+        children = [
+            (StubVerifier("a", 0.3, True), 1.0),
+            (StubVerifier("b", 0.8, True), 1.0),
+        ]
+        cv = CompositeVerifier("cmin", children, combine="min", pass_threshold=0.5)
+        out = cv.verify(_sample())
+        assert out.score == pytest.approx(0.3)
+        assert out.passed is False  # 0.3 < 0.5
+
+    def test_all_pass_true(self):
+        children = [
+            (StubVerifier("a", 0.6, True), 1.0),
+            (StubVerifier("b", 0.9, True), 1.0),
+        ]
+        cv = CompositeVerifier("cap", children, combine="all_pass")
+        out = cv.verify(_sample())
+        assert out.score == 1.0
+        assert out.passed is True
+
+    def test_all_pass_false(self):
+        children = [
+            (StubVerifier("a", 0.6, True), 1.0),
+            (StubVerifier("b", 0.9, False), 1.0),
+        ]
+        cv = CompositeVerifier("cap", children, combine="all_pass")
+        out = cv.verify(_sample())
+        assert out.score == 0.0
+        assert out.passed is False
+
+    def test_unknown_combine_raises(self):
+        with pytest.raises(ValueError):
+            CompositeVerifier("bad", [], combine="nonsense")
+
+
+# ---------------------------------------------------------------------------
+# substring builtin
+# ---------------------------------------------------------------------------
+
+class TestSubstringVerifier:
+
+    def test_contained(self):
+        v = build_verifier({"type": "substring", "target": "hello"})
+        out = v.verify(_sample("well hello there"))
+        assert out.score == 1.0
+        assert out.passed is True
+
+    def test_not_contained(self):
+        v = build_verifier({"type": "substring", "target": "absent"})
+        out = v.verify(_sample("nothing here"))
+        assert out.score == 0.0
+        assert out.passed is False
+
+    def test_empty_needle_is_vacuous(self):
+        v = build_verifier({"type": "substring", "target": ""})
+        out = v.verify(_sample("anything at all"))
+        assert out.score == 1.0
+        assert out.passed is True
+
+    def test_case_insensitive_default(self):
+        v = build_verifier({"type": "substring", "target": "HELLO"})
+        out = v.verify(_sample("say hello now"))
+        assert out.score == 1.0
+
+    def test_case_sensitive_flag(self):
+        v = build_verifier(
+            {"type": "substring", "target": "HELLO", "case_sensitive": True}
+        )
+        out = v.verify(_sample("say hello now"))
+        assert out.score == 0.0
+
+    def test_target_field_from_ground_truth(self):
+        v = build_verifier({"type": "substring", "target_field": "answer"})
+        out = v.verify(_sample("the value is 42", ground_truth={"answer": "42"}))
+        assert out.score == 1.0
+
+
+# ---------------------------------------------------------------------------
+# structure builtin — parity with FitnessEvaluator
+# ---------------------------------------------------------------------------
+
+VALID_TOOL_CALL = (
+    '<tool_call>\n{"name": "useTools", "arguments": {"a": 1}}\n</tool_call>'
+)
+INVALID_COMPLETION = "just plain text, no tool call here"
+
+
+class TestStructureVerifier:
+
+    @pytest.mark.parametrize("completion", [VALID_TOOL_CALL, INVALID_COMPLETION])
+    def test_parity_with_fitness_evaluator(self, completion):
+        # Expected: compute via FitnessEvaluator directly with the same config.
+        ref = create_fitness_evaluator(validations=[], scoring_method="binary")
+        ref_result = ref.evaluate(completion)
+
+        v = build_verifier(
+            {
+                "type": "structure",
+                "validations": [],
+                "scoring_method": "binary",
+            }
+        )
+        out = v.verify(_sample(completion))
+
+        assert out.score == ref_result.score
+        assert out.passed == ref_result.is_valid
+
+    def test_valid_vs_invalid_differ(self):
+        v = build_verifier(
+            {"type": "structure", "validations": [], "scoring_method": "binary"}
+        )
+        valid = v.verify(_sample(VALID_TOOL_CALL))
+        invalid = v.verify(_sample(INVALID_COMPLETION))
+        assert valid.score == 1.0 and valid.passed is True
+        assert invalid.score == 0.0 and invalid.passed is False
+
+
+# ---------------------------------------------------------------------------
+# llm_judge builtin — aggregation parity with judge_reward._aggregate
+# ---------------------------------------------------------------------------
+
+class FakeJudgeService:
+    """A judge service stub returning a fixed JudgeResult (no network)."""
+
+    def __init__(self, result: JudgeResult):
+        self._result = result
+        self.calls = []
+
+    def judge(self, prompt, rubrics, system_prompt=None):
+        self.calls.append((prompt, rubrics))
+        return self._result
+
+
+def _make_judge_result() -> JudgeResult:
+    return JudgeResult(
+        passed=False,
+        scores=[
+            JudgeScore(
+                rubric_key="r1",
+                rubric_name="R1",
+                score=0.8,
+                passed=True,
+                pass_threshold=0.5,
+            ),
+            JudgeScore(
+                rubric_key="r2",
+                rubric_name="R2",
+                score=0.2,
+                passed=False,
+                pass_threshold=0.5,
+            ),
+            JudgeScore(
+                rubric_key="r3",
+                rubric_name="R3",
+                score=0.6,
+                passed=True,
+                pass_threshold=0.5,
+            ),
+        ],
+    )
+
+
+class TestLLMJudgeAggregationParity:
+    """Canonical aggregate() must match judge_reward._aggregate exactly."""
+
+    @pytest.mark.parametrize(
+        "strategy", ["mean_score", "mean_passed", "min_score", "all_pass"]
+    )
+    def test_aggregate_parity(self, strategy):
+        from judge_reward import _aggregate as grpo_aggregate
+
+        result = _make_judge_result()
+        assert canonical_aggregate(result, strategy) == grpo_aggregate(result, strategy)
+
+    def test_aggregate_empty_scores(self):
+        from judge_reward import _aggregate as grpo_aggregate
+
+        empty = JudgeResult(passed=False, scores=[])
+        for strategy in ("mean_score", "mean_passed", "min_score", "all_pass"):
+            assert canonical_aggregate(empty, strategy) == grpo_aggregate(empty, strategy)
+
+    def test_unknown_aggregation_raises(self):
+        with pytest.raises(ValueError):
+            canonical_aggregate(_make_judge_result(), "bogus")
+
+
+class TestLLMJudgeVerifier:
+
+    def _rubric(self, key):
+        return RubricDef(
+            key=key,
+            name=key.upper(),
+            description="d",
+            scope="response",
+            pass_threshold=0.5,
+            judge_prompt="judge {response}",
+            output_schema={},
+        )
+
+    def test_injected_judge_service(self):
+        result = _make_judge_result()
+        fake = FakeJudgeService(result)
+
+        v = build_verifier(
+            {
+                "type": "llm_judge",
+                "params": {
+                    "judge_service": fake,
+                    "rubrics": [self._rubric("r1"), self._rubric("r2"), self._rubric("r3")],
+                    "aggregation": "mean_passed",
+                    "pass_threshold": 0.5,
+                },
+            }
+        )
+        out = v.verify(_sample("a response", prompt="a prompt"))
+        # mean_passed over [True, False, True] = 2/3
+        assert out.score == pytest.approx(2.0 / 3.0)
+        assert out.passed is True  # 0.666 >= 0.5
+        assert len(fake.calls) == 1
+
+    def test_mean_score_aggregation(self):
+        result = _make_judge_result()
+        fake = FakeJudgeService(result)
+        v = build_verifier(
+            {
+                "type": "llm_judge",
+                "params": {
+                    "judge_service": fake,
+                    "rubrics": [self._rubric("r1"), self._rubric("r2"), self._rubric("r3")],
+                    "aggregation": "min_score",
+                    "pass_threshold": 0.5,
+                },
+            }
+        )
+        out = v.verify(_sample("resp"))
+        assert out.score == pytest.approx(0.2)  # min of [0.8, 0.2, 0.6]
+        assert out.passed is False
+
+    def test_missing_judge_service_raises(self):
+        with pytest.raises(ValueError):
+            build_verifier(
+                {"type": "llm_judge", "params": {"rubrics": [self._rubric("r1")]}}
+            )
+
+
+# ---------------------------------------------------------------------------
+# registry
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+
+    def test_build_substring_works(self):
+        v = build_verifier({"type": "substring", "target": "ok"})
+        out = v.verify(_sample("looks ok to me"))
+        assert out.score == 1.0
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(KeyError):
+            build_verifier({"type": "does_not_exist"})
+
+    def test_missing_type_raises(self):
+        with pytest.raises(ValueError):
+            build_verifier({"no_type": True})
+
+    def test_build_composite_via_specs(self):
+        cv = build_composite(
+            specs=[
+                {"type": "substring", "target": "a", "weight": 1.0},
+                {"type": "substring", "target": "b", "weight": 0.5},
+            ],
+            combine="weighted_sum",
+            pass_threshold=0.5,
+        )
+        # "a" present (1.0*1.0), "b" absent (0.5*0.0) -> 1.0
+        out = cv.verify(_sample("only a here"))
+        assert out.score == pytest.approx(1.0)
+        assert out.passed is True

--- a/tests/shared/test_verifiers.py
+++ b/tests/shared/test_verifiers.py
@@ -5,8 +5,8 @@ These tests prove:
 - The three builtins (substring/structure/llm_judge) behave per contract and
   hold parity with the existing source logic they consolidate:
     * structure  -> parity with FitnessEvaluator directly.
-    * llm_judge  -> aggregate() parity with judge_reward._aggregate (the copy
-      that Phase 3 will delete in favor of this canonical one).
+    * llm_judge  -> aggregate() pins the canonical aggregation scalars (the
+      GRPO copy ``judge_reward._aggregate`` was deleted in Phase 3).
 - The registry builds verifiers by spec and rejects unknown types.
 """
 
@@ -17,9 +17,6 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
-# judge_reward._aggregate lives under the GRPO src tree; add it for the ONE
-# allowed cross-import (parity assertion only).
-sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
 
 from shared.verifiers import (
     CompositeVerifier,
@@ -281,23 +278,32 @@ def _make_judge_result() -> JudgeResult:
 
 
 class TestLLMJudgeAggregationParity:
-    """Canonical aggregate() must match judge_reward._aggregate exactly."""
+    """Canonical aggregate() must produce the expected per-strategy scalars.
 
+    Phase 3 deleted ``judge_reward._aggregate`` (its math now lives only in the
+    canonical ``shared.verifiers.builtins.llm_judge.aggregate``). The expected
+    values below are the SAME numbers the old parity assertion checked against
+    that now-removed copy, hardcoded to pin canonical behavior.
+    """
+
+    # _make_judge_result() scores: 0.8 (pass), 0.2 (fail), 0.6 (pass).
     @pytest.mark.parametrize(
-        "strategy", ["mean_score", "mean_passed", "min_score", "all_pass"]
+        "strategy, expected",
+        [
+            ("mean_score", (0.8 + 0.2 + 0.6) / 3),  # 0.5333...
+            ("mean_passed", 2.0 / 3.0),
+            ("min_score", 0.2),
+            ("all_pass", 0.0),
+        ],
     )
-    def test_aggregate_parity(self, strategy):
-        from judge_reward import _aggregate as grpo_aggregate
-
+    def test_aggregate_values(self, strategy, expected):
         result = _make_judge_result()
-        assert canonical_aggregate(result, strategy) == grpo_aggregate(result, strategy)
+        assert canonical_aggregate(result, strategy) == expected
 
     def test_aggregate_empty_scores(self):
-        from judge_reward import _aggregate as grpo_aggregate
-
         empty = JudgeResult(passed=False, scores=[])
         for strategy in ("mean_score", "mean_passed", "min_score", "all_pass"):
-            assert canonical_aggregate(empty, strategy) == grpo_aggregate(empty, strategy)
+            assert canonical_aggregate(empty, strategy) == 0.0
 
     def test_unknown_aggregation_raises(self):
         with pytest.raises(ValueError):

--- a/tests/test_evaluator_assertions.py
+++ b/tests/test_evaluator_assertions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from Evaluator.assertions import evaluate_correctness, select_path
+from shared.verifiers.builtins.assertion_verifier import evaluate_correctness, select_path
 from Evaluator.config_loader import ConfigLoader
 from Evaluator.prompt_sets import PromptCase
 from Evaluator.protocols import BackendResponse

--- a/tests/trainers/grpo/test_functional_verifier.py
+++ b/tests/trainers/grpo/test_functional_verifier.py
@@ -11,11 +11,13 @@ sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
 
 from functional_verifier import (
-    _normalize_value,
-    _normalize_tool_call,
     _extract_tool_call,
-    _compare_args,
     functional_equivalence_reward,
+)
+from shared.verifiers.builtins.args_match import (
+    normalize_value as _normalize_value,
+    normalize_tool_call as _normalize_tool_call,
+    compare_args_overlap as _compare_args,
 )
 
 

--- a/tests/trainers/grpo/test_phase3_characterization.py
+++ b/tests/trainers/grpo/test_phase3_characterization.py
@@ -1,0 +1,176 @@
+"""Phase 3 characterization tests — pin CURRENT numeric behavior.
+
+These tests capture the exact numeric outputs of the GRPO scoring building
+blocks BEFORE the Phase 3 dedup refactor, so the refactor can be proven
+byte-identical. They must pass against the unrefactored code AND against the
+refactored code (where the duplicated logic is consolidated into
+``shared.verifiers.builtins.args_match``).
+
+Covered:
+- ``functional_equivalence_reward`` on representative cases.
+- ``RewardRubric._score_weighted`` for a mapping-based AND a legacy config.
+- ``RewardRubric._compare_values`` for all four strategies.
+"""
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
+
+from functional_verifier import functional_equivalence_reward
+import rewards as R
+
+
+def _make_rubric(cfg: dict) -> "R.RewardRubric":
+    d = tempfile.mkdtemp()
+    p = Path(d) / "r.yaml"
+    p.write_text(yaml.safe_dump(cfg))
+    return R.RewardRubric(p)
+
+
+# ---------------------------------------------------------------------------
+# functional_equivalence_reward
+# ---------------------------------------------------------------------------
+
+class TestFunctionalEquivalenceRewardCharacterization:
+
+    def test_representative_vector(self):
+        exact = '<tool_call>{"name": "readFile", "arguments": {"path": "/a.txt"}}</tool_call>'
+        partial = '<tool_call>{"name": "readFile", "arguments": {"path": "/a.txt", "extra": "z"}}</tool_call>'
+        wrong = '<tool_call>{"name": "writeFile", "arguments": {"path": "/a.txt"}}</tool_call>'
+        missing_gt = '<tool_call>{"name": "readFile", "arguments": {"path": "/a.txt"}}</tool_call>'
+
+        scores = functional_equivalence_reward(
+            [exact, partial, wrong, missing_gt],
+            ground_truth_tool=["readFile", "readFile", "readFile", None],
+            ground_truth_args_json=[
+                json.dumps({"path": "/a.txt"}),
+                json.dumps({"path": "/a.txt"}),
+                json.dumps({"path": "/a.txt"}),
+                json.dumps({"path": "/a.txt"}),
+            ],
+        )
+        # Pinned current outputs:
+        # - exact tool + perfect args -> 1.0
+        # - partial key overlap (extra arg) -> 0.8
+        # - wrong tool -> 0.0
+        # - missing ground_truth -> 0.0
+        assert scores == [1.0, 0.8, 0.0, 0.0]
+
+
+# ---------------------------------------------------------------------------
+# RewardRubric._compare_values — all four strategies
+# ---------------------------------------------------------------------------
+
+class TestCompareValuesCharacterization:
+
+    @pytest.fixture(scope="class")
+    def rubric(self):
+        return _make_rubric({"name": "x"})
+
+    def test_equals(self, rubric):
+        assert rubric._compare_values("a", "a", "equals") == 1.0
+        assert rubric._compare_values("a", "b", "equals") == 0.0
+
+    def test_contains(self, rubric):
+        assert rubric._compare_values("hello world", "world", "contains") == 1.0
+        assert rubric._compare_values("hi", "world", "contains") == 0.0
+
+    def test_key_overlap(self, rubric):
+        # pred keys {a,b}, gt keys {a,c}; overlap {a} = 1; len(gt) = 2 -> 0.5
+        assert rubric._compare_values(
+            {"a": 1, "b": 2}, {"a": 9, "c": 3}, "key_overlap"
+        ) == 0.5
+
+    def test_tool_name_match_exact(self, rubric):
+        assert rubric._compare_values("agent_tool", "agent_tool", "tool_name_match") == 1.0
+
+    def test_tool_name_match_partial(self, rubric):
+        # same agent prefix -> 0.3
+        assert rubric._compare_values("agent_x", "agent_y", "tool_name_match") == 0.3
+
+    def test_tool_name_match_none(self, rubric):
+        assert rubric._compare_values("a_x", "b_y", "tool_name_match") == 0.0
+
+    def test_none_input(self, rubric):
+        assert rubric._compare_values(None, "a", "equals") == 0.0
+
+
+# ---------------------------------------------------------------------------
+# RewardRubric._score_weighted — mapping-based AND legacy
+# ---------------------------------------------------------------------------
+
+class TestScoreWeightedCharacterization:
+
+    def test_mapping_based(self):
+        cfg = {
+            "name": "mapped",
+            "scoring": {"strategy": "weighted"},
+            "ground_truth": {"field": "ground_truth_args_json", "parse": "json"},
+            "comparison": {
+                "mappings": [
+                    {"use_tool_name": True, "strategy": "tool_name_match", "weight": 2.0},
+                    {"pred_path": "path", "gt_path": "path", "strategy": "equals", "weight": 1.0},
+                    {"pred_path": "", "gt_path": "calls.0.params", "strategy": "key_overlap", "weight": 1.0},
+                ]
+            },
+        }
+        rb = _make_rubric(cfg)
+        data = {"tool_name": "agent_read", "parsed_args": {"path": "/a.txt", "mode": "r"}}
+        kwargs = {
+            "ground_truth_tool": "agent_read",
+            "ground_truth_args_json": json.dumps(
+                {"path": "/a.txt", "calls": [{"params": {"mode": 1, "path": 2}}]}
+            ),
+        }
+        # tool_name 1.0*2 + equals(path) 1.0*1 + key_overlap(mode,path vs mode,path) 1.0*1
+        # = 4.0 / 4.0 = 1.0
+        assert rb._score_weighted(data, kwargs) == 1.0
+
+    def test_mapping_missing_ground_truth(self):
+        cfg = {
+            "name": "mapped",
+            "scoring": {"strategy": "weighted"},
+            "ground_truth": {"field": "ground_truth_args_json", "parse": "json"},
+            "comparison": {"mappings": [{"pred_path": "p", "gt_path": "p", "weight": 1.0}]},
+        }
+        rb = _make_rubric(cfg)
+        assert rb._score_weighted({"parsed_args": {}}, {}) == 0.0
+
+    def test_legacy(self):
+        cfg = {
+            "name": "legacy",
+            "scoring": {
+                "strategy": "weighted",
+                "weights": {"context_match": 0.4, "tool_match": 0.3, "params_match": 0.3},
+            },
+            "ground_truth": {"field": "ground_truth_args_json", "parse": "json"},
+            "comparison": {"context_fields": ["userId"], "call_fields": []},
+        }
+        rb = _make_rubric(cfg)
+        data = {"tool_name": "agent_x", "parsed_args": {"userId": "u1", "query": "hi"}}
+        kwargs = {
+            "ground_truth_tool": "agent_x",
+            "ground_truth_args_json": json.dumps(
+                {"context": {"userId": "u1"}, "calls": [{"params": {"query": 1, "limit": 2}}]}
+            ),
+        }
+        # context 0.4*(1/1) + tool 0.3*1.0 + params 0.3*(1/2) = 0.4 + 0.3 + 0.15 = 0.85
+        assert rb._score_weighted(data, kwargs) == pytest.approx(0.85)
+
+    def test_legacy_missing_ground_truth(self):
+        cfg = {
+            "name": "legacy",
+            "scoring": {"strategy": "weighted"},
+            "ground_truth": {"field": "ground_truth_args_json", "parse": "json"},
+            "comparison": {"context_fields": ["userId"]},
+        }
+        rb = _make_rubric(cfg)
+        assert rb._score_weighted({"parsed_args": {}}, {}) == 0.0


### PR DESCRIPTION
## Summary

Borrows the central design idea from [NVIDIA-NeMo/Gym](https://github.com/NVIDIA-NeMo/Gym) — *write a verifier once, score both evaluation and training reward with it* — and uses it to consolidate scoring logic that was triplicated and drifting across three subsystems (Evaluator, GRPO reward, flywheel fitness).

Introduces a new `shared/verifiers/` package: a `Verifier` contract, a config-driven registry of composable builtins, a `CompositeVerifier`, and a unified answer/tool-call extraction abstraction. The Evaluator and GRPO reward path now draw scoring logic from this shared vocabulary instead of each owning private copies.

## What changed (phased, behavior-preserving)

| Phase | Change |
|-------|--------|
| **0+1** | New `shared/verifiers/` package (`contract`, `registry`, `extraction`). Deduped **4 copies** of tool-call extraction into one config-driven `extract()` (named modes + `output_regex` priority, modeled on NeMo Gym's `mcqa` grading modes). |
| **2** | `CompositeVerifier` with five combine modes mapped exactly to the three pre-existing combine semantics (GRPO weighted-sum, Evaluator max-tier, judge mean/min/all_pass). Adds `structure`, `llm_judge`, `substring` builtins. |
| **3** | GRPO consumes the shared `args_match` builtin — killed **3 divergent argument comparators** plus the duplicated judge aggregation/rendering. The weighted-sum `combined_reward` loop and all TRL signatures are unchanged. |
| **4** | Evaluator's assertion engine **moved** to a shared builtin (recorded by git as a pure rename — byte-identical), tool-sequence predicates extracted to a `tool_sequence` builtin, judge prompt-rendering deduped. The `_run_path_scoring` max-tier loop is unchanged. |

Registry now exposes: `args_match`, `assertions`, `llm_judge`, `structure`, `substring`, `tool_sequence`.

## Design decisions

- **Both proven scoring loops kept as-is.** Rewriting GRPO's weighted-sum loop or the Evaluator's max-tier loop into `CompositeVerifier` would have been zero behavioral change for real regression risk on the live training/eval paths. The dedup value was fully captured without touching them.
- **No backward-compat shims.** Code was moved and importers updated directly, per the repo's refactoring rule.
- **Clean dependency direction.** `shared/verifiers/` imports no `Trainers/` or `Evaluator/` code (verified by grep).

## Behavior preservation

- Phase 3 added characterization tests pinning exact GRPO reward vectors before/after the rewire.
- Phase 4's assertion-engine move is byte-identical (git rename).
- Verified by stash-and-rerun that the change introduces **zero** new test failures.

## Tests

114 passed across all touched paths (extraction, verifiers, composite, GRPO reward, evaluator assertions + scoring).

**Pre-existing, not introduced by this PR:** 6 `test_evaluator_multistep` env-loop `stop_reason` failures, and collection errors in some flywheel/grpo-env test modules from missing optional deps (`torch`/`datasets`/`transformers`). Both confirmed present on `main` before these changes.

## Deferred

- **Phase 5 (flywheel adoption)** is intentionally left out — the `FitnessEvaluator` carries pinned invariants (empty-rules→1.0, non-tool-call→0.0, `FitnessResult` shape consumed by tagger/cleaner) that warrant a separate, opt-in change.

https://claude.ai/code/session_01KrQxhmsvULxNXtBw34uMSp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KrQxhmsvULxNXtBw34uMSp)_