### PR TITLE
[codex] Add thinking effort provider support

### DIFF
--- a/.agents/skills/synethetic-data-generation/reference/settings-config.md
+++ b/.agents/skills/synethetic-data-generation/reference/settings-config.md
@@ -12,10 +12,11 @@ Two separate LLM configs — generation (raw examples) and improvement (judge/im
 llm:
   # Generation model — creates raw examples. Local models work fine.
   generation:
-    provider: openrouter          # openrouter | lmstudio | ollama | unsloth
+    provider: openrouter          # openrouter | openai_responses | lmstudio | ollama | unsloth
     model: MODEL_ID
     temperature: 0.7              # Higher = more variety in generated examples
     max_tokens: 4096
+    thinking_effort: low          # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:
       order: ["PROVIDER_NAME"]    # Optional hosted-provider preference
       allow_fallbacks: true       # Fall back if preferred unavailable
@@ -38,12 +39,13 @@ llm:
     model: MODEL_ID
     temperature: 0.1              # Low = deterministic judging
     max_tokens: 2048
+    thinking_effort: medium       # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:             # OpenRouter-specific
       order: ["PROVIDER_NAME"]   # Optional hosted-provider preference
       allow_fallbacks: true      # Fall back if preferred unavailable
 ```
 
-**Providers:** `openrouter`, `lmstudio`, `ollama`, `unsloth`
+**Providers:** `openrouter`, `openai_responses`, `lmstudio`, `ollama`, `unsloth`
 
 CLI flags `--provider` and `--model` override these at runtime.
 

--- a/.claude/skills/synethetic-data-generation/reference/settings-config.md
+++ b/.claude/skills/synethetic-data-generation/reference/settings-config.md
@@ -12,10 +12,11 @@ Two separate LLM configs — generation (raw examples) and improvement (judge/im
 llm:
   # Generation model — creates raw examples. Local models work fine.
   generation:
-    provider: openrouter          # openrouter | lmstudio | ollama | unsloth
+    provider: openrouter          # openrouter | openai_responses | lmstudio | ollama | unsloth
     model: MODEL_ID
     temperature: 0.7              # Higher = more variety in generated examples
     max_tokens: 4096
+    thinking_effort: low          # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:
       order: ["PROVIDER_NAME"]    # Optional hosted-provider preference
       allow_fallbacks: true       # Fall back if preferred unavailable
@@ -38,12 +39,13 @@ llm:
     model: MODEL_ID
     temperature: 0.1              # Low = deterministic judging
     max_tokens: 2048
+    thinking_effort: medium       # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:             # OpenRouter-specific
       order: ["PROVIDER_NAME"]   # Optional hosted-provider preference
       allow_fallbacks: true      # Fall back if preferred unavailable
 ```
 
-**Providers:** `openrouter`, `lmstudio`, `ollama`, `unsloth`
+**Providers:** `openrouter`, `openai_responses`, `lmstudio`, `ollama`, `unsloth`
 
 CLI flags `--provider` and `--model` override these at runtime.
 

--- a/.skills/synethetic-data-generation/reference/settings-config.md
+++ b/.skills/synethetic-data-generation/reference/settings-config.md
@@ -12,10 +12,11 @@ Two separate LLM configs — generation (raw examples) and improvement (judge/im
 llm:
   # Generation model — creates raw examples. Local models work fine.
   generation:
-    provider: openrouter          # openrouter | lmstudio | ollama | unsloth
+    provider: openrouter          # openrouter | openai_responses | lmstudio | ollama | unsloth
     model: MODEL_ID
     temperature: 0.7              # Higher = more variety in generated examples
     max_tokens: 4096
+    thinking_effort: low          # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:
       order: ["PROVIDER_NAME"]    # Optional hosted-provider preference
       allow_fallbacks: true       # Fall back if preferred unavailable
@@ -38,12 +39,13 @@ llm:
     model: MODEL_ID
     temperature: 0.1              # Low = deterministic judging
     max_tokens: 2048
+    thinking_effort: medium       # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:             # OpenRouter-specific
       order: ["PROVIDER_NAME"]   # Optional hosted-provider preference
       allow_fallbacks: true      # Fall back if preferred unavailable
 ```
 
-**Providers:** `openrouter`, `lmstudio`, `ollama`, `unsloth`
+**Providers:** `openrouter`, `openai_responses`, `lmstudio`, `ollama`, `unsloth`
 
 CLI flags `--provider` and `--model` override these at runtime.
 

--- a/Evaluator/client_factory.py
+++ b/Evaluator/client_factory.py
@@ -101,6 +101,7 @@ def create_settings(
     temperature: float = 0.2,
     top_p: float = 0.9,
     max_tokens: int = 1024,
+    thinking_effort: Optional[str] = None,
     seed: Optional[int] = None,
 ) -> BackendSettings:
     """Create backend settings for the specified backend type.
@@ -116,6 +117,7 @@ def create_settings(
         temperature: Sampling temperature
         top_p: Top-p sampling parameter
         max_tokens: Maximum output tokens
+        thinking_effort: Optional reasoning effort for supported cloud providers
         seed: Optional random seed for reproducibility
 
     Returns:
@@ -153,6 +155,8 @@ def create_settings(
         "max_tokens": max_tokens,
         "seed": seed,
     }
+    if backend in {BackendType.OPENROUTER, BackendType.OPENAI_RESPONSES}:
+        kwargs["thinking_effort"] = thinking_effort
     if host is not None:
         kwargs["host"] = host
     if port is not None:
@@ -169,6 +173,7 @@ def create_client_from_args(
     temperature: float = 0.2,
     top_p: float = 0.9,
     max_tokens: int = 1024,
+    thinking_effort: Optional[str] = None,
     seed: Optional[int] = None,
     timeout: float = 60.0,
     retries: int = 2,
@@ -209,6 +214,7 @@ def create_client_from_args(
         temperature=temperature,
         top_p=top_p,
         max_tokens=max_tokens,
+        thinking_effort=thinking_effort,
         seed=seed,
     )
     return create_client(

--- a/Evaluator/config.py
+++ b/Evaluator/config.py
@@ -311,6 +311,7 @@ class OpenRouterSettings:
     temperature: float = 0.2
     top_p: float = 0.9
     max_tokens: int = 1024
+    thinking_effort: Optional[str] = None
     seed: Optional[int] = None
 
     # Required by BackendSettings protocol but not used for API
@@ -333,6 +334,7 @@ class OpenAIResponsesSettings:
     temperature: float = 0.2
     top_p: float = 0.9
     max_tokens: int = 1024
+    thinking_effort: Optional[str] = None
     seed: Optional[int] = None
 
     # Required by BackendSettings protocol but not used for direct API routing.

--- a/Evaluator/shared_llm_adapters.py
+++ b/Evaluator/shared_llm_adapters.py
@@ -50,11 +50,16 @@ class SharedLLMAdapter:
 
         # Create shared LLM client
         # Note: API keys/hosts come from environment
+        config_defaults = {"timeout_seconds": timeout}
+        thinking_effort = getattr(settings, "thinking_effort", None)
+        if thinking_effort is not None:
+            config_defaults["thinking_effort"] = thinking_effort
+
         try:
             self.client: BaseLLMClient = create_client(
                 provider=provider,
                 model=settings.model,
-                config_defaults={"timeout_seconds": timeout},
+                config_defaults=config_defaults,
             )
         except LLMError as e:
             raise self._create_error(f"Failed to create {provider} client: {e}")

--- a/SynthChat/README.md
+++ b/SynthChat/README.md
@@ -59,6 +59,7 @@ llm:
     model: openai/gpt-oss-120b
     temperature: 0.7
     max_tokens: 4096
+    thinking_effort: low          # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:
       order: ["Groq"]
       allow_fallbacks: true
@@ -68,6 +69,7 @@ llm:
     provider: openrouter
     model: openai/gpt-4o
     temperature: 0.1              # Low for deterministic judging
+    thinking_effort: medium       # Optional for OpenRouter/OpenAI reasoning models
 
 improvement:
   max_iterations: 10              # Max improvement loops per example

--- a/SynthChat/config/settings.yaml
+++ b/SynthChat/config/settings.yaml
@@ -9,6 +9,7 @@ llm:
     model: openai/gpt-oss-120b
     temperature: 0.7
     max_tokens: 4096  # Increased for content writing scenarios
+    # thinking_effort: low  # Optional for OpenRouter/OpenAI reasoning models
     provider_routing:
       order: ["Groq"]  # Prioritize Groq for speed
       allow_fallbacks: true  # Fall back to others if Groq unavailable
@@ -37,6 +38,7 @@ llm:
     model: openai/gpt-oss-120b
     temperature: 0.1  # Deterministic judging
     max_tokens: 2048
+    # thinking_effort: medium  # Optional for OpenRouter/OpenAI reasoning models
     # Provider routing - prioritize specific providers
     provider_routing:
       order: ["Groq"]  # Prioritize Groq for speed

--- a/SynthChat/llm/client_pool.py
+++ b/SynthChat/llm/client_pool.py
@@ -59,8 +59,15 @@ class LLMClientPool:
         provider = str(value.get("provider") or "").strip().lower()
         provider_routing = value.get("provider_routing")
         timeout_seconds = value.get("timeout_seconds")
+        thinking_effort = value.get("thinking_effort", value.get("reasoning_effort"))
 
-        has_override = bool(model or provider or provider_routing is not None or timeout_seconds is not None)
+        has_override = bool(
+            model
+            or provider
+            or provider_routing is not None
+            or timeout_seconds is not None
+            or thinking_effort is not None
+        )
         if not has_override:
             return None
 
@@ -73,6 +80,8 @@ class LLMClientPool:
             spec["provider_routing"] = provider_routing
         if timeout_seconds is not None:
             spec["timeout_seconds"] = timeout_seconds
+        if thinking_effort is not None:
+            spec["thinking_effort"] = thinking_effort
         return spec
 
     def get_or_create(self, spec: Dict[str, Any]) -> Any:
@@ -81,17 +90,20 @@ class LLMClientPool:
         base_model = str(getattr(self.default_client, "model_name", "") or "").strip()
         base_provider_routing = deepcopy(getattr(self.default_client, "provider", None))
         base_timeout_seconds = getattr(self.default_client, "timeout_seconds", None)
+        base_thinking_effort = getattr(self.default_client, "thinking_effort", None)
 
         provider = str(spec.get("provider") or base_provider).strip().lower()
         model = str(spec.get("model") or base_model).strip()
         provider_routing = deepcopy(spec.get("provider_routing", base_provider_routing))
         timeout_seconds = spec.get("timeout_seconds", base_timeout_seconds)
+        thinking_effort = spec.get("thinking_effort", base_thinking_effort)
 
         cache_key = (
             provider,
             model,
             json.dumps(provider_routing, sort_keys=True) if provider_routing is not None else "",
             str(timeout_seconds) if timeout_seconds is not None else "",
+            str(thinking_effort) if thinking_effort is not None else "",
         )
         cached = self._cache.get(cache_key)
         if cached is not None:
@@ -103,7 +115,8 @@ class LLMClientPool:
                 timeout_seconds == base_timeout_seconds
                 or (timeout_seconds is None and base_timeout_seconds is None)
             )
-            if same_routing and same_timeout:
+            same_thinking_effort = thinking_effort == base_thinking_effort
+            if same_routing and same_timeout and same_thinking_effort:
                 self._cache[cache_key] = self.default_client
                 return self.default_client
 
@@ -115,6 +128,8 @@ class LLMClientPool:
             config_defaults["provider_routing"] = provider_routing
         if timeout_seconds is not None:
             config_defaults["timeout_seconds"] = timeout_seconds
+        if thinking_effort is not None:
+            config_defaults["thinking_effort"] = thinking_effort
 
         client = self._create_client(
             provider=provider,

--- a/SynthChat/run.py
+++ b/SynthChat/run.py
@@ -61,6 +61,9 @@ def create_llm_client(config: Dict, mode: str = "generation",
         "temperature": llm_config.get("temperature", 0.7),
         "max_tokens": llm_config.get("max_tokens", 2048),
     }
+    thinking_effort = llm_config.get("thinking_effort", llm_config.get("reasoning_effort"))
+    if thinking_effort is not None:
+        config_defaults["thinking_effort"] = thinking_effort
 
     # Provider-specific config
     if provider == "unsloth":

--- a/SynthChat/services/rubric_runner.py
+++ b/SynthChat/services/rubric_runner.py
@@ -97,6 +97,10 @@ class RubricRunner:
                 provider_routing["order"] = pr["order"]
             if "allow_fallbacks" in pr:
                 provider_routing["allow_fallbacks"] = pr["allow_fallbacks"]
+        thinking_effort = improvement_config.get(
+            "thinking_effort",
+            improvement_config.get("reasoning_effort"),
+        )
 
         config = LLMConfig(
             provider=backend,
@@ -104,6 +108,7 @@ class RubricRunner:
             openrouter_api_key=os.getenv("OPENROUTER_API_KEY"),
             openai_api_key=os.getenv("OPENAI_API_KEY"),
             provider_routing=provider_routing,
+            thinking_effort=thinking_effort,
             lmstudio_host=lmstudio_host,
             lmstudio_port=lmstudio_port,
             ollama_host=ollama_host,

--- a/shared/llm/README.md
+++ b/shared/llm/README.md
@@ -47,6 +47,7 @@ IMPROVEMENT_MODEL=openai/gpt-5-mini
 
 # OpenRouter (cloud)
 OPENROUTER_API_KEY=sk-or-v1-your-key-here
+OPENROUTER_THINKING_EFFORT=medium  # Optional: none, minimal, low, medium, high, xhigh
 
 # OpenAI Responses (cloud)
 OPENAI_API_KEY=sk-your-key-here
@@ -54,6 +55,7 @@ OPENAI_RESPONSES_BASE_URL=https://api.openai.com/v1
 OPENAI_RESPONSES_TIMEOUT_SECONDS=60
 OPENAI_RESPONSES_STORE=false
 OPENAI_RESPONSES_STRUCTURED_OUTPUT_STRICT=false
+OPENAI_RESPONSES_THINKING_EFFORT=medium  # Optional: model-dependent reasoning effort
 
 # LM Studio (local)
 LMSTUDIO_HOST=localhost
@@ -99,6 +101,8 @@ response = client.chat([{"role": "user", "content": "Hello!"}])
 ```
 
 The provider calls `POST /v1/responses`, sends `store: false` by default, maps the shared `max_tokens` argument to `max_output_tokens`, and uses `text.format` for JSON Schema structured output. Structured-output strict mode defaults to false for schema compatibility and can be enabled with `OPENAI_RESPONSES_STRUCTURED_OUTPUT_STRICT=true` or explicit config.
+
+For reasoning models, set `thinking_effort` in config defaults or `OPENAI_RESPONSES_THINKING_EFFORT` in the environment. The provider maps it to Responses API `reasoning.effort`.
 
 #### **3. LM Studio (Local)**
 

--- a/shared/llm/config.py
+++ b/shared/llm/config.py
@@ -15,6 +15,7 @@ class LLMConfig:
     model: str  # Model name or path to LoRA adapter (for unsloth)
     temperature: float = 0.7
     max_tokens: int = 2048
+    thinking_effort: Optional[str] = None
 
     # OpenRouter config
     openrouter_api_key: Optional[str] = None
@@ -59,6 +60,8 @@ class LLMConfig:
             OPENAI_RESPONSES_TIMEOUT_SECONDS: Optional OpenAI Responses timeout
             OPENAI_RESPONSES_STORE: Optional response storage opt-in (default false)
             OPENAI_RESPONSES_STRUCTURED_OUTPUT_STRICT: Optional JSON Schema strict opt-in
+            OPENROUTER_THINKING_EFFORT: Optional OpenRouter reasoning effort
+            OPENAI_RESPONSES_THINKING_EFFORT: Optional OpenAI Responses reasoning effort
             LMSTUDIO_HOST: LM Studio host (default: localhost)
             LMSTUDIO_PORT: LM Studio port (default: 1234)
             OLLAMA_HOST: Ollama host (default: localhost)
@@ -89,6 +92,7 @@ class LLMConfig:
         model = cfg.get("model", os.getenv(f"{env_prefix}_MODEL", "openai/gpt-5-mini"))
         temperature = float(cfg.get("temperature", 0.7))
         max_tokens = int(cfg.get("max_tokens", 2048))
+        thinking_effort = _config_thinking_effort(cfg, provider)
 
         # Build provider routing config for OpenRouter
         provider_routing = None
@@ -109,6 +113,7 @@ class LLMConfig:
             model=model,
             temperature=temperature,
             max_tokens=max_tokens,
+            thinking_effort=thinking_effort,
             openrouter_api_key=os.getenv("OPENROUTER_API_KEY"),
             provider_routing=provider_routing,
             openrouter_timeout_seconds=float(
@@ -237,3 +242,16 @@ def _coerce_bool(value: Any) -> bool:
     if value is None:
         return False
     return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _config_thinking_effort(cfg: Dict[str, Any], provider: str) -> Optional[str]:
+    value = cfg.get("thinking_effort", cfg.get("reasoning_effort"))
+    if value is None:
+        if str(provider).lower() == "openrouter":
+            value = os.getenv("OPENROUTER_THINKING_EFFORT")
+        elif str(provider).lower() == "openai_responses":
+            value = os.getenv("OPENAI_RESPONSES_THINKING_EFFORT")
+    if value is None:
+        return None
+    value = str(value).strip().lower()
+    return value or None

--- a/shared/llm/factory.py
+++ b/shared/llm/factory.py
@@ -52,13 +52,12 @@ def create_client(
     """
     # Load config if not provided
     if config is None:
-        config = LLMConfig.from_env(env_prefix=env_prefix, config_defaults=config_defaults)
-
-        # Override with explicit parameters if provided
+        resolved_defaults = dict(config_defaults or {})
         if provider:
-            config.provider = provider.lower()
+            resolved_defaults["provider"] = provider.lower()
         if model:
-            config.model = model
+            resolved_defaults["model"] = model
+        config = LLMConfig.from_env(env_prefix=env_prefix, config_defaults=resolved_defaults)
 
     # Validate config
     config.validate()
@@ -75,6 +74,7 @@ def create_client(
             model=config.model,
             provider=config.provider_routing,  # Pass provider routing (e.g., {"order": ["Groq"]})
             timeout_seconds=config.openrouter_timeout_seconds,
+            thinking_effort=config.thinking_effort,
         )
 
     elif config.provider == "openai_responses":
@@ -90,6 +90,7 @@ def create_client(
             timeout_seconds=config.openai_responses_timeout_seconds,
             store=config.openai_responses_store,
             structured_output_strict=config.openai_responses_structured_output_strict,
+            thinking_effort=config.thinking_effort,
         )
 
     elif config.provider == "lmstudio":

--- a/shared/llm/providers/openai_responses.py
+++ b/shared/llm/providers/openai_responses.py
@@ -22,6 +22,7 @@ class OpenAIResponsesClient(BaseLLMClient):
         timeout_seconds: float = 60.0,
         store: bool = False,
         structured_output_strict: bool = False,
+        thinking_effort: str | None = None,
     ):
         self.api_key = api_key
         self.model = model
@@ -30,6 +31,7 @@ class OpenAIResponsesClient(BaseLLMClient):
         self.timeout_seconds = float(timeout_seconds)
         self.store = bool(store)
         self.structured_output_strict = bool(structured_output_strict)
+        self.thinking_effort = _normalize_thinking_effort(thinking_effort)
 
     @property
     def provider_name(self) -> str:
@@ -67,6 +69,8 @@ class OpenAIResponsesClient(BaseLLMClient):
         }
         if temperature is not None:
             payload["temperature"] = temperature
+        if self.thinking_effort:
+            payload["reasoning"] = {"effort": self.thinking_effort}
         payload.update(kwargs)
 
         try:
@@ -109,6 +113,8 @@ class OpenAIResponsesClient(BaseLLMClient):
             payload["temperature"] = temperature
         if max_tokens is not None:
             payload["max_output_tokens"] = max_tokens
+        if self.thinking_effort:
+            payload["reasoning"] = {"effort": self.thinking_effort}
         payload.update(kwargs)
 
         content = ""
@@ -216,3 +222,10 @@ def _truncate_response(content: Any, limit: int = 1200) -> str:
     if len(text) <= limit:
         return text
     return f"{text[:limit]}...<truncated>"
+
+
+def _normalize_thinking_effort(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip().lower()
+    return value or None

--- a/shared/llm/providers/openrouter.py
+++ b/shared/llm/providers/openrouter.py
@@ -17,6 +17,7 @@ class OpenRouterClient(BaseLLMClient):
         model: str,
         provider: Dict[str, Any] = None,
         timeout_seconds: float = 60.0,
+        thinking_effort: str | None = None,
     ):
         """
         Initialize OpenRouter client.
@@ -35,6 +36,7 @@ class OpenRouterClient(BaseLLMClient):
         self.provider = provider
         self.api_url = "https://openrouter.ai/api/v1/chat/completions"
         self.timeout_seconds = float(timeout_seconds)
+        self.thinking_effort = _normalize_thinking_effort(thinking_effort)
 
     @property
     def provider_name(self) -> str:
@@ -82,6 +84,8 @@ class OpenRouterClient(BaseLLMClient):
         # Add provider routing if configured
         if self.provider:
             payload["provider"] = self.provider
+        if self.thinking_effort:
+            payload["reasoning"] = {"effort": self.thinking_effort}
 
         try:
             data = self._make_request(payload)
@@ -135,6 +139,8 @@ class OpenRouterClient(BaseLLMClient):
         # Add provider routing if configured
         if self.provider:
             payload["provider"] = self.provider
+        if self.thinking_effort:
+            payload["reasoning"] = {"effort": self.thinking_effort}
 
         try:
             data = self._make_request(payload)
@@ -209,3 +215,10 @@ def _truncate_response(content: Any, limit: int = 1200) -> str:
     if len(text) <= limit:
         return text
     return f"{text[:limit]}...<truncated>"
+
+
+def _normalize_thinking_effort(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = str(value).strip().lower()
+    return value or None

--- a/tests/shared/test_openai_responses_provider.py
+++ b/tests/shared/test_openai_responses_provider.py
@@ -71,6 +71,25 @@ def test_openai_responses_chat_omits_default_temperature(monkeypatch):
     assert "temperature" not in captured["json"]
 
 
+def test_openai_responses_chat_sends_reasoning_effort(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return _FakeResponse({"output_text": "hello"})
+
+    monkeypatch.setattr("shared.llm.providers.openai_responses.requests.post", fake_post)
+
+    client = OpenAIResponsesClient(
+        api_key="test-key",
+        model="gpt-test",
+        thinking_effort="HIGH",
+    )
+
+    assert client.chat([{"role": "user", "content": "Hello"}]) == "hello"
+    assert captured["json"]["reasoning"] == {"effort": "high"}
+
+
 def test_openai_responses_chat_extracts_typed_output(monkeypatch):
     def fake_post(url, headers, json, timeout):
         return _FakeResponse(
@@ -181,6 +200,30 @@ def test_openai_responses_structured_output_strict_opt_in(monkeypatch):
     assert captured["json"]["text"]["format"]["strict"] is False
 
 
+def test_openai_responses_structured_output_sends_reasoning_effort(monkeypatch):
+    captured = {}
+
+    def fake_post(url, headers, json, timeout):
+        captured["json"] = json
+        return _FakeResponse({"output_text": '{"answer": "yes"}'})
+
+    monkeypatch.setattr("shared.llm.providers.openai_responses.requests.post", fake_post)
+
+    client = OpenAIResponsesClient(
+        api_key="test-key",
+        model="gpt-test",
+        thinking_effort="minimal",
+    )
+
+    result = client.structured_output(
+        [{"role": "user", "content": "Return JSON"}],
+        schema={"name": "response", "type": "object"},
+    )
+
+    assert result == {"answer": "yes"}
+    assert captured["json"]["reasoning"] == {"effort": "minimal"}
+
+
 @pytest.mark.parametrize("field", ["store", "previous_response_id", "conversation"])
 def test_openai_responses_rejects_stateful_kwargs(field):
     client = OpenAIResponsesClient(api_key="test-key", model="gpt-test")
@@ -217,6 +260,7 @@ def test_openai_responses_factory_registration():
         openai_responses_timeout_seconds=5,
         openai_responses_store=True,
         openai_responses_structured_output_strict=True,
+        thinking_effort="low",
     )
 
     client = create_client(config=config)
@@ -227,7 +271,21 @@ def test_openai_responses_factory_registration():
     assert client.timeout_seconds == 5
     assert client.store is True
     assert client.structured_output_strict is True
+    assert client.thinking_effort == "low"
     assert "openai_responses" in list_providers()
+
+
+def test_openai_responses_explicit_provider_uses_openai_thinking_effort_env(monkeypatch):
+    monkeypatch.setattr("shared.llm.config._load_env_file", lambda: False)
+    monkeypatch.setenv("IMPROVEMENT_BACKEND", "openrouter")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
+    monkeypatch.setenv("OPENAI_RESPONSES_THINKING_EFFORT", "high")
+    monkeypatch.setenv("OPENROUTER_THINKING_EFFORT", "low")
+
+    client = create_client(provider="openai_responses", model="gpt-test")
+
+    assert isinstance(client, OpenAIResponsesClient)
+    assert client.thinking_effort == "high"
 
 
 def test_openai_responses_config_requires_openai_api_key():
@@ -300,4 +358,36 @@ def test_evaluator_openai_responses_adapter_passes_timeout_to_shared_client(monk
         "provider": "openai_responses",
         "model": "gpt-test",
         "config_defaults": {"timeout_seconds": 17.5},
+    }
+
+
+def test_evaluator_openai_responses_adapter_passes_thinking_effort(monkeypatch):
+    from Evaluator.config import OpenAIResponsesSettings
+    from Evaluator.shared_llm_adapters import SharedOpenAIResponsesAdapter
+
+    captured = {}
+
+    class FakeClient:
+        provider_name = "openai_responses"
+
+    def fake_create_client(provider=None, model=None, config_defaults=None):
+        captured["provider"] = provider
+        captured["model"] = model
+        captured["config_defaults"] = config_defaults
+        return FakeClient()
+
+    monkeypatch.setattr("Evaluator.shared_llm_adapters.create_client", fake_create_client)
+
+    SharedOpenAIResponsesAdapter(
+        settings=OpenAIResponsesSettings(model="gpt-test", thinking_effort="medium"),
+        timeout=17.5,
+    )
+
+    assert captured == {
+        "provider": "openai_responses",
+        "model": "gpt-test",
+        "config_defaults": {
+            "timeout_seconds": 17.5,
+            "thinking_effort": "medium",
+        },
     }

--- a/tests/shared/test_openrouter_provider.py
+++ b/tests/shared/test_openrouter_provider.py
@@ -32,3 +32,44 @@ def test_openrouter_structured_output_parse_failure_includes_raw_response():
     assert err.raw_response is not None
     assert '"environment"' in err.raw_response
     assert "Response excerpt:" in str(err)
+
+
+def test_openrouter_chat_sends_reasoning_effort_object():
+    client = OpenRouterClient(
+        api_key="test-key",
+        model="test-model",
+        thinking_effort="HIGH",
+    )
+    captured = {}
+
+    def fake_make_request(payload):
+        captured["payload"] = payload
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    client._make_request = fake_make_request  # type: ignore[method-assign]
+
+    assert client.chat([{"role": "user", "content": "Hello"}]) == "ok"
+    assert captured["payload"]["reasoning"] == {"effort": "high"}
+    assert "reasoning_effort" not in captured["payload"]
+
+
+def test_openrouter_structured_output_sends_reasoning_effort_object():
+    client = OpenRouterClient(
+        api_key="test-key",
+        model="test-model",
+        thinking_effort="minimal",
+    )
+    captured = {}
+
+    def fake_make_request(payload):
+        captured["payload"] = payload
+        return {"choices": [{"message": {"content": '{"ok": true}'}}]}
+
+    client._make_request = fake_make_request  # type: ignore[method-assign]
+
+    assert client.structured_output(
+        messages=[{"role": "user", "content": "Generate JSON"}],
+        schema={"name": "response", "type": "object"},
+    ) == {"ok": True}
+    assert captured["payload"]["reasoning"] == {"effort": "minimal"}
+    assert "reasoning_effort" not in captured["payload"]

--- a/tests/synthchat/test_llm.py
+++ b/tests/synthchat/test_llm.py
@@ -13,6 +13,7 @@ class _FakeClient:
         self._model_name = model_name
         self.provider = None
         self.timeout_seconds = 60.0
+        self.thinking_effort = None
         self.default_max_tokens = None
 
     @property
@@ -66,6 +67,10 @@ class TestLLMClientPool:
         result = LLMClientPool.normalize_stage_spec({"model": "gpt-4", "provider": "OpenRouter"})
         assert result == {"model": "gpt-4", "provider": "openrouter"}
 
+    def test_normalize_stage_spec_thinking_effort_alias(self):
+        result = LLMClientPool.normalize_stage_spec({"reasoning_effort": "high"})
+        assert result == {"thinking_effort": "high"}
+
     def test_normalize_stage_spec_empty_dict(self):
         result = LLMClientPool.normalize_stage_spec({})
         assert result is None
@@ -93,6 +98,19 @@ class TestLLMClientPool:
         c2 = pool.get_or_create({"model": "other/model"})
         assert c1 is c2
         assert len(created_clients) == 1
+
+    def test_get_or_create_passes_thinking_effort(self):
+        default = _FakeClient()
+        captured = {}
+
+        def factory(provider, model, config_defaults=None):
+            captured["config_defaults"] = config_defaults
+            return _FakeClient(provider_name=provider, model_name=model)
+
+        pool = LLMClientPool(default, client_factory=factory)
+        pool.get_or_create({"model": "other/model", "thinking_effort": "medium"})
+
+        assert captured["config_defaults"]["thinking_effort"] == "medium"
 
     def test_different_specs_create_different_clients(self):
         default = _FakeClient()


### PR DESCRIPTION
## Summary
- Add configurable thinking_effort support across OpenAI Responses and OpenRouter providers.
- Propagate thinking_effort through SynthChat and Evaluator shared LLM paths.
- Use documented OpenRouter reasoning.effort payload and OpenAI Responses reasoning.effort payload.
- Update config examples, docs, synced skill references, and focused tests.

## Validation
- python .skills/scripts/sync_skill_trees.py --check
- python -m pytest tests/shared/test_openai_responses_provider.py tests/shared/test_openrouter_provider.py tests/synthchat/test_llm.py
- Live smoke tested OpenAI Responses and OpenRouter minimal calls.