### PR TITLE
[codex] Fix KTO logging import for cloud smoke

### DIFF
--- a/.agents/skills/dataset-publishing/SKILL.md
+++ b/.agents/skills/dataset-publishing/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 # Dataset Publishing
 
 Publish a local dataset JSONL to a Hugging Face dataset repo with the skill-owned script:
-`python3 scripts/publish_dataset_to_hf.py`
+`python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py`
 
 The script accepts:
 - `dataset_path`
@@ -21,11 +21,11 @@ It also auto-uploads a matching metadata sidecar if present:
 
 | Task | Command |
 |------|---------|
-| Dry-run a dataset upload | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
-| Upload dataset + sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
-| Upload under a new repo filename | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
-| Upload with explicit metadata file | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
-| Skip metadata sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
+| Dry-run a dataset upload | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
+| Upload dataset + sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
+| Upload under a new repo filename | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
+| Upload with explicit metadata file | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
+| Skip metadata sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
 
 ## Defaults
 
@@ -45,19 +45,19 @@ It also auto-uploads a matching metadata sidecar if present:
 
 **Upload a filtered SFT dataset:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --dry-run
 
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset
 ```
 
 **Rename on upload:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --path-in-repo nonthinking_tools_sft_filtered_03.22.26.jsonl
@@ -65,7 +65,7 @@ python3 scripts/publish_dataset_to_hf.py \
 
 **Upload without a sidecar:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --no-metadata

--- a/.claude/skills/dataset-publishing/SKILL.md
+++ b/.claude/skills/dataset-publishing/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 # Dataset Publishing
 
 Publish a local dataset JSONL to a Hugging Face dataset repo with the skill-owned script:
-`python3 scripts/publish_dataset_to_hf.py`
+`python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py`
 
 The script accepts:
 - `dataset_path`
@@ -21,11 +21,11 @@ It also auto-uploads a matching metadata sidecar if present:
 
 | Task | Command |
 |------|---------|
-| Dry-run a dataset upload | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
-| Upload dataset + sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
-| Upload under a new repo filename | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
-| Upload with explicit metadata file | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
-| Skip metadata sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
+| Dry-run a dataset upload | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
+| Upload dataset + sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
+| Upload under a new repo filename | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
+| Upload with explicit metadata file | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
+| Skip metadata sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
 
 ## Defaults
 
@@ -45,19 +45,19 @@ It also auto-uploads a matching metadata sidecar if present:
 
 **Upload a filtered SFT dataset:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --dry-run
 
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset
 ```
 
 **Rename on upload:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --path-in-repo nonthinking_tools_sft_filtered_03.22.26.jsonl
@@ -65,7 +65,7 @@ python3 scripts/publish_dataset_to_hf.py \
 
 **Upload without a sidecar:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --no-metadata

--- a/.skills/dataset-publishing/SKILL.md
+++ b/.skills/dataset-publishing/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Read, Bash, Write, Grep, Glob
 # Dataset Publishing
 
 Publish a local dataset JSONL to a Hugging Face dataset repo with the skill-owned script:
-`python3 scripts/publish_dataset_to_hf.py`
+`python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py`
 
 The script accepts:
 - `dataset_path`
@@ -21,11 +21,11 @@ It also auto-uploads a matching metadata sidecar if present:
 
 | Task | Command |
 |------|---------|
-| Dry-run a dataset upload | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
-| Upload dataset + sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
-| Upload under a new repo filename | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
-| Upload with explicit metadata file | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
-| Skip metadata sidecar | `python3 scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
+| Dry-run a dataset upload | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --dry-run` |
+| Upload dataset + sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo` |
+| Upload under a new repo filename | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --path-in-repo new_name.jsonl` |
+| Upload with explicit metadata file | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --metadata-path DATASET.metadata.json` |
+| Skip metadata sidecar | `python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py DATASET.jsonl namespace/repo --no-metadata` |
 
 ## Defaults
 
@@ -45,19 +45,19 @@ It also auto-uploads a matching metadata sidecar if present:
 
 **Upload a filtered SFT dataset:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --dry-run
 
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset
 ```
 
 **Rename on upload:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --path-in-repo nonthinking_tools_sft_filtered_03.22.26.jsonl
@@ -65,7 +65,7 @@ python3 scripts/publish_dataset_to_hf.py \
 
 **Upload without a sidecar:**
 ```bash
-python3 scripts/publish_dataset_to_hf.py \
+python3 .skills/dataset-publishing/scripts/publish_dataset_to_hf.py \
   Datasets/synthchat/my_filtered_dataset.jsonl \
   professorsynapse/claudesidian-synthetic-dataset \
   --no-metadata

--- a/Trainers/dpo/README.md
+++ b/Trainers/dpo/README.md
@@ -48,8 +48,8 @@ Phase 1 pins are:
 
 | Flag | Model |
 |------|-------|
-| `--qwen3-4b` | `unsloth/Qwen3-4B-Instruct-bnb-4bit` (pilot) |
-| `--qwen3-8b` | `unsloth/Qwen3-8B-Instruct-bnb-4bit` (confirm) |
+| `--qwen3-4b` | `unsloth/Qwen3-4B-bnb-4bit` (pilot) |
+| `--qwen3-8b` | `unsloth/Qwen3-8B-bnb-4bit` (confirm) |
 
 Any model can also be set directly with `--model-name`.
 

--- a/Trainers/dpo/README.md
+++ b/Trainers/dpo/README.md
@@ -1,0 +1,80 @@
+# DPO Fine-Tuning
+
+Direct Preference Optimization (DPO) trainer, built by mirroring the KTO trainer
+(`Trainers/kto/`) so it inherits the same env bootstrap, Unsloth model loader,
+shared callbacks, cloud-artifact plumbing, and experiment tracking. DPO learns
+from explicit chosen/rejected preference pairs.
+
+## When to use DPO vs KTO
+
+| Method | Data shape | Signal |
+|--------|-----------|--------|
+| **DPO** | Paired `chosen` / `rejected` per prompt | Relative preference between two completions |
+| **KTO** | Unpaired completions with a boolean `label` | Per-completion desirable / undesirable |
+
+Use DPO when you have a clear better/worse pair for each prompt. Use KTO when you
+only have a thumbs-up / thumbs-down signal on individual completions.
+
+## Dataset format
+
+One JSON object per line, with `prompt` / `chosen` / `rejected` as message lists
+(the TRL conversational DPO convention):
+
+```jsonl
+{"prompt":[{"role":"system","content":"..."},{"role":"user","content":"<question>"}],"chosen":[{"role":"assistant","content":"<desirable>"}],"rejected":[{"role":"assistant","content":"<undesirable>"}]}
+```
+
+There is no interleaving and no label column (contrast KTO): the chosen/rejected
+pairing carries the preference signal directly.
+
+## Quick start
+
+```bash
+# Validate config + data + preset resolution without downloading a model:
+python train_dpo.py --qwen3-4b --local-file ../../path/to/dpo_train.jsonl --dry-run
+
+# Real training run (local 4B pilot):
+python train_dpo.py --qwen3-4b --local-file ../../path/to/dpo_train.jsonl
+```
+
+`--dry-run` exits before any model load (it validates config, loads and checks
+the dataset, and resolves the model preset), so it is safe to run without GPUs or
+the full ML stack.
+
+## Model presets
+
+Friendly flags resolve to `(size, hf_repo)` in `configs/model_presets.py`. The
+Phase 1 pins are:
+
+| Flag | Model |
+|------|-------|
+| `--qwen3-4b` | `unsloth/Qwen3-4B-Instruct-bnb-4bit` (pilot) |
+| `--qwen3-8b` | `unsloth/Qwen3-8B-Instruct-bnb-4bit` (confirm) |
+
+Any model can also be set directly with `--model-name`.
+
+## Config and LoRA budget
+
+`configs/config.yaml` holds the defaults; per-arm recipes live under
+`Trainers/recipes/`. The LoRA budget surface (`r`, `lora_alpha`, `lora_dropout`,
+`target_modules`, `use_rslora`, `use_dora`) is identical to the KTO and SFT
+trainers, so an experiment can pin the same budget across SFT / DPO / KTO arms.
+
+## DPO-specific config fields
+
+- `beta` — DPO KL-regularization strength (default `0.1`).
+- `loss_type` — DPO loss variant; `sigmoid` is vanilla DPO (default).
+
+The KTO-only fields (`desirable_weight`, `undesirable_weight`, `use_kto_s`) do
+not exist here.
+
+## Reference model
+
+Like KTO, DPO uses TRL's implicit (shared-weight) reference model by default to
+save VRAM. Set `USE_EXPLICIT_REF_MODEL=true` to load an explicit frozen copy.
+
+## TRL version
+
+`train_dpo.py` targets modern TRL (>=0.22.x, used by the cloud recipes), where
+`DPOTrainer` takes `processing_class=`. See `requirements.txt` for the local
+RTX-3090 baseline pin and the version note.

--- a/Trainers/dpo/configs/config.yaml
+++ b/Trainers/dpo/configs/config.yaml
@@ -1,5 +1,5 @@
 model:
-  model_name: unsloth/Qwen3-4B-Instruct-bnb-4bit
+  model_name: unsloth/Qwen3-4B-bnb-4bit
   max_seq_length: 2048
   dtype: null
   load_in_4bit: true

--- a/Trainers/dpo/configs/config.yaml
+++ b/Trainers/dpo/configs/config.yaml
@@ -1,0 +1,63 @@
+model:
+  model_name: unsloth/Qwen3-4B-Instruct-bnb-4bit
+  max_seq_length: 2048
+  dtype: null
+  load_in_4bit: true
+lora:
+  r: 32
+  lora_alpha: 64
+  lora_dropout: 0.05
+  bias: none
+  target_modules:
+  - q_proj
+  - k_proj
+  - v_proj
+  - o_proj
+  - gate_proj
+  - up_proj
+  - down_proj
+  use_gradient_checkpointing: unsloth
+  random_state: 3407
+  use_rslora: false
+  use_dora: false
+training:
+  output_dir: ./dpo_output
+  per_device_train_batch_size: 2
+  gradient_accumulation_steps: 4
+  beta: 0.1
+  loss_type: sigmoid
+  learning_rate: 5e-6
+  max_grad_norm: 0.5
+  lr_scheduler_type: cosine
+  use_two_stage_lr: false
+  lr_reduction_step: 50
+  lr_reduction_factor: 0.5
+  max_length: 2048
+  max_prompt_length: 1024
+  gradient_checkpointing: true
+  optim: adamw_8bit
+  fp16: false
+  bf16: true
+  num_train_epochs: 1
+  warmup_ratio: 0.15
+  logging_steps: 5
+  save_steps: 25
+  save_total_limit: 3
+  dataloader_num_workers: 0
+  dataloader_pin_memory: true
+  group_by_length: false
+  eval_strategy: 'no'
+  eval_steps: 100
+dataset:
+  dataset_name: null
+  dataset_file: null
+  local_file: null
+  num_proc: 1
+  test_size: 0.1
+  chat_template: chatml
+wandb:
+  enabled: false
+  project: dpo-finetuning
+  run_name: null
+  entity: null
+seed: 42

--- a/Trainers/dpo/configs/config_loader.py
+++ b/Trainers/dpo/configs/config_loader.py
@@ -1,0 +1,252 @@
+"""
+YAML Configuration Loader for DPO Training
+Loads config.yaml and converts to Python dataclass objects.
+
+Mirrors Trainers/kto/configs/config_loader.py. The only structural deltas are
+in DPOTrainingConfig (see its docstring): the KTO-specific weighting/sign fields
+are dropped and a DPO loss_type field is added. ModelConfig, LoRAConfig,
+DatasetConfig, WandbConfig, and the load/convert helpers are intentionally
+identical to the KTO loader so the two trainers expose the same config surface
+(notably the same LoRA budget knobs).
+"""
+
+import yaml
+from pathlib import Path
+from dataclasses import dataclass, field
+from typing import List, Optional, Any, Dict
+
+
+def load_yaml_config(config_path: str = None) -> Dict[str, Any]:
+    """
+    Load YAML configuration file.
+
+    Args:
+        config_path: Path to config.yaml (defaults to configs/config.yaml)
+
+    Returns:
+        Dictionary with configuration values
+    """
+    if config_path is None:
+        # Default to config.yaml in same directory as this file
+        config_path = Path(__file__).parent / "config.yaml"
+
+    with open(config_path, 'r') as f:
+        config = yaml.safe_load(f)
+
+    return config
+
+
+@dataclass
+class ModelConfig:
+    """Model configuration parameters."""
+    model_name: str
+    max_seq_length: int
+    dtype: Optional[str]
+    load_in_4bit: bool
+
+
+@dataclass
+class LoRAConfig:
+    """LoRA adapter configuration."""
+    r: int
+    lora_alpha: int
+    lora_dropout: float
+    bias: str
+    target_modules: List[str]
+    use_gradient_checkpointing: str
+    random_state: int
+    use_rslora: bool = False
+    use_dora: bool = False
+
+
+@dataclass
+class DPOTrainingConfig:
+    """DPO training configuration.
+
+    Deltas vs KTOTrainingConfig (Trainers/kto): the KTO-only fields
+    desirable_weight, undesirable_weight, and use_kto_s are removed (DPO
+    consumes paired chosen/rejected data and has no per-class weighting or
+    sign-correction variant), and loss_type is added (DPO loss variant;
+    "sigmoid" is vanilla DPO). beta is retained but is DPO's own
+    KL-regularization strength, not KTO's. Every other field (LoRA budget,
+    optim/lr/scheduler, early-stop eval fields, two-stage LR) carries over
+    unchanged so the LoRA and training budget surface matches KTO/SFT.
+    """
+    output_dir: str
+    per_device_train_batch_size: int
+    gradient_accumulation_steps: int
+    beta: float
+    loss_type: str
+    learning_rate: float
+    max_grad_norm: float
+    lr_scheduler_type: str
+    use_two_stage_lr: bool
+    lr_reduction_step: int
+    lr_reduction_factor: float
+    max_length: int
+    max_prompt_length: int
+    gradient_checkpointing: bool
+    optim: str
+    fp16: bool
+    bf16: bool
+    num_train_epochs: int
+    warmup_ratio: float
+    logging_steps: int
+    save_steps: int
+    save_total_limit: int
+    dataloader_num_workers: int
+    dataloader_pin_memory: bool
+    group_by_length: bool
+    eval_strategy: str
+    eval_steps: int
+
+
+@dataclass
+class DatasetConfig:
+    """Dataset configuration."""
+    dataset_name: str
+    dataset_file: str
+    local_file: Optional[str]
+    num_proc: int
+    test_size: float
+    chat_template: str
+
+
+@dataclass
+class WandbConfig:
+    """Weights & Biases configuration."""
+    enabled: bool
+    project: str
+    run_name: Optional[str]
+    entity: Optional[str]
+
+
+@dataclass
+class Config:
+    """Master configuration combining all sub-configs."""
+    model: ModelConfig
+    lora: LoRAConfig
+    training: DPOTrainingConfig
+    dataset: DatasetConfig
+    wandb: WandbConfig
+    seed: int = 42
+
+    @property
+    def use_wandb(self) -> bool:
+        """Backwards compatibility: access wandb.enabled as use_wandb."""
+        return self.wandb.enabled
+
+    @use_wandb.setter
+    def use_wandb(self, value: bool):
+        """Backwards compatibility: set wandb.enabled via use_wandb."""
+        self.wandb.enabled = value
+
+    @property
+    def wandb_project(self) -> Optional[str]:
+        """Backwards compatibility: access wandb.project as wandb_project."""
+        return self.wandb.project
+
+    @wandb_project.setter
+    def wandb_project(self, value: Optional[str]):
+        """Backwards compatibility: set wandb.project via wandb_project."""
+        self.wandb.project = value
+
+    @property
+    def wandb_run_name(self) -> Optional[str]:
+        """Backwards compatibility: access wandb.run_name as wandb_run_name."""
+        return self.wandb.run_name
+
+    @wandb_run_name.setter
+    def wandb_run_name(self, value: Optional[str]):
+        """Backwards compatibility: set wandb.run_name via wandb_run_name."""
+        self.wandb.run_name = value
+
+
+def dict_to_dataclass(cls, data: Dict[str, Any]):
+    """
+    Convert dictionary to dataclass instance.
+    Handles type conversion for numeric fields that might be strings.
+    """
+    import typing
+
+    fieldtypes = {f.name: f.type for f in cls.__dataclass_fields__.values()}
+    converted_data = {}
+
+    for k, v in data.items():
+        if k not in fieldtypes:
+            continue
+
+        field_type = fieldtypes[k]
+
+        # Handle Optional types
+        if hasattr(field_type, '__origin__') and field_type.__origin__ is typing.Union:
+            # Get the non-None type from Optional
+            types = [t for t in field_type.__args__ if t is not type(None)]
+            if types:
+                field_type = types[0]
+
+        # Convert strings to appropriate numeric types
+        if field_type == float and isinstance(v, str):
+            converted_data[k] = float(v)
+        elif field_type == int and isinstance(v, str):
+            converted_data[k] = int(v)
+        else:
+            converted_data[k] = v
+
+    return cls(**converted_data)
+
+
+def load_config(config_path: str = None) -> Config:
+    """
+    Load YAML config and convert to Config dataclass.
+
+    Args:
+        config_path: Path to config.yaml
+
+    Returns:
+        Config object with all settings
+    """
+    yaml_config = load_yaml_config(config_path)
+
+    # Convert each section to dataclass
+    model_config = dict_to_dataclass(ModelConfig, yaml_config['model'])
+    lora_config = dict_to_dataclass(LoRAConfig, yaml_config['lora'])
+    training_config = dict_to_dataclass(DPOTrainingConfig, yaml_config['training'])
+    dataset_config = dict_to_dataclass(DatasetConfig, yaml_config['dataset'])
+    wandb_config = dict_to_dataclass(WandbConfig, yaml_config.get('wandb', {}))
+
+    return Config(
+        model=model_config,
+        lora=lora_config,
+        training=training_config,
+        dataset=dataset_config,
+        wandb=wandb_config,
+        seed=yaml_config.get('seed', 42)
+    )
+
+
+# Backwards compatibility: Provide same function names as the KTO loader.
+def get_7b_config(config_path: str = None) -> Config:
+    """Load default 7B config from YAML."""
+    return load_config(config_path)
+
+
+def get_3b_config(config_path: str = None) -> Config:
+    """Load config and override for 3B model."""
+    config = load_config(config_path)
+    config.training.per_device_train_batch_size = 8
+    return config
+
+
+def get_13b_config(config_path: str = None) -> Config:
+    """Load config and override for 13B model."""
+    config = load_config(config_path)
+    config.training.per_device_train_batch_size = 2
+    return config
+
+
+def get_20b_config(config_path: str = None) -> Config:
+    """Load config and override for 20B model."""
+    config = load_config(config_path)
+    config.training.per_device_train_batch_size = 4
+    return config

--- a/Trainers/dpo/configs/model_presets.py
+++ b/Trainers/dpo/configs/model_presets.py
@@ -1,0 +1,58 @@
+"""
+Model preset map for the DPO trainer.
+
+DEVIATION FROM KTO (flagged): Trainers/kto/train_kto.py defines its model_map
+inline inside main(), so preset resolution cannot be exercised without importing
+the full trl/unsloth/torch stack. This module lifts the equivalent map to an
+importable, dependency-free location so a config-validation dry-run (and its
+smoke test) can resolve a friendly flag (e.g. --qwen3-4b) to a (size, repo)
+pair without loading any ML library. train_dpo.py imports MODEL_MAP /
+resolve_model_flag from here.
+
+Each entry maps a friendly argparse flag name (underscored, matching the
+store_true dest) to a (model_size, hf_repo) tuple. Qwen3-4B/8B are the Phase 1
+pins (Apache-2.0, ungated). The repo names use the unsloth bnb-4bit mirrors,
+matching the convention of every other entry in the map; CODE/operators should
+confirm the exact unsloth/Qwen3-* repo names resolve on live HF before a real
+run (model-landscape doc confirms the upstream Qwen3-4B/8B-Instruct exist).
+"""
+
+from typing import Dict, Optional, Tuple
+
+# flag_dest -> (model_size, hf_repo)
+MODEL_MAP: Dict[str, Tuple[str, str]] = {
+    # 3-4B models (fast iteration)
+    'qwen_3b': ('3b', 'unsloth/Qwen2.5-3B-Instruct-bnb-4bit'),
+    'llama_3b': ('3b', 'unsloth/Llama-3.2-3B-Instruct-bnb-4bit'),
+    'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-Instruct-bnb-4bit'),
+
+    # 7-8B models (production quality)
+    'mistral_7b': ('7b', 'unsloth/mistral-7b-v0.3-bnb-4bit'),
+    'llama_8b': ('7b', 'unsloth/llama-3.1-8b-instruct-bnb-4bit'),
+    'qwen_7b': ('7b', 'unsloth/Qwen2.5-7B-Instruct-bnb-4bit'),
+    'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-Instruct-bnb-4bit'),
+
+    # 11-14B models (advanced)
+    'llama_13b': ('13b', 'unsloth/llama-2-13b-bnb-4bit'),
+    'gemma_12b': ('13b', 'unsloth/gemma-3-12b-it-unsloth-bnb-4bit'),
+
+    # 17-24B models (very large)
+    'gpt_20b': ('20b', 'unsloth/gpt-oss-20b-unsloth-bnb-4bit'),
+    'mistral_24b': ('20b', 'unsloth/Mistral-Small-3.2-24B-Instruct-2506-unsloth-bnb-4bit'),
+}
+
+
+def resolve_model_flag(args) -> Optional[Tuple[str, str]]:
+    """Return (model_size, hf_repo) for the first set friendly flag, else None.
+
+    Args:
+        args: argparse.Namespace whose attributes match MODEL_MAP keys.
+
+    Returns:
+        (model_size, hf_repo) for the first truthy flag in MODEL_MAP order,
+        or None if no friendly flag is set (caller falls back to config / --model-name).
+    """
+    for flag, (size, model_name) in MODEL_MAP.items():
+        if getattr(args, flag, False):
+            return size, model_name
+    return None

--- a/Trainers/dpo/configs/model_presets.py
+++ b/Trainers/dpo/configs/model_presets.py
@@ -24,13 +24,13 @@ MODEL_MAP: Dict[str, Tuple[str, str]] = {
     # 3-4B models (fast iteration)
     'qwen_3b': ('3b', 'unsloth/Qwen2.5-3B-Instruct-bnb-4bit'),
     'llama_3b': ('3b', 'unsloth/Llama-3.2-3B-Instruct-bnb-4bit'),
-    'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-Instruct-bnb-4bit'),
+    'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-bnb-4bit'),
 
     # 7-8B models (production quality)
     'mistral_7b': ('7b', 'unsloth/mistral-7b-v0.3-bnb-4bit'),
     'llama_8b': ('7b', 'unsloth/llama-3.1-8b-instruct-bnb-4bit'),
     'qwen_7b': ('7b', 'unsloth/Qwen2.5-7B-Instruct-bnb-4bit'),
-    'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-Instruct-bnb-4bit'),
+    'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-bnb-4bit'),
 
     # 11-14B models (advanced)
     'llama_13b': ('13b', 'unsloth/llama-2-13b-bnb-4bit'),

--- a/Trainers/dpo/configs/tiers/quick.yaml
+++ b/Trainers/dpo/configs/tiers/quick.yaml
@@ -1,0 +1,10 @@
+# Quick tier: fast iteration for exploring ideas
+# ~5 minutes on consumer GPU, low quality but fast feedback
+r: 8
+lora_alpha: 16
+learning_rate: 5e-6
+num_train_epochs: 1
+max_steps: 200
+warmup_ratio: 0.1
+batch_size: 2
+gradient_accumulation_steps: 2

--- a/Trainers/dpo/configs/tiers/standard.yaml
+++ b/Trainers/dpo/configs/tiers/standard.yaml
@@ -1,0 +1,9 @@
+# Standard tier: current production defaults
+# ~30-60 minutes, good quality
+r: 64
+lora_alpha: 128
+learning_rate: 5e-6
+num_train_epochs: 1
+warmup_ratio: 0.15
+batch_size: 2
+gradient_accumulation_steps: 4

--- a/Trainers/dpo/configs/tiers/thorough.yaml
+++ b/Trainers/dpo/configs/tiers/thorough.yaml
@@ -1,0 +1,11 @@
+# Thorough tier: maximum quality training
+# ~2-4 hours, best results on sufficient data
+# Note: DPO uses a low LR and few epochs even at the thorough tier; only the
+# LoRA budget grows relative to standard.
+r: 128
+lora_alpha: 256
+learning_rate: 5e-6
+num_train_epochs: 1
+warmup_ratio: 0.1
+batch_size: 4
+gradient_accumulation_steps: 8

--- a/Trainers/dpo/requirements.txt
+++ b/Trainers/dpo/requirements.txt
@@ -1,0 +1,55 @@
+# RTX 3090 DPO Training Requirements - STABLE VERSIONS
+# Hardware: NVIDIA RTX 3090 (24GB, Ampere, CUDA Capability 8.6)
+# Last Updated: November 2025
+#
+# DPO/TRL VERSION NOTE: the trl==0.11.4 pin below is the local RTX-3090 stable
+# baseline (DPOTrainer takes `tokenizer=` there). train_dpo.py is written for
+# modern TRL (>=0.22.x, used by the cloud recipes under Trainers/recipes/) where
+# DPOTrainer takes `processing_class=`. For local runs on the old pin, the
+# trainer's `processing_class=tokenizer` call must be adjusted to `tokenizer=`,
+# or upgrade trl in this file to match the cloud recipes.
+
+# IMPORTANT: Do NOT install Unsloth from this file
+# Unsloth requires special installation - see setup.sh
+
+# PyTorch with CUDA 12.1 support (stable for RTX 3090)
+--extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.4.1
+torchvision==0.19.1
+torchaudio==2.4.1
+
+# Core ML libraries (tested compatible versions)
+transformers==4.45.2
+datasets==2.16.1
+accelerate==0.27.0
+
+# Quantization and LoRA
+bitsandbytes==0.43.0
+peft==0.7.1
+
+# TRL for KTO Training (compatible with transformers 4.45.2)
+trl==0.11.4
+
+# Utilities
+numpy>=1.24.0
+pandas>=2.0.0
+tqdm>=4.65.0
+
+# CRITICAL: huggingface-hub 0.25.0 required for Unsloth 2024.9 compatibility
+# DO NOT upgrade - newer versions break Unsloth due to missing _token module
+huggingface-hub==0.25.0
+
+# Additional dependencies for datasets and transformers
+tokenizers>=0.20,<0.21
+fsspec[http]>=2023.1.0,<=2023.10.0
+pyarrow>=14.0.0
+pyarrow_hotfix
+sentencepiece>=0.1.99  # Required for tokenizer
+protobuf<4.0.0  # Required by Unsloth
+
+# Optional: Weights & Biases
+# wandb>=0.16.0
+
+# Note: Flash Attention is optional but recommended
+# Install separately: MAX_JOBS=4 pip install flash-attn==2.5.9.post1 --no-build-isolation
+python-dotenv

--- a/Trainers/dpo/setup.sh
+++ b/Trainers/dpo/setup.sh
@@ -1,0 +1,244 @@
+#!/bin/bash
+# Setup script for RTX 3090 DPO Training - IMPROVED
+# Run with: bash setup.sh
+# For quick setup: bash setup.sh --quick
+# For flash-attn: bash setup.sh --with-flash-attn
+# For vision models: bash setup.sh --with-vision
+# For WebGPU/browser deployment: bash setup.sh --with-webgpu
+
+set -e  # Exit on error
+
+# Parse arguments
+QUICK_MODE=false
+INSTALL_FLASH_ATTN=false
+INSTALL_VISION=false
+INSTALL_WEBGPU=false
+for arg in "$@"; do
+    case $arg in
+        --quick)
+            QUICK_MODE=true
+            shift
+            ;;
+        --with-flash-attn)
+            INSTALL_FLASH_ATTN=true
+            shift
+            ;;
+        --with-vision)
+            INSTALL_VISION=true
+            shift
+            ;;
+        --with-webgpu)
+            INSTALL_WEBGPU=true
+            shift
+            ;;
+    esac
+done
+
+echo "=========================================="
+echo "RTX 3090 DPO Training - Setup"
+echo "=========================================="
+echo "Mode: $([ "$QUICK_MODE" = true ] && echo "Quick (no verification)" || echo "Full")"
+echo "Flash Attention: $([ "$INSTALL_FLASH_ATTN" = true ] && echo "Yes" || echo "No")"
+echo "Vision Models: $([ "$INSTALL_VISION" = true ] && echo "Yes (Qwen-VL, LLaVA, Pixtral)" || echo "No")"
+echo "WebGPU/MLC-LLM: $([ "$INSTALL_WEBGPU" = true ] && echo "Yes (browser deployment)" || echo "No")"
+echo "=========================================="
+
+# Check Python version
+echo -e "\n[1/8] Checking Python version..."
+python_version=$(python3 --version 2>&1 | awk '{print $2}')
+echo "Python version: $python_version"
+
+if ! python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 9) else 1)"; then
+    echo "ERROR: Python 3.9+ required (3.10 recommended for best compatibility)"
+    exit 1
+fi
+
+# Recommend Python 3.10 for best compatibility
+if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" 2>/dev/null; then
+    echo "WARNING: Python 3.11+ detected. Python 3.10 is recommended for best compatibility."
+    echo "Consider using: conda create -p ./venv python=3.10"
+fi
+
+echo "✓ Python version OK"
+
+# Check NVIDIA GPU
+echo -e "\n[2/8] Checking NVIDIA GPU..."
+if ! command -v nvidia-smi &> /dev/null; then
+    echo "WARNING: nvidia-smi not found. Make sure NVIDIA drivers are installed."
+    echo "Required: Driver 535+ for CUDA 12.1"
+else
+    echo "GPU Information:"
+    nvidia-smi --query-gpu=name,memory.total,driver_version,compute_cap --format=csv,noheader
+
+    # Check compute capability
+    compute_cap=$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -1)
+    if [ "$(echo "$compute_cap < 8.6" | bc -l)" -eq 1 ]; then
+        echo "WARNING: GPU compute capability $compute_cap (RTX 3090 is 8.6)"
+    fi
+
+    echo "✓ GPU detected"
+fi
+
+# Create conda environment with Python 3.10
+echo -e "\n[3/8] Creating conda environment with Python 3.10..."
+
+# Check if conda is available
+if ! command -v conda &> /dev/null; then
+    echo "ERROR: conda not found. Please install Miniconda or Anaconda."
+    echo "Download from: https://docs.conda.io/en/latest/miniconda.html"
+    exit 1
+fi
+
+# Source conda
+source ~/miniconda3/etc/profile.d/conda.sh 2>/dev/null || source ~/anaconda3/etc/profile.d/conda.sh 2>/dev/null || true
+
+if [ -d "venv" ]; then
+    echo "Virtual environment already exists"
+    read -p "Recreate it? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        rm -rf venv
+        conda create -y -p ./venv python=3.10
+        echo "✓ Conda environment recreated with Python 3.10"
+    fi
+else
+    conda create -y -p ./venv python=3.10
+    echo "✓ Conda environment created with Python 3.10"
+fi
+
+# Activate conda environment
+echo -e "\n[4/8] Activating conda environment..."
+conda activate ./venv
+echo "✓ Conda environment activated (Python $(python --version 2>&1 | awk '{print $2}'))"
+
+# Upgrade pip and install uv (required by Unsloth for GGUF conversion)
+echo -e "\n[5/8] Upgrading pip, setuptools, wheel, uv..."
+pip install --upgrade pip setuptools wheel uv -q
+echo "✓ pip upgraded to $(pip --version | awk '{print $2}')"
+echo "✓ uv installed (required for GGUF conversion)"
+
+# Install PyTorch and core dependencies
+echo -e "\n[6/8] Installing PyTorch and core dependencies..."
+echo "This may take 2-3 minutes..."
+pip install -r requirements.txt
+echo "✓ Core dependencies installed"
+
+# Verify PyTorch CUDA
+echo -e "\n[7/8] Verifying PyTorch CUDA support..."
+if python -c "import torch; assert torch.cuda.is_available(), 'CUDA not available'" 2>/dev/null; then
+    python -c "import torch; print(f'✓ PyTorch {torch.__version__} with CUDA {torch.version.cuda}')"
+    python -c "import torch; print(f'✓ GPU: {torch.cuda.get_device_name(0)}')"
+else
+    echo "✗ ERROR: PyTorch CUDA not available!"
+    echo "Troubleshooting:"
+    echo "  1. Check NVIDIA drivers: nvidia-smi"
+    echo "  2. Verify CUDA 12.1 installation"
+    echo "  3. Reinstall PyTorch: pip install torch --force-reinstall --index-url https://download.pytorch.org/whl/cu121"
+    exit 1
+fi
+
+# Install Unsloth and Xformers (special installation)
+echo -e "\n[8/8] Installing Unsloth and Xformers..."
+
+if [ "$INSTALL_VISION" = true ]; then
+    echo "Installing Unsloth (latest) with Vision Model support..."
+    echo "This includes FastVisionModel for Qwen-VL, LLaVA, Pixtral, etc."
+    pip install --upgrade unsloth unsloth_zoo
+    echo "✓ Unsloth with Vision support installed"
+else
+    echo "Installing Unsloth (latest)..."
+    pip install --upgrade unsloth
+    echo "✓ Unsloth installed"
+fi
+
+echo "Installing Xformers (attention backend)..."
+pip install --upgrade xformers
+echo "✓ Xformers installed"
+
+echo ""
+echo "NOTE: Unsloth will use Xformers for efficient attention."
+echo "Flash Attention 2 can be installed separately if needed (see below)."
+if [ "$INSTALL_VISION" = false ]; then
+    echo ""
+    echo "To add Vision Model support later, run:"
+    echo "  pip install --upgrade unsloth unsloth_zoo"
+fi
+
+# Optional: Install Flash Attention
+if [ "$INSTALL_FLASH_ATTN" = true ]; then
+    echo -e "\n[OPTIONAL] Installing Flash Attention..."
+    echo "This will take 5-10 minutes to compile..."
+
+    # Check RAM before compilation
+    total_ram=$(free -g | awk '/^Mem:/{print $2}')
+    if [ "$total_ram" -lt 32 ]; then
+        echo "WARNING: Less than 32GB RAM detected. Using MAX_JOBS=2 to limit compilation."
+        MAX_JOBS=2 pip install flash-attn==2.5.9.post1 --no-build-isolation
+    else
+        MAX_JOBS=4 pip install flash-attn==2.5.9.post1 --no-build-isolation
+    fi
+
+    echo "✓ Flash Attention installed"
+fi
+
+# Optional: Install MLC-LLM for WebGPU conversion
+if [ "$INSTALL_WEBGPU" = true ]; then
+    echo -e "\n[OPTIONAL] Installing MLC-LLM for WebGPU..."
+    echo "This enables converting models for browser deployment via WebLLM"
+
+    # Install MLC-LLM nightly (includes pre-built binaries)
+    pip install --pre mlc-llm-nightly mlc-ai-nightly -f https://mlc.ai/wheels
+
+    # Verify installation
+    if mlc_llm --help &>/dev/null; then
+        echo "✓ MLC-LLM installed"
+    else
+        echo "⚠ MLC-LLM installation may need additional setup"
+        echo "  See: https://llm.mlc.ai/docs/install/mlc_llm.html"
+    fi
+fi
+
+# Final verification (unless quick mode)
+if [ "$QUICK_MODE" = false ]; then
+    echo -e "\n=========================================="
+    echo "Running Installation Tests..."
+    echo "=========================================="
+    python test_installation.py
+fi
+
+echo ""
+echo "=========================================="
+echo "✓ Setup Complete!"
+echo "=========================================="
+echo ""
+echo "Installation Summary:"
+python -c "import torch; print(f'  PyTorch: {torch.__version__}')"
+python -c "import transformers; print(f'  Transformers: {transformers.__version__}')"
+python -c "import datasets; print(f'  Datasets: {datasets.__version__}')"
+python -c "import peft; print(f'  PEFT: {peft.__version__}')"
+python -c "import trl; print(f'  TRL: {trl.__version__}')"
+python -c "import huggingface_hub; print(f'  HuggingFace Hub: {huggingface_hub.__version__}')"
+python -c "import unsloth; print(f'  Unsloth: {getattr(unsloth, \"__version__\", \"latest\")} ✓')"
+python -c "import xformers; print(f'  Xformers: {xformers.__version__}')"
+if [ "$INSTALL_FLASH_ATTN" = true ]; then
+    python -c "import flash_attn; print(f'  Flash Attention: {flash_attn.__version__}')" 2>/dev/null || echo "  Flash Attention: ✗ Not installed"
+fi
+
+# Check vision model support
+echo ""
+echo "Vision Model Support:"
+if python -c "from unsloth import FastVisionModel" 2>/dev/null; then
+    echo "  FastVisionModel: ✓ Available (Qwen-VL, LLaVA, Pixtral supported)"
+else
+    echo "  FastVisionModel: ✗ Not available"
+    echo "  To enable: pip install --upgrade unsloth unsloth_zoo"
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. Activate environment: conda activate ./venv"
+echo "  2. Test with dry run: python train_dpo.py --qwen3-4b --dry-run"
+echo "  3. Start training: python train_dpo.py --qwen3-4b --local-file <dpo_train.jsonl>"
+echo ""
+echo "For help: python train_dpo.py --help"
+echo ""

--- a/Trainers/dpo/src/data_loader.py
+++ b/Trainers/dpo/src/data_loader.py
@@ -1,0 +1,171 @@
+"""
+Data loading and preprocessing for DPO training.
+
+Consumes the on-disk DPO preference-pair schema (one JSON object per line):
+
+    {"prompt":   [{"role": "system", "content": "..."},
+                  {"role": "user",   "content": "<question>"}],
+     "chosen":   [{"role": "assistant", "content": "<desirable completion>"}],
+     "rejected": [{"role": "assistant", "content": "<undesirable completion>"}]}
+
+This is the TRL "conversational" DPO convention (prompt/chosen/rejected as
+message lists). Unlike KTO (Trainers/kto/src/data_loader.py), DPO is PAIRED and
+unweighted, so there is NO interleaving and NO True/False label column — the
+chosen/rejected pairing carries the preference signal directly. The KTO loader's
+ChatML->prompt/completion/label transform is replaced here by a
+prompt/chosen/rejected pass-through with structural validation.
+"""
+
+from typing import Dict, List, Optional, Tuple
+from datasets import load_dataset, Dataset
+
+
+# Columns TRL's DPOTrainer expects in conversational mode.
+REQUIRED_DPO_COLUMNS = ["prompt", "chosen", "rejected"]
+
+
+def _is_message_list(value) -> bool:
+    """True if value is a non-empty list of {role, content} message dicts."""
+    if not isinstance(value, list) or not value:
+        return False
+    for msg in value:
+        if not isinstance(msg, dict):
+            return False
+        if "role" not in msg or "content" not in msg:
+            return False
+    return True
+
+
+def load_and_prepare_dataset(
+    dataset_name: Optional[str] = None,
+    data_files: Optional[str] = None,
+    local_file: Optional[str] = None,
+    num_proc: int = 1,
+    test_size: float = 0.1,
+    split_dataset: bool = False
+) -> Tuple[Dataset, Optional[Dataset]]:
+    """
+    Load and prepare a preference-pair dataset for DPO training.
+
+    Args:
+        dataset_name: HuggingFace dataset name
+        data_files: Specific file within the dataset
+        local_file: Path to local JSONL file (prompt/chosen/rejected schema)
+        num_proc: Number of processes for dataset loading (1 for Windows)
+        test_size: Fraction of data for validation
+        split_dataset: Whether to create a train/val split
+
+    Returns:
+        Tuple of (train_dataset, eval_dataset or None) with columns
+        prompt / chosen / rejected.
+    """
+    print("=" * 60)
+    print("LOADING DATASET")
+    print("=" * 60)
+
+    # Load raw dataset
+    if local_file:
+        print(f"Loading from local file: {local_file}")
+        raw_datasets = load_dataset("json", data_files=local_file, split="train")
+    elif dataset_name:
+        print(f"Loading from HuggingFace: {dataset_name}")
+        if data_files:
+            print(f"Using file: {data_files}")
+            raw_datasets = load_dataset(
+                dataset_name,
+                data_files=data_files,
+                num_proc=num_proc
+            )
+        else:
+            raw_datasets = load_dataset(dataset_name, num_proc=num_proc)
+        raw_datasets = raw_datasets["train"]
+    else:
+        raise ValueError("Must provide either dataset_name or local_file")
+
+    print(f"\nRaw dataset size: {len(raw_datasets)} examples")
+
+    # Keep only the DPO columns; drop any extras the builder may have emitted
+    # (e.g. provenance fields) so the Dataset matches what DPOTrainer expects.
+    extra_cols = [c for c in raw_datasets.column_names if c not in REQUIRED_DPO_COLUMNS]
+    if extra_cols:
+        print(f"Dropping non-DPO columns: {extra_cols}")
+        raw_datasets = raw_datasets.remove_columns(extra_cols)
+
+    train_dataset = raw_datasets
+
+    # Optional train/validation split
+    eval_dataset = None
+    if split_dataset and test_size > 0:
+        print(f"\nCreating train/validation split ({1-test_size:.0%}/{test_size:.0%})")
+        split = train_dataset.train_test_split(test_size=test_size, seed=42)
+        train_dataset = split["train"]
+        eval_dataset = split["test"]
+
+        print(f"  Training set: {len(train_dataset)} examples")
+        print(f"  Validation set: {len(eval_dataset)} examples")
+    else:
+        print(f"\nReady for training: {len(train_dataset)} examples")
+
+    print("=" * 60)
+
+    return train_dataset, eval_dataset
+
+
+def validate_dpo_dataset(dataset: Dataset) -> bool:
+    """
+    Validate that a DPO dataset has the required prompt/chosen/rejected columns
+    and that each row's values are well-formed message lists.
+
+    Args:
+        dataset: Dataset to validate
+
+    Returns:
+        True if valid, False otherwise
+    """
+    print("\nValidating DPO dataset...")
+
+    # Check required columns
+    missing_cols = [col for col in REQUIRED_DPO_COLUMNS if col not in dataset.column_names]
+    if missing_cols:
+        print(f"✗ Missing required columns: {missing_cols}")
+        return False
+
+    print(f"✓ All required columns present: {REQUIRED_DPO_COLUMNS}")
+
+    # Check each row is structurally valid (message lists, non-empty)
+    bad_prompt = 0
+    bad_chosen = 0
+    bad_rejected = 0
+    for ex in dataset:
+        if not _is_message_list(ex["prompt"]):
+            bad_prompt += 1
+        if not _is_message_list(ex["chosen"]):
+            bad_chosen += 1
+        if not _is_message_list(ex["rejected"]):
+            bad_rejected += 1
+
+    if bad_prompt or bad_chosen or bad_rejected:
+        print(f"✗ Malformed rows -> prompt: {bad_prompt}, chosen: {bad_chosen}, rejected: {bad_rejected}")
+        print("  Each of prompt/chosen/rejected must be a non-empty list of {role, content} messages.")
+        return False
+
+    print(f"✓ All {len(dataset)} rows have well-formed prompt/chosen/rejected message lists")
+    print("✓ Dataset validation passed\n")
+    return True
+
+
+def print_dataset_samples(dataset: Dataset, num_samples: int = 3):
+    """Print sample examples from the dataset."""
+    print("\nDataset samples:")
+    print("=" * 60)
+
+    for i in range(min(num_samples, len(dataset))):
+        example = dataset[i]
+        prompt_text = example["prompt"][-1]["content"] if example["prompt"] else ""
+        chosen_text = example["chosen"][-1]["content"] if example["chosen"] else ""
+        rejected_text = example["rejected"][-1]["content"] if example["rejected"] else ""
+        print(f"\nExample {i+1}:")
+        print(f"Prompt:   {prompt_text[:160]}...")
+        print(f"Chosen:   {chosen_text[:160]}...")
+        print(f"Rejected: {rejected_text[:160]}...")
+        print("-" * 60)

--- a/Trainers/dpo/src/model_loader.py
+++ b/Trainers/dpo/src/model_loader.py
@@ -1,0 +1,348 @@
+"""
+Model loading with Unsloth optimizations for RTX 3090.
+"""
+
+from unsloth import FastLanguageModel, is_bfloat16_supported
+from typing import Tuple, Optional
+import torch
+
+# Try to import FastVisionModel for VL models
+try:
+    from unsloth import FastVisionModel
+    VISION_MODEL_AVAILABLE = True
+except ImportError:
+    VISION_MODEL_AVAILABLE = False
+
+
+# Mistral-specific chat template (for models using [INST] format)
+# Official Mistral format: <s>[INST] user [/INST] assistant</s>
+# System messages are prepended before first [INST] (Mistral doesn't have native system support)
+MISTRAL_CHAT_TEMPLATE = """{{ bos_token }}{% for message in messages %}{% if message['role'] == 'system' %}{% if loop.index == 1 %}{{ message['content'] + ' ' }}{% endif %}{% elif message['role'] == 'user' %}{{ '[INST] ' + message['content'] + ' [/INST]' }}{% elif message['role'] == 'assistant' %}{{ ' ' + message['content'] + eos_token }}{% endif %}{% endfor %}"""
+
+# Generic fallback template for other models (Zephyr/ChatML style)
+DEFAULT_CHAT_TEMPLATE = """{% for message in messages %}
+{% if message['role'] == 'user' %}
+{{ '<|user|>\n' + message['content'] + eos_token }}
+{% elif message['role'] == 'system' %}
+{{ '<|system|>\n' + message['content'] + eos_token }}
+{% elif message['role'] == 'assistant' %}
+{{ '<|assistant|>\n'  + message['content'] + eos_token }}
+{% endif %}
+{% if loop.last and add_generation_prompt %}
+{{ '<|assistant|>' }}
+{% endif %}
+{% endfor %}"""
+
+
+def _is_mistral_model(model_name: str) -> bool:
+    """Detect if a model is a Mistral model based on name."""
+    model_name_lower = model_name.lower()
+    return 'mistral' in model_name_lower
+
+
+def _is_vision_model(model_name: str) -> bool:
+    """Detect if a model is a Vision-Language (VL) model based on name."""
+    model_name_lower = model_name.lower()
+    # Common VL model indicators
+    vl_indicators = ['vl', 'vision', 'qwen2-vl', 'qwen3-vl', 'llava', 'pixtral']
+    return any(indicator in model_name_lower for indicator in vl_indicators)
+
+
+def load_model_and_tokenizer(
+    model_name: str,
+    max_seq_length: int = 2048,
+    dtype: Optional[str] = None,
+    load_in_4bit: bool = True,
+    hf_token: Optional[str] = None
+) -> Tuple:
+    """
+    Load model and tokenizer with Unsloth optimizations.
+
+    Args:
+        model_name: HuggingFace model name or path
+        max_seq_length: Maximum sequence length (1024-4096)
+        dtype: Data type (None for auto-detection)
+        load_in_4bit: Whether to use 4-bit quantization
+        hf_token: HuggingFace token for gated models
+
+    Returns:
+        Tuple of (model, tokenizer)
+    """
+    print("=" * 60)
+    print("LOADING MODEL AND TEXT ENCODER")
+    print("=" * 60)
+    print(f"Model: {model_name}")
+    print(f"Max sequence length: {max_seq_length}")
+    print(f"4-bit quantization: {load_in_4bit}")
+    print(f"dtype: {dtype if dtype else 'auto-detect'}")
+
+    # Detect if this is a VL model and use appropriate loader
+    is_vl = _is_vision_model(model_name)
+
+    if is_vl and VISION_MODEL_AVAILABLE:
+        print(f"✓ Detected Vision-Language model, using FastVisionModel")
+        model, tokenizer = FastVisionModel.from_pretrained(
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            dtype=dtype,
+            load_in_4bit=load_in_4bit,
+            token=hf_token,
+        )
+    elif is_vl and not VISION_MODEL_AVAILABLE:
+        raise ImportError(
+            f"Model {model_name} appears to be a VL model but FastVisionModel is not available. "
+            "Install unsloth_zoo: pip install unsloth_zoo"
+        )
+    else:
+        # Standard language model
+        model, tokenizer = FastLanguageModel.from_pretrained(
+            model_name=model_name,
+            max_seq_length=max_seq_length,
+            dtype=dtype,
+            load_in_4bit=load_in_4bit,
+            token=hf_token,
+        )
+
+    # Verify model loaded correctly
+    print(f"\n✓ Model loaded: {model.config._name_or_path}")
+
+    # Handle VL models where tokenizer is actually a processor
+    # For DPO training with text-only data, we need the actual tokenizer, not the VL processor
+    if hasattr(tokenizer, 'tokenizer'):
+        processor_cls = type(tokenizer).__name__
+        print(f"✓ Detected VL processor ({processor_cls})")
+        print("  Extracting the text encoder for text-only DPO training...")
+        vl_processor = tokenizer
+        tokenizer = vl_processor.tokenizer
+        text_encoder_cls = type(tokenizer).__name__
+        print(f"✓ Using text encoder: {text_encoder_cls}")
+
+    # Add chat template if missing
+    if getattr(tokenizer, 'chat_template', None) is None:
+        # Detect model type and use appropriate template
+        if _is_mistral_model(model_name):
+            print("\n⚠ No chat template found, adding Mistral [INST] template")
+            tokenizer.chat_template = MISTRAL_CHAT_TEMPLATE
+            print("   Format: <s>[INST] user [/INST] assistant</s>")
+        else:
+            print("\n⚠ No chat template found, adding default template")
+            tokenizer.chat_template = DEFAULT_CHAT_TEMPLATE
+    else:
+        print("✓ Chat template already configured")
+        # Optionally display what format is being used
+        if _is_mistral_model(model_name):
+            print("   Detected Mistral model - ensure template uses [INST] format")
+
+    # Get vocab size
+    try:
+        vocab_size = len(tokenizer)
+    except TypeError:
+        vocab_size = "N/A"
+    print(f"✓ Vocab size: {vocab_size}")
+
+    # Check CUDA availability
+    if torch.cuda.is_available():
+        gpu_name = torch.cuda.get_device_name(0)
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1e9
+        print(f"✓ GPU: {gpu_name} ({gpu_memory:.1f}GB)")
+    else:
+        print("⚠ WARNING: CUDA not available!")
+
+    print("=" * 60)
+
+    return model, tokenizer
+
+
+def apply_lora_adapters(
+    model,
+    r: int = 64,
+    lora_alpha: int = 128,
+    lora_dropout: float = 0.05,
+    bias: str = "none",
+    target_modules: list = None,
+    use_gradient_checkpointing: str = "unsloth",
+    random_state: int = 3407,
+    use_rslora: bool = False,
+    use_dora: bool = False
+):
+    """
+    Apply LoRA adapters to the model using Unsloth.
+
+    Args:
+        model: Base model to add LoRA to
+        r: LoRA rank (3B: 32, 7B: 64, 20B: 128)
+        lora_alpha: LoRA alpha scaling factor (typically 2x rank)
+        lora_dropout: Dropout probability
+        bias: Bias configuration
+        target_modules: Modules to apply LoRA to
+        use_gradient_checkpointing: Gradient checkpointing mode
+        random_state: Random seed
+        use_rslora: Enable rank-stabilized LoRA scaling (recommended at r>=128)
+        use_dora: Enable Weight-Decomposed LoRA (passes through to PEFT via kwargs)
+
+    Returns:
+        Model with LoRA adapters applied
+    """
+    print("\n" + "=" * 60)
+    print("APPLYING LORA ADAPTERS")
+    print("=" * 60)
+    print(f"LoRA rank: {r}")
+    print(f"LoRA alpha: {lora_alpha}")
+    print(f"LoRA dropout: {lora_dropout}")
+    print(f"rsLoRA: {use_rslora}")
+    print(f"DoRA: {use_dora}")
+    print(f"Gradient checkpointing: {use_gradient_checkpointing}")
+
+    if target_modules is None:
+        target_modules = [
+            "q_proj", "k_proj", "v_proj", "o_proj",
+            "gate_proj", "up_proj", "down_proj"
+        ]
+
+    print(f"Target modules: {', '.join(target_modules)}")
+
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=r,
+        target_modules=target_modules,
+        lora_alpha=lora_alpha,
+        lora_dropout=lora_dropout,
+        bias=bias,
+        use_gradient_checkpointing=use_gradient_checkpointing,
+        random_state=random_state,
+        use_rslora=use_rslora,
+        use_dora=use_dora,
+    )
+
+    # Print trainable parameters
+    trainable_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total_params = sum(p.numel() for p in model.parameters())
+    trainable_pct = 100 * trainable_params / total_params
+
+    print(f"\n✓ LoRA adapters applied")
+    print(f"Trainable parameters: {trainable_params:,} ({trainable_pct:.2f}%)")
+    print(f"Total parameters: {total_params:,}")
+    print("=" * 60)
+
+    return model
+
+
+def check_gpu_memory():
+    """Print current GPU memory usage."""
+    if torch.cuda.is_available():
+        gpu_stats = torch.cuda.get_device_properties(0)
+        max_memory = round(gpu_stats.total_memory / 1024 / 1024 / 1024, 3)
+        reserved = round(torch.cuda.max_memory_reserved() / 1024 / 1024 / 1024, 3)
+
+        print("\nGPU Memory Status:")
+        print(f"  Device: {gpu_stats.name}")
+        print(f"  Total: {max_memory} GB")
+        print(f"  Reserved: {reserved} GB")
+        print(f"  Available: {max_memory - reserved} GB")
+    else:
+        print("CUDA not available")
+
+
+def create_reference_model(
+    model_name: str,
+    max_seq_length: int = 2048,
+    dtype: Optional[str] = None,
+    load_in_4bit: bool = True,
+    hf_token: Optional[str] = None
+):
+    """
+    Create a reference model for DPO training.
+
+    The reference model is a frozen copy of the base model used to compute the
+    DPO implicit-reward KL term. It should NOT have LoRA adapters applied.
+
+    Args:
+        model_name: HuggingFace model name or path
+        max_seq_length: Maximum sequence length
+        dtype: Data type (None for auto-detection)
+        load_in_4bit: Whether to use 4-bit quantization
+        hf_token: HuggingFace token for gated models
+
+    Returns:
+        Reference model (frozen, no LoRA)
+    """
+    print("\n" + "=" * 60)
+    print("CREATING REFERENCE MODEL FOR DPO")
+    print("=" * 60)
+    print(f"Model: {model_name}")
+    print("Note: Reference model will be frozen (no LoRA)")
+
+    # Load reference model (same as policy model but will stay frozen)
+    ref_model, _ = FastLanguageModel.from_pretrained(
+        model_name=model_name,
+        max_seq_length=max_seq_length,
+        dtype=dtype,
+        load_in_4bit=load_in_4bit,
+        token=hf_token,
+    )
+
+    # Freeze reference model
+    for param in ref_model.parameters():
+        param.requires_grad = False
+
+    # Set to eval mode
+    ref_model.eval()
+
+    print("✓ Reference model created and frozen")
+    print("=" * 60)
+
+    return ref_model
+
+
+def prepare_model_for_inference(model, tokenizer, chat_template: str = "chatml"):
+    """
+    Prepare model for inference by setting it to inference mode
+    and configuring the chat template.
+
+    Args:
+        model: Model to prepare
+        tokenizer: Tokenizer to configure
+        chat_template: Chat template name
+
+    Returns:
+        Tuple of (model, tokenizer)
+    """
+    from unsloth.chat_templates import get_chat_template
+
+    # Apply chat template
+    tokenizer = get_chat_template(
+        tokenizer,
+        chat_template=chat_template,
+        mapping={"role": "role", "content": "content", "user": "user", "assistant": "assistant"},
+    )
+
+    # Set model to inference mode
+    FastLanguageModel.for_inference(model)
+
+    print(f"✓ Model prepared for inference with {chat_template} template")
+
+    return model, tokenizer
+
+
+if __name__ == "__main__":
+    # Test model loading
+    print("Testing model loading...")
+
+    # Load small model for testing
+    model, tokenizer = load_model_and_tokenizer(
+        model_name="unsloth/Qwen2.5-3B-Instruct-bnb-4bit",
+        max_seq_length=1024,
+        load_in_4bit=True
+    )
+
+    # Apply LoRA
+    model = apply_lora_adapters(
+        model,
+        r=32,
+        lora_alpha=64
+    )
+
+    # Check memory
+    check_gpu_memory()
+
+    print("\n✓ Model loading test completed successfully!")

--- a/Trainers/dpo/src/training_callbacks.py
+++ b/Trainers/dpo/src/training_callbacks.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Per-trainer DPO concrete callback subclasses and re-exports.
+
+Public symbols `MetricsTableCallback`, `CheckpointMonitorCallback`,
+`LiveDashboardCallback`, `TwoStageLRCallback`, `DASHBOARD_AVAILABLE`,
+`RICH_AVAILABLE` are re-exported at their original paths. Shared lifecycle
+lives in `Trainers.shared.callbacks`.
+
+DEVIATION FROM KTO (flagged): DPO reuses KTOHealthChecker rather than adding a
+new DPOHealthChecker to the shared callbacks package. DPO and KTO both surface
+TRL preference-pair metrics under the same log keys (rewards/chosen,
+rewards/rejected, rewards/margins), so the KTO health heuristics apply
+unchanged. Keeping the reuse here (inside Trainers/dpo) avoids editing the
+shared Trainers/shared/callbacks package, which is outside this trainer's
+mirror scope.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# sys.path bootstrap is handled by Trainers/shared/callbacks/__init__.py.
+from Trainers.shared.callbacks import (
+    BaseLiveDashboardCallback,
+    BaseMetricsCallback,
+    CheckpointMonitorCallback,
+    DASHBOARD_AVAILABLE,
+    KTOHealthChecker,
+    RICH_AVAILABLE,
+    TwoStageLRCallback,
+)
+
+
+class MetricsTableCallback(BaseMetricsCallback):
+    """DPO table output: loss/LR/chosen/reject/margin/gpu/samples/eta; writes JSONL every on_log."""
+
+    default_output_dir = "./dpo_output"
+    start_banner = "TRAINING STARTED"
+    completion_banner = "TRAINING COMPLETED"
+    log_every_write = True  # DPO writes JSONL on every on_log, matching KTO.
+
+    def __init__(
+        self,
+        log_every_n_steps: int = 5,
+        output_dir: str = "./dpo_output",
+        previous_log_entries: Optional[List[Dict[str, Any]]] = None,
+    ):
+        super().__init__(
+            log_every_n_steps=log_every_n_steps,
+            output_dir=output_dir,
+            previous_log_entries=previous_log_entries,
+        )
+        # DPO shares KTO's preference-pair metric keys; reuse its health checker.
+        self.health_checker = KTOHealthChecker()
+
+    def _print_header(self):
+        print("\n" + "=" * 110)
+        print(" " * 47 + "TRAINING METRICS")
+        print("=" * 110)
+        print("   Step      |   Loss   |    LR     | Chosen | Reject | Margin | GPU Mem  | Time/5s | Samp/sec |    ETA    ")
+        print("-" * 110)
+
+    def _print_row(self, *, step, state, args, logs, capacity_snapshot, interval_time, samples_per_sec, eta, progress):
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        loss = logs.get("loss", 0.0)
+        learning_rate = logs.get("learning_rate", 0.0)
+        dpo_chosen = logs.get("rewards/chosen", 0.0)
+        dpo_rejected = logs.get("rewards/rejected", 0.0)
+        dpo_margin = logs.get("rewards/margins", 0.0)
+        print(
+            f" {progress:>12} | {loss:>8.4f} | {learning_rate:>9.2e} | "
+            f"{dpo_chosen:>6.3f} | {dpo_rejected:>6.3f} | {dpo_margin:>6.3f} | "
+            f"{gpu_mem:>8} | {interval_time:>7.1f}s | {samples_per_sec:>8.1f} | {eta:>9} "
+        )
+
+
+class LiveDashboardCallback(BaseLiveDashboardCallback):
+    """DPO live dashboard: margin + KL-with-logps-fallback."""
+
+    default_output_dir = "./dpo_output"
+    default_title = "DPO Training"
+    training_type_attr = "dpo"
+    completion_banner = "DPO TRAINING COMPLETED"
+
+    def _dashboard_metrics(self, logs, capacity_snapshot):
+        return {
+            "kl": logs.get("kl", logs.get("logps/rejected", 0)),
+            "margin": logs.get("rewards/margins"),
+        }
+
+    def _fallback_row(self, *, state, logs, capacity_snapshot):
+        loss = logs.get("loss", 0)
+        margin = logs.get("rewards/margins", 0)
+        gpu_mem_value = capacity_snapshot.get("gpu_memory_gb")
+        gpu_mem = f"{gpu_mem_value:.1f}GB" if isinstance(gpu_mem_value, (int, float)) else "N/A"
+        print(f"  Step {state.global_step}/{self.total_steps} | Loss: {loss:.4f} | Margin: {margin:.4f} | GPU: {gpu_mem}")
+
+
+__all__ = [
+    "MetricsTableCallback",
+    "LiveDashboardCallback",
+    "TwoStageLRCallback",
+    "CheckpointMonitorCallback",
+    "DASHBOARD_AVAILABLE",
+    "RICH_AVAILABLE",
+]

--- a/Trainers/dpo/train_dpo.py
+++ b/Trainers/dpo/train_dpo.py
@@ -1,0 +1,737 @@
+#!/usr/bin/env python3
+"""
+DPO Training Script (mirrors Trainers/kto/train_kto.py)
+
+Direct Preference Optimization with TRL's DPOTrainer/DPOConfig, built by
+mirroring the KTO trainer so it inherits the same env bootstrap, model loader,
+shared callbacks, cloud-artifact plumbing, and lineage/tracking. The deltas vs
+KTO are: TRL DPOConfig/DPOTrainer in place of KTOConfig/KTOTrainer; a
+prompt/chosen/rejected preference-pair data loader (no True/False interleaving);
+no KTO-S sign-correction variant and no large-vocab forward monkey-patch (both
+KTO-specific); and the DPO config surface (loss_type, no per-class weights).
+
+Usage:
+    python train_dpo.py --qwen3-4b --local-file ../../path/to/dpo_train.jsonl
+    python train_dpo.py --model-name unsloth/Qwen3-8B-Instruct-bnb-4bit --dry-run
+
+DEVIATION FROM KTO (flagged): the --dry-run exit is placed BEFORE model load
+(KTO exits after loading the model). A dry-run here validates config + data +
+preset resolution without downloading any model, which is the contract this
+trainer's smoke test relies on.
+"""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+# Add src and repo root to path before imports
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# Config + data + preset resolution are import-light (yaml/datasets only) and do
+# not pull in torch/unsloth/trl, so a --dry-run can run without the ML stack.
+from configs.config_loader import Config, load_config
+from configs.model_presets import resolve_model_flag
+from src.data_loader import (
+    load_and_prepare_dataset,
+    validate_dpo_dataset,
+    print_dataset_samples,
+)
+
+
+def setup_environment():
+    """Setup DPO-specific environment variables and print training banner."""
+    import torch
+    from unsloth import is_bfloat16_supported
+    from shared.env_bootstrap import suppress_transformers_logging
+
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+    # CUDA MEMORY OPTIMIZATION: reduce fragmentation by consolidating allocations.
+    os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"
+
+    suppress_transformers_logging()
+
+    print("=" * 60)
+    print("DPO TRAINING")
+    print("=" * 60)
+    print(f"PyTorch version: {torch.__version__}")
+    print(f"CUDA available: {torch.cuda.is_available()}")
+    if torch.cuda.is_available():
+        print(f"CUDA version: {torch.version.cuda}")
+        print(f"GPU: {torch.cuda.get_device_name(0)}")
+        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1e9
+        print(f"GPU Memory: {gpu_memory:.1f} GB")
+    print(f"BFloat16 supported: {is_bfloat16_supported()}")
+    print("=" * 60 + "\n")
+
+
+def build_training_lineage(
+    config,
+    train_dataset,
+    eval_dataset,
+    trainer,
+    run_dir: Path,
+    args: argparse.Namespace,
+    training_time_seconds: Optional[float] = None,
+    final_loss: Optional[float] = None
+) -> Dict[str, Any]:
+    """Build DPO training lineage using shared base + DPO-specific fields."""
+    import torch
+    from shared.training_utils import build_base_lineage
+    from shared.experiment_tracking.lineage_enrichment import enrich_training_lineage
+
+    dataset_source = args.local_file or config.dataset.local_file
+    if not dataset_source:
+        dataset_source = f"{config.dataset.dataset_name}/{config.dataset.dataset_file}"
+
+    lineage = build_base_lineage(
+        training_type="DPO",
+        model_info={
+            "base_model": config.model.model_name,
+            "max_seq_length": config.model.max_seq_length,
+            "load_in_4bit": config.model.load_in_4bit,
+            "dtype": str(config.model.dtype),
+        },
+        lora_info={
+            "rank": config.lora.r,
+            "alpha": config.lora.lora_alpha,
+            "dropout": config.lora.lora_dropout,
+            "target_modules": config.lora.target_modules,
+            "bias": config.lora.bias,
+        },
+        training_info={
+            "batch_size": config.training.per_device_train_batch_size,
+            "gradient_accumulation_steps": config.training.gradient_accumulation_steps,
+            "effective_batch_size": config.training.per_device_train_batch_size * config.training.gradient_accumulation_steps,
+            "learning_rate": config.training.learning_rate,
+            "num_epochs": config.training.num_train_epochs,
+            "max_steps": args.max_steps if args.max_steps else -1,
+            "warmup_ratio": config.training.warmup_ratio,
+            "lr_scheduler": config.training.lr_scheduler_type,
+            "optimizer": config.training.optim,
+            "max_grad_norm": config.training.max_grad_norm,
+            "max_length": config.training.max_length,
+            "max_prompt_length": config.training.max_prompt_length,
+            "gradient_checkpointing": config.training.gradient_checkpointing,
+            "fp16": not torch.cuda.is_bf16_supported() if config.training.fp16 is False else config.training.fp16,
+            "bf16": torch.cuda.is_bf16_supported() if config.training.bf16 is True else config.training.bf16,
+            "seed": config.seed,
+            # DPO-specific parameters
+            "beta": config.training.beta,
+            "loss_type": config.training.loss_type,
+        },
+        dataset_info={
+            "source": dataset_source,
+            "train_examples": len(train_dataset),
+            "eval_examples": len(eval_dataset) if eval_dataset else 0,
+        },
+        run_dir=run_dir,
+        trainer=trainer,
+        training_time_seconds=training_time_seconds,
+    )
+
+    if config.training.use_two_stage_lr:
+        lineage["training"]["two_stage_lr"] = {
+            "enabled": True,
+            "initial_lr": config.training.learning_rate,
+            "reduced_lr": config.training.learning_rate * config.training.lr_reduction_factor,
+            "reduction_step": config.training.lr_reduction_step,
+            "reduction_factor": config.training.lr_reduction_factor,
+        }
+
+    if final_loss is not None:
+        lineage["results"]["final_loss"] = final_loss
+
+    return enrich_training_lineage(lineage, args=args)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Construct the DPO trainer argument parser.
+
+    Factored out of main() so the CLI surface (model presets, LoRA budget knobs,
+    cloud-artifact flags) can be exercised by the dry-run smoke test without
+    importing the ML stack.
+    """
+    parser = argparse.ArgumentParser(description="DPO Training")
+
+    # Model configuration
+    parser.add_argument(
+        "--model-size",
+        type=str,
+        default=None,
+        choices=["3b", "7b", "13b", "20b", None],
+        help="Model size preset (optional - if not provided, uses config defaults)"
+    )
+    parser.add_argument(
+        "--model-name",
+        type=str,
+        help="Override model name (e.g., unsloth/Qwen3-8B-Instruct-bnb-4bit)"
+    )
+
+    # Friendly model selection shortcuts (dests match configs/model_presets.MODEL_MAP keys)
+    # 3-4B models (fast iteration)
+    parser.add_argument("--qwen-3b", action="store_true", help="Use Qwen2.5 3B Instruct (fast iteration)")
+    parser.add_argument("--llama-3b", action="store_true", help="Use Llama 3.2 3B Instruct (fast iteration)")
+    parser.add_argument("--qwen3-4b", action="store_true", help="Use Qwen3 4B Instruct (Phase 1 pilot pin)")
+
+    # 7-8B models (production quality)
+    parser.add_argument("--mistral-7b", action="store_true", help="Use Mistral 7B v0.3 (production quality)")
+    parser.add_argument("--llama-8b", action="store_true", help="Use Llama 3.1 8B Instruct")
+    parser.add_argument("--qwen-7b", action="store_true", help="Use Qwen2.5 7B Instruct")
+    parser.add_argument("--qwen3-8b", action="store_true", help="Use Qwen3 8B Instruct (Phase 1 confirm pin)")
+
+    # 11-14B models (advanced)
+    parser.add_argument("--llama-13b", action="store_true", help="Use Llama 2 13B (advanced)")
+    parser.add_argument("--gemma-12b", action="store_true", help="Use Gemma 3 12B Instruct")
+
+    # 17-24B models (very large)
+    parser.add_argument("--gpt-20b", action="store_true", help="Use GPT-OSS 20B (very large)")
+    parser.add_argument("--mistral-24b", action="store_true", help="Use Mistral Small 3.2 24B Instruct (extremely large)")
+
+    parser.add_argument("--max-seq-length", type=int, help="Override max sequence length")
+
+    # Dataset configuration
+    parser.add_argument("--dataset-name", type=str, help="HuggingFace dataset name")
+    parser.add_argument("--dataset-file", type=str, help="Dataset file within HuggingFace dataset")
+    parser.add_argument("--local-file", type=str, help="Path to local JSONL file (prompt/chosen/rejected)")
+    parser.add_argument("--split-dataset", action="store_true", help="Create train/validation split")
+
+    # Training configuration
+    parser.add_argument("--output-dir", type=str, help="Override output directory")
+    parser.add_argument("--output-root", type=str, help="Override root directory for training outputs")
+    parser.add_argument(
+        "--cloud-provider", type=str, choices=["hf_jobs", "modal", "runpod"],
+        help="Cloud provider identifier for canonical cloud run layout"
+    )
+    parser.add_argument(
+        "--artifact-backend", type=str,
+        choices=["hf_bucket", "modal_volume", "runpod_network_volume"],
+        help="Provider-native artifact backend"
+    )
+    parser.add_argument("--artifact-bucket", type=str, help="Hugging Face Bucket identifier used by HF Jobs")
+    parser.add_argument("--artifact-prefix", type=str, help="Bucket prefix for this run")
+    parser.add_argument("--publish-final-model", action="store_true", help="Publish final_model to Hugging Face Hub after training")
+    parser.add_argument("--publish-target-repo", type=str, help="Target Hugging Face model repo when publishing final_model")
+    parser.add_argument("--run-timestamp", type=str, help="Explicit run timestamp for canonical cloud run layout")
+    parser.add_argument("--batch-size", type=int, help="Override per_device_train_batch_size")
+    parser.add_argument("--gradient-accumulation", type=int, help="Override gradient_accumulation_steps")
+    parser.add_argument("--learning-rate", type=float, help="Override learning rate")
+    parser.add_argument("--beta", type=float, help="Override DPO beta parameter (controls KL regularization strength)")
+    parser.add_argument("--loss-type", type=str, help="Override DPO loss variant (default: sigmoid = vanilla DPO)")
+    parser.add_argument("--num-epochs", type=int, help="Override number of training epochs")
+    parser.add_argument("--max-steps", type=int, help="Override max training steps (takes precedence over epochs)")
+
+    # Two-stage learning rate schedule
+    parser.add_argument("--two-stage-lr", action="store_true", help="Enable two-stage learning rate schedule (reduces LR at specified step)")
+    parser.add_argument("--lr-reduction-step", type=int, default=50, help="Step at which to reduce learning rate (default: 50)")
+    parser.add_argument("--lr-reduction-factor", type=float, default=0.5, help="Factor to multiply LR by at reduction step (default: 0.5)")
+
+    # Experiment tracking
+    parser.add_argument("--wandb", action="store_true", help="Enable Weights & Biases logging")
+    parser.add_argument("--wandb-project", type=str, default="dpo-finetuning", help="W&B project name")
+    parser.add_argument("--wandb-run-name", type=str, help="W&B run name")
+
+    # LoRA technique variants (same budget surface as KTO/SFT)
+    parser.add_argument("--use-dora", action="store_true", help="Enable DoRA (Weight-Decomposed LoRA). Passes through to PEFT via Unsloth kwargs.")
+    parser.add_argument("--use-rslora", action="store_true", help="Enable rsLoRA (rank-stabilized scaling). Recommended at r>=128.")
+
+    # Tier preset
+    parser.add_argument(
+        "--tier", choices=["quick", "standard", "thorough"],
+        help="Preset complexity tier. Overrides individual LoRA/training hyperparams. "
+             "Explicit flags still override tier defaults."
+    )
+
+    # Other options
+    parser.add_argument("--hf-token", type=str, help="HuggingFace token for gated models")
+    parser.add_argument("--resume-from-checkpoint", type=str, help="Path to checkpoint directory to resume training from")
+    parser.add_argument("--dry-run", action="store_true", help="Setup and validate config/data without training (no model download)")
+    parser.add_argument("--debug", action="store_true", help="Enable detailed debug logging to diagnose freezes/hangs")
+
+    return parser
+
+
+def apply_cli_overrides(config: Config, args: argparse.Namespace) -> Config:
+    """Resolve presets and apply CLI overrides onto the loaded config.
+
+    Import-light (no ML stack) so the dry-run smoke test can verify preset
+    resolution and override precedence. Mirrors KTO's override block minus the
+    KTO-only knobs, and applies tier presets via the shared helper.
+    """
+    from shared.training_utils import apply_tier_preset
+
+    # Resolve a friendly model flag (e.g. --qwen3-4b) to (size, repo)
+    resolved = resolve_model_flag(args)
+    if resolved is not None:
+        args.model_size, args.model_name = resolved
+
+    # Tier preset (overrides base config; explicit CLI flags override tier)
+    if args.tier:
+        _dpo_tier_config_map = {
+            "r": ("lora", "r"),
+            "lora_alpha": ("lora", "lora_alpha"),
+            "use_dora": ("lora", "use_dora"),
+            "use_rslora": ("lora", "use_rslora"),
+            "target_modules": ("lora", "target_modules"),
+            "learning_rate": ("training", "learning_rate"),
+            "num_train_epochs": ("training", "num_train_epochs"),
+            "warmup_ratio": ("training", "warmup_ratio"),
+            "batch_size": ("training", "per_device_train_batch_size"),
+            "gradient_accumulation_steps": ("training", "gradient_accumulation_steps"),
+        }
+        apply_tier_preset(
+            config, args.tier, _dpo_tier_config_map, args,
+            configs_dir=Path(__file__).parent / "configs",
+        )
+
+    # LoRA technique CLI overrides (after tier, so they take precedence)
+    if args.use_dora:
+        config.lora.use_dora = True
+    if args.use_rslora:
+        config.lora.use_rslora = True
+
+    # Command-line overrides
+    if args.model_name:
+        config.model.model_name = args.model_name
+    if args.max_seq_length:
+        config.model.max_seq_length = args.max_seq_length
+        config.training.max_length = args.max_seq_length
+        config.training.max_prompt_length = args.max_seq_length // 2
+
+    if args.dataset_name:
+        config.dataset.dataset_name = args.dataset_name
+    if args.dataset_file:
+        config.dataset.dataset_file = args.dataset_file
+
+    if args.batch_size:
+        config.training.per_device_train_batch_size = args.batch_size
+    if args.gradient_accumulation:
+        config.training.gradient_accumulation_steps = args.gradient_accumulation
+    if args.learning_rate:
+        config.training.learning_rate = args.learning_rate
+    if args.beta:
+        config.training.beta = args.beta
+    if args.loss_type:
+        config.training.loss_type = args.loss_type
+    if args.num_epochs:
+        config.training.num_train_epochs = args.num_epochs
+
+    if args.two_stage_lr:
+        config.training.use_two_stage_lr = True
+    if args.lr_reduction_step:
+        config.training.lr_reduction_step = args.lr_reduction_step
+    if args.lr_reduction_factor:
+        config.training.lr_reduction_factor = args.lr_reduction_factor
+
+    return config
+
+
+def main():
+    parser = build_arg_parser()
+    args = parser.parse_args()
+
+    # Environment bootstrap — must run before importing torch/unsloth/transformers.
+    from shared.env_bootstrap import init_trainer_env
+    init_trainer_env()
+
+    setup_environment()
+
+    # Auto-setup W&B if API key present in .env
+    from shared.training_utils import setup_wandb
+    wandb_auto_enabled = setup_wandb()
+
+    print("Loading configuration from configs/config.yaml\n")
+    config = load_config()
+    config = apply_cli_overrides(config, args)
+
+    # Auto-enable W&B if API key found or --wandb flag used
+    if wandb_auto_enabled or args.wandb:
+        config.use_wandb = True
+        if args.wandb_project:
+            config.wandb_project = args.wandb_project
+        elif not getattr(config, "wandb_project", None):
+            config.wandb_project = "dpo-training"
+        if args.wandb_run_name:
+            config.wandb_run_name = args.wandb_run_name
+        elif not getattr(config, "wandb_run_name", None):
+            from datetime import datetime
+            ts = datetime.now().strftime("%Y%m%d_%H%M")
+            config.wandb_run_name = f"{args.model_size or 'dpo'}-{ts}"
+
+    if not args.hf_token:
+        args.hf_token = os.environ.get("HF_TOKEN") or os.environ.get("HF_API_KEY")
+
+    # Cloud-artifact run layout
+    from datetime import datetime
+    from shared.cloud_artifacts import build_manifest, build_run_paths, write_manifest
+
+    repo_branch = os.environ.get("CLOUD_REPO_BRANCH")
+    repo_commit = os.environ.get("CLOUD_REPO_COMMIT")
+    artifact_identifier = args.artifact_bucket or os.environ.get("CLOUD_ARTIFACT_IDENTIFIER")
+
+    timestamp = args.run_timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")
+    base_output_dir = Path(args.output_root or args.output_dir or config.training.output_dir)
+    manifest_path = None
+    run_paths = None
+    if args.cloud_provider:
+        run_paths = build_run_paths(
+            base_output_dir=base_output_dir,
+            provider=args.cloud_provider,
+            method="dpo",
+            timestamp=timestamp,
+            commit=repo_commit or "local",
+        )
+        run_dir = run_paths.run_dir
+        checkpoints_dir = run_paths.checkpoints_dir
+        logs_dir = run_paths.logs_dir
+        output_path = run_paths.final_model_dir
+        manifest_path = run_paths.manifest_path
+        for path in (run_dir, checkpoints_dir, logs_dir):
+            path.mkdir(parents=True, exist_ok=True)
+        write_manifest(
+            manifest_path,
+            build_manifest(
+                provider=args.cloud_provider,
+                method="dpo",
+                artifact_backend=args.artifact_backend or "",
+                artifact_identifier=artifact_identifier,
+                run_paths=run_paths,
+                repo_branch=repo_branch,
+                repo_commit=repo_commit,
+                publish_final_model=args.publish_final_model,
+                publish_target_repo=args.publish_target_repo,
+                status="running",
+            ),
+        )
+    else:
+        run_dir = base_output_dir / timestamp
+        checkpoints_dir = run_dir / "checkpoints"
+        logs_dir = run_dir / "logs"
+        output_path = run_dir / "final_model"
+        checkpoints_dir.mkdir(parents=True, exist_ok=True)
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+    config.training.output_dir = str(checkpoints_dir)
+    print(f"Training run directory: {run_dir}")
+    print(f"  Checkpoints: {checkpoints_dir}")
+    print(f"  Logs: {logs_dir}\n")
+
+    # Load dataset - prioritize local_file from args, then config, then HuggingFace
+    local_file_path = args.local_file or config.dataset.local_file
+    train_dataset, eval_dataset = load_and_prepare_dataset(
+        dataset_name=config.dataset.dataset_name if not local_file_path else None,
+        data_files=config.dataset.dataset_file if not local_file_path else None,
+        local_file=local_file_path,
+        num_proc=config.dataset.num_proc,
+        test_size=config.dataset.test_size,
+        split_dataset=args.split_dataset,
+    )
+
+    # Validate dataset (prompt/chosen/rejected structure). DPO is paired and
+    # unweighted, so there is no interleaving step (contrast KTO).
+    if not validate_dpo_dataset(train_dataset):
+        print("✗ Dataset validation failed. Exiting.")
+        return
+
+    print_dataset_samples(train_dataset, num_samples=2)
+
+    # Print training configuration
+    print("\n" + "=" * 60)
+    print("TRAINING CONFIGURATION")
+    print("=" * 60)
+    print(f"Model: {config.model.model_name}")
+    print(f"Output directory: {config.training.output_dir}")
+    print(f"Dataset: {len(train_dataset)} examples")
+    if eval_dataset:
+        print(f"Validation: {len(eval_dataset)} examples")
+    effective_batch = config.training.per_device_train_batch_size * config.training.gradient_accumulation_steps
+    print(f"\nBatch configuration:")
+    print(f"  Batch size: {config.training.per_device_train_batch_size}")
+    print(f"  Gradient accumulation: {config.training.gradient_accumulation_steps}")
+    print(f"  Effective batch size: {effective_batch}")
+    print(f"\nHyperparameters:")
+    print(f"  Learning rate: {config.training.learning_rate}")
+    print(f"  Beta: {config.training.beta}")
+    print(f"  Loss type: {config.training.loss_type}")
+    print(f"  Warmup ratio: {config.training.warmup_ratio}")
+    print(f"  Max length: {config.training.max_length}")
+    print(f"\nLoRA configuration:")
+    print(f"  Rank: {config.lora.r}")
+    print(f"  Alpha: {config.lora.lora_alpha}")
+    print(f"  Dropout: {config.lora.lora_dropout}")
+    print("=" * 60 + "\n")
+
+    # DEVIATION FROM KTO: exit on dry-run BEFORE any model load, so a dry-run
+    # never downloads a model. This is the smoke-test contract.
+    if args.dry_run:
+        print("✓ Dry run completed (config + data + presets validated). Exiting without model load or training.")
+        return
+
+    # ---- Heavy path: only reached for a real run (model load + training) ----
+    import torch
+    from unsloth import is_bfloat16_supported
+    from trl import DPOConfig, DPOTrainer
+
+    from src.model_loader import (
+        load_model_and_tokenizer,
+        apply_lora_adapters,
+        create_reference_model,
+        check_gpu_memory,
+    )
+    from src.training_callbacks import (
+        LiveDashboardCallback,
+        MetricsTableCallback,
+        CheckpointMonitorCallback,
+        TwoStageLRCallback,
+        DASHBOARD_AVAILABLE,
+        RICH_AVAILABLE,
+    )
+    from shared.cloud_artifacts import (
+        HFBucketSyncCallback,
+        publish_final_model_to_hub,
+        sync_directory_to_hf_bucket,
+    )
+    from shared.training_utils import (
+        extract_previous_log_entries,
+        save_training_lineage,
+    )
+
+    model, tokenizer = load_model_and_tokenizer(
+        model_name=config.model.model_name,
+        max_seq_length=config.model.max_seq_length,
+        dtype=config.model.dtype,
+        load_in_4bit=config.model.load_in_4bit,
+        hf_token=args.hf_token,
+    )
+
+    # Reference model: like KTO, default to TRL's implicit (shared-weight)
+    # reference to save VRAM; create an explicit frozen copy only when asked.
+    ref_model = None
+    if os.getenv("USE_EXPLICIT_REF_MODEL", "false").lower() == "true":
+        print("\n⚠️  Creating explicit reference model (uses extra VRAM)")
+        ref_model = create_reference_model(
+            model_name=config.model.model_name,
+            max_seq_length=config.model.max_seq_length,
+            dtype=config.model.dtype,
+            load_in_4bit=config.model.load_in_4bit,
+            hf_token=args.hf_token,
+        )
+    else:
+        print("\n✓ Using implicit reference model (TRL manages internally)")
+
+    # Apply LoRA adapters to policy model only (not reference)
+    model = apply_lora_adapters(
+        model,
+        r=config.lora.r,
+        lora_alpha=config.lora.lora_alpha,
+        lora_dropout=config.lora.lora_dropout,
+        bias=config.lora.bias,
+        target_modules=config.lora.target_modules,
+        use_gradient_checkpointing=config.lora.use_gradient_checkpointing,
+        random_state=config.lora.random_state,
+        use_rslora=config.lora.use_rslora,
+        use_dora=config.lora.use_dora,
+    )
+
+    check_gpu_memory()
+
+    training_args = DPOConfig(
+        output_dir=config.training.output_dir,
+        per_device_train_batch_size=config.training.per_device_train_batch_size,
+        gradient_accumulation_steps=config.training.gradient_accumulation_steps,
+        beta=config.training.beta,
+        loss_type=config.training.loss_type,
+        learning_rate=config.training.learning_rate,
+        max_grad_norm=config.training.max_grad_norm,
+        lr_scheduler_type=config.training.lr_scheduler_type,
+        max_length=config.training.max_length,
+        max_prompt_length=config.training.max_prompt_length,
+        gradient_checkpointing=config.training.gradient_checkpointing,
+        optim=config.training.optim,
+        fp16=not is_bfloat16_supported() if config.training.fp16 is False else config.training.fp16,
+        bf16=is_bfloat16_supported() if config.training.bf16 is True else config.training.bf16,
+        num_train_epochs=1 if args.max_steps else config.training.num_train_epochs,
+        max_steps=args.max_steps if args.max_steps else -1,
+        warmup_ratio=config.training.warmup_ratio,
+        logging_steps=config.training.logging_steps,
+        save_steps=config.training.save_steps,
+        save_total_limit=config.training.save_total_limit,
+        dataloader_num_workers=config.training.dataloader_num_workers,
+        dataloader_pin_memory=config.training.dataloader_pin_memory,
+        group_by_length=config.training.group_by_length,
+        eval_strategy=config.training.eval_strategy if eval_dataset else "no",
+        eval_steps=config.training.eval_steps if eval_dataset else None,
+        report_to="wandb" if config.use_wandb else "none",
+        run_name=config.wandb_run_name if config.use_wandb else None,
+        seed=config.seed,
+    )
+
+    previous_log_entries = None
+    if args.resume_from_checkpoint:
+        previous_log_entries = extract_previous_log_entries(args.resume_from_checkpoint)
+
+    use_dashboard = DASHBOARD_AVAILABLE and RICH_AVAILABLE
+    if use_dashboard:
+        callbacks = [
+            LiveDashboardCallback(
+                log_every_n_steps=5,
+                output_dir=str(run_dir),
+                previous_log_entries=previous_log_entries,
+            ),
+        ]
+    else:
+        callbacks = [
+            MetricsTableCallback(
+                log_every_n_steps=5,
+                output_dir=str(run_dir),
+                previous_log_entries=previous_log_entries,
+            ),
+            CheckpointMonitorCallback(),
+        ]
+    if args.artifact_backend == "hf_bucket" and args.artifact_bucket and args.artifact_prefix:
+        callbacks.append(
+            HFBucketSyncCallback(
+                run_dir=run_dir,
+                bucket_id=args.artifact_bucket,
+                prefix=args.artifact_prefix,
+                token=args.hf_token,
+                log_every_n_steps=5,
+            )
+        )
+    if config.training.use_two_stage_lr:
+        reduced_lr = config.training.learning_rate * config.training.lr_reduction_factor
+        callbacks.append(
+            TwoStageLRCallback(
+                initial_lr=config.training.learning_rate,
+                reduced_lr=reduced_lr,
+                reduction_step=config.training.lr_reduction_step,
+            )
+        )
+
+    print("Initializing DPO Trainer...")
+    trainer = DPOTrainer(
+        model=model,
+        ref_model=ref_model,
+        args=training_args,
+        processing_class=tokenizer,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        callbacks=callbacks,
+    )
+    print("✓ DPO trainer initialized with metrics tracking")
+
+    if use_dashboard:
+        from transformers.trainer_callback import PrinterCallback
+        trainer.remove_callback(PrinterCallback)
+
+    print("=" * 60)
+    if args.resume_from_checkpoint:
+        print(f"RESUMING TRAINING FROM: {args.resume_from_checkpoint}")
+    else:
+        print("STARTING TRAINING")
+    print("=" * 60 + "\n")
+
+    training_start_time = time.time()
+    final_loss = None
+    try:
+        trainer_output = trainer.train(resume_from_checkpoint=args.resume_from_checkpoint)
+        final_loss = trainer_output.training_loss
+        print("\n✓ TRAINING COMPLETED SUCCESSFULLY!")
+        print(f"Final loss: {final_loss:.4f}")
+        check_gpu_memory()
+    except Exception as e:
+        print("\n✗ TRAINING FAILED")
+        print(f"Error type: {type(e).__name__}")
+        print(f"Error message: {e}")
+        if manifest_path:
+            write_manifest(
+                manifest_path,
+                build_manifest(
+                    provider=args.cloud_provider or "local",
+                    method="dpo",
+                    artifact_backend=args.artifact_backend or "",
+                    artifact_identifier=artifact_identifier,
+                    run_paths=run_paths,
+                    repo_branch=repo_branch,
+                    repo_commit=repo_commit,
+                    publish_final_model=args.publish_final_model,
+                    publish_target_repo=args.publish_target_repo,
+                    status=f"failed: {type(e).__name__}",
+                ),
+            )
+            if args.artifact_backend == "hf_bucket" and args.artifact_bucket and args.artifact_prefix:
+                sync_directory_to_hf_bucket(run_dir, args.artifact_bucket, args.artifact_prefix, token=args.hf_token)
+        raise
+
+    print("\nSAVING MODEL")
+    model.save_pretrained(str(output_path))
+    tokenizer.save_pretrained(str(output_path))
+    print(f"✓ Model saved to: {output_path}")
+
+    training_time_seconds = time.time() - training_start_time
+
+    print("\nBuilding training lineage...")
+    lineage = build_training_lineage(
+        config=config,
+        train_dataset=train_dataset,
+        eval_dataset=eval_dataset,
+        trainer=trainer,
+        run_dir=run_dir,
+        args=args,
+        training_time_seconds=training_time_seconds,
+        final_loss=final_loss,
+    )
+    save_training_lineage(lineage, run_dir)
+
+    # Register in unified experiment tracking registry (best-effort)
+    try:
+        from shared.experiment_tracking.adapters import dpo_lineage_to_run_record
+        from shared.experiment_tracking.registry import RunRegistry
+
+        is_cloud = getattr(args, "cloud_provider", None) is not None
+        record = dpo_lineage_to_run_record(lineage, str(run_dir), cloud=is_cloud)
+        RunRegistry().register_run(record)
+        logging.getLogger(__name__).info("Run registered: %s", record.run_id)
+    except Exception as exc:
+        logging.getLogger(__name__).warning(
+            "Unified tracking registration failed (non-fatal): %s", exc
+        )
+
+    if args.artifact_backend == "hf_bucket" and args.artifact_bucket and args.artifact_prefix:
+        sync_directory_to_hf_bucket(run_dir, args.artifact_bucket, args.artifact_prefix, token=args.hf_token)
+
+    if args.publish_final_model and args.publish_target_repo:
+        if not args.hf_token:
+            raise RuntimeError("Publishing final_model requires HF_TOKEN or --hf-token.")
+        publish_final_model_to_hub(output_path, args.publish_target_repo, args.hf_token)
+
+    if manifest_path:
+        write_manifest(
+            manifest_path,
+            build_manifest(
+                provider=args.cloud_provider,
+                method="dpo",
+                artifact_backend=args.artifact_backend or "",
+                artifact_identifier=artifact_identifier,
+                run_paths=run_paths,
+                repo_branch=repo_branch,
+                repo_commit=repo_commit,
+                publish_final_model=args.publish_final_model,
+                publish_target_repo=args.publish_target_repo,
+                status="completed",
+            ),
+        )
+        if args.artifact_backend == "hf_bucket" and args.artifact_bucket and args.artifact_prefix:
+            sync_directory_to_hf_bucket(run_dir, args.artifact_bucket, args.artifact_prefix, token=args.hf_token)
+
+    print("\n" + "=" * 60)
+    print("✓ ALL DONE!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/Trainers/dpo/train_dpo.py
+++ b/Trainers/dpo/train_dpo.py
@@ -12,7 +12,7 @@ KTO-specific); and the DPO config surface (loss_type, no per-class weights).
 
 Usage:
     python train_dpo.py --qwen3-4b --local-file ../../path/to/dpo_train.jsonl
-    python train_dpo.py --model-name unsloth/Qwen3-8B-Instruct-bnb-4bit --dry-run
+    python train_dpo.py --model-name unsloth/Qwen3-8B-bnb-4bit --dry-run
 
 DEVIATION FROM KTO (flagged): the --dry-run exit is placed BEFORE model load
 (KTO exits after loading the model). A dry-run here validates config + data +
@@ -169,7 +169,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model-name",
         type=str,
-        help="Override model name (e.g., unsloth/Qwen3-8B-Instruct-bnb-4bit)"
+        help="Override model name (e.g., unsloth/Qwen3-8B-bnb-4bit)"
     )
 
     # Friendly model selection shortcuts (dests match configs/model_presets.MODEL_MAP keys)
@@ -306,7 +306,11 @@ def apply_cli_overrides(config: Config, args: argparse.Namespace) -> Config:
     # Command-line overrides
     if args.model_name:
         config.model.model_name = args.model_name
-    if args.max_seq_length:
+    # Numeric overrides use is not None so an explicit falsy value (e.g. 0) is
+    # honored instead of silently dropped to the config default — the same
+    # provenance discipline as seed/beta/lora below (a run record must never
+    # claim a value the trainer did not actually use).
+    if args.max_seq_length is not None:
         config.model.max_seq_length = args.max_seq_length
         config.training.max_length = args.max_seq_length
         config.training.max_prompt_length = args.max_seq_length // 2
@@ -316,11 +320,11 @@ def apply_cli_overrides(config: Config, args: argparse.Namespace) -> Config:
     if args.dataset_file:
         config.dataset.dataset_file = args.dataset_file
 
-    if args.batch_size:
+    if args.batch_size is not None:
         config.training.per_device_train_batch_size = args.batch_size
-    if args.gradient_accumulation:
+    if args.gradient_accumulation is not None:
         config.training.gradient_accumulation_steps = args.gradient_accumulation
-    if args.learning_rate:
+    if args.learning_rate is not None:
         config.training.learning_rate = args.learning_rate
     # is not None so seed=0 and beta=0.0 are honored, not silently swapped for the
     # config default — the handler forwards explicit zeros (provenance: no silent override).
@@ -330,7 +334,7 @@ def apply_cli_overrides(config: Config, args: argparse.Namespace) -> Config:
         config.training.beta = args.beta
     if args.loss_type:
         config.training.loss_type = args.loss_type
-    if args.num_epochs:
+    if args.num_epochs is not None:
         config.training.num_train_epochs = args.num_epochs
 
     # LoRA budget overrides. is not None so an explicit 0 (e.g. --lora-dropout 0.0)

--- a/Trainers/dpo/train_dpo.py
+++ b/Trainers/dpo/train_dpo.py
@@ -220,6 +220,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--batch-size", type=int, help="Override per_device_train_batch_size")
     parser.add_argument("--gradient-accumulation", type=int, help="Override gradient_accumulation_steps")
     parser.add_argument("--learning-rate", type=float, help="Override learning rate")
+    parser.add_argument("--seed", type=int, help="Override the training random seed (config.seed)")
     parser.add_argument("--beta", type=float, help="Override DPO beta parameter (controls KL regularization strength)")
     parser.add_argument("--loss-type", type=str, help="Override DPO loss variant (default: sigmoid = vanilla DPO)")
     parser.add_argument("--num-epochs", type=int, help="Override number of training epochs")
@@ -234,6 +235,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--wandb", action="store_true", help="Enable Weights & Biases logging")
     parser.add_argument("--wandb-project", type=str, default="dpo-finetuning", help="W&B project name")
     parser.add_argument("--wandb-run-name", type=str, help="W&B run name")
+
+    # LoRA budget (same surface as KTO/SFT, so the recipe's LoRA budget flows
+    # end-to-end rather than silently falling back to the trainer config default).
+    parser.add_argument("--lora-r", type=int, help="Override LoRA rank (config.lora.r)")
+    parser.add_argument("--lora-alpha", type=int, help="Override LoRA alpha (config.lora.lora_alpha)")
+    parser.add_argument("--lora-dropout", type=float, help="Override LoRA dropout (config.lora.lora_dropout)")
+    parser.add_argument("--lora-target-modules", type=str, help="Override LoRA target modules (comma-separated)")
+    parser.add_argument("--init-lora-weights", type=str, help="Override LoRA weight initialization scheme")
 
     # LoRA technique variants (same budget surface as KTO/SFT)
     parser.add_argument("--use-dora", action="store_true", help="Enable DoRA (Weight-Decomposed LoRA). Passes through to PEFT via Unsloth kwargs.")
@@ -313,12 +322,29 @@ def apply_cli_overrides(config: Config, args: argparse.Namespace) -> Config:
         config.training.gradient_accumulation_steps = args.gradient_accumulation
     if args.learning_rate:
         config.training.learning_rate = args.learning_rate
-    if args.beta:
+    # is not None so seed=0 and beta=0.0 are honored, not silently swapped for the
+    # config default — the handler forwards explicit zeros (provenance: no silent override).
+    if args.seed is not None:
+        config.seed = args.seed
+    if args.beta is not None:
         config.training.beta = args.beta
     if args.loss_type:
         config.training.loss_type = args.loss_type
     if args.num_epochs:
         config.training.num_train_epochs = args.num_epochs
+
+    # LoRA budget overrides. is not None so an explicit 0 (e.g. --lora-dropout 0.0)
+    # is honored, not silently dropped — the recipe's LoRA budget is the SSOT.
+    if args.lora_r is not None:
+        config.lora.r = args.lora_r
+    if args.lora_alpha is not None:
+        config.lora.lora_alpha = args.lora_alpha
+    if args.lora_dropout is not None:
+        config.lora.lora_dropout = args.lora_dropout
+    if args.lora_target_modules is not None:
+        config.lora.target_modules = [m.strip() for m in args.lora_target_modules.split(",") if m.strip()]
+    if args.init_lora_weights is not None:
+        config.lora.init_lora_weights = args.init_lora_weights
 
     if args.two_stage_lr:
         config.training.use_two_stage_lr = True

--- a/Trainers/kto/train_kto.py
+++ b/Trainers/kto/train_kto.py
@@ -326,6 +326,11 @@ def main():
         help="Override learning rate"
     )
     parser.add_argument(
+        "--seed",
+        type=int,
+        help="Override the training random seed (config.seed)"
+    )
+    parser.add_argument(
         "--beta",
         type=float,
         help="Override KTO beta parameter (controls KL divergence penalty)"
@@ -377,6 +382,14 @@ def main():
         type=str,
         help="W&B run name"
     )
+
+    # LoRA budget (same surface as DPO/SFT, so the recipe's LoRA budget flows
+    # end-to-end rather than silently falling back to the trainer config default).
+    parser.add_argument("--lora-r", type=int, help="Override LoRA rank (config.lora.r)")
+    parser.add_argument("--lora-alpha", type=int, help="Override LoRA alpha (config.lora.lora_alpha)")
+    parser.add_argument("--lora-dropout", type=float, help="Override LoRA dropout (config.lora.lora_dropout)")
+    parser.add_argument("--lora-target-modules", type=str, help="Override LoRA target modules (comma-separated)")
+    parser.add_argument("--init-lora-weights", type=str, help="Override LoRA weight initialization scheme")
 
     # LoRA technique variants
     parser.add_argument("--use-dora", action="store_true",
@@ -540,6 +553,19 @@ def main():
     if args.use_rslora:
         config.lora.use_rslora = True
 
+    # LoRA budget overrides. is not None so an explicit 0 (e.g. --lora-dropout 0.0)
+    # is honored, not silently dropped — the recipe's LoRA budget is the SSOT.
+    if args.lora_r is not None:
+        config.lora.r = args.lora_r
+    if args.lora_alpha is not None:
+        config.lora.lora_alpha = args.lora_alpha
+    if args.lora_dropout is not None:
+        config.lora.lora_dropout = args.lora_dropout
+    if args.lora_target_modules is not None:
+        config.lora.target_modules = [m.strip() for m in args.lora_target_modules.split(",") if m.strip()]
+    if args.init_lora_weights is not None:
+        config.lora.init_lora_weights = args.init_lora_weights
+
     # Apply command-line overrides
     if args.model_name:
         config.model.model_name = args.model_name
@@ -579,7 +605,11 @@ def main():
         config.training.gradient_accumulation_steps = args.gradient_accumulation
     if args.learning_rate:
         config.training.learning_rate = args.learning_rate
-    if args.beta:
+    # is not None so seed=0 and beta=0.0 are honored, not silently swapped for the
+    # config default — the handler forwards explicit zeros (provenance: no silent override).
+    if args.seed is not None:
+        config.seed = args.seed
+    if args.beta is not None:
         config.training.beta = args.beta
     if args.num_epochs:
         config.training.num_train_epochs = args.num_epochs

--- a/Trainers/kto/train_kto.py
+++ b/Trainers/kto/train_kto.py
@@ -434,13 +434,13 @@ def main():
         # 3-4B models
         'qwen_3b': ('3b', 'unsloth/Qwen2.5-3B-Instruct-bnb-4bit'),
         'llama_3b': ('3b', 'unsloth/Llama-3.2-3B-Instruct-bnb-4bit'),
-        'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-Instruct-bnb-4bit'),
+        'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-bnb-4bit'),
 
         # 7-8B models
         'mistral_7b': ('7b', 'unsloth/mistral-7b-v0.3-bnb-4bit'),
         'llama_8b': ('7b', 'unsloth/llama-3.1-8b-instruct-bnb-4bit'),
         'qwen_7b': ('7b', 'unsloth/Qwen2.5-7B-Instruct-bnb-4bit'),
-        'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-Instruct-bnb-4bit'),
+        'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-bnb-4bit'),
         'magistral': ('7b', 'unsloth/Magistral-Small-2509-unsloth-bnb-4bit'),
         'deepseek_7b': ('7b', 'unsloth/DeepSeek-R1-Distill-Qwen-7B-unsloth-bnb-4bit'),
         'qwen_vl_8b': ('7b', 'unsloth/Qwen3-VL-8B-Instruct-unsloth-bnb-4bit'),
@@ -569,7 +569,11 @@ def main():
     # Apply command-line overrides
     if args.model_name:
         config.model.model_name = args.model_name
-    if args.max_seq_length:
+    # Numeric overrides use is not None so an explicit falsy value (e.g. 0) is
+    # honored instead of silently dropped to the config default — the same
+    # provenance discipline as seed/beta/lora below (a run record must never
+    # claim a value the trainer did not actually use).
+    if args.max_seq_length is not None:
         config.model.max_seq_length = args.max_seq_length
         config.training.max_length = args.max_seq_length
         config.training.max_prompt_length = args.max_seq_length // 2
@@ -598,12 +602,13 @@ def main():
         print(f"  Effective batch size: {adaptive_settings['batch_size'] * adaptive_settings['gradient_accumulation']}")
         print(f"  Gradient checkpointing: {adaptive_settings.get('gradient_checkpointing', False)}")
         print("="*60 + "\n")
-    # Allow manual overrides even with adaptive memory
-    elif args.batch_size:
+    # Allow manual overrides even with adaptive memory (is not None so an explicit
+    # --batch-size 0 still overrides; the elif keeps adaptive-memory precedence).
+    elif args.batch_size is not None:
         config.training.per_device_train_batch_size = args.batch_size
-    if args.gradient_accumulation:
+    if args.gradient_accumulation is not None:
         config.training.gradient_accumulation_steps = args.gradient_accumulation
-    if args.learning_rate:
+    if args.learning_rate is not None:
         config.training.learning_rate = args.learning_rate
     # is not None so seed=0 and beta=0.0 are honored, not silently swapped for the
     # config default — the handler forwards explicit zeros (provenance: no silent override).
@@ -611,7 +616,7 @@ def main():
         config.seed = args.seed
     if args.beta is not None:
         config.training.beta = args.beta
-    if args.num_epochs:
+    if args.num_epochs is not None:
         config.training.num_train_epochs = args.num_epochs
 
     # Apply two-stage LR schedule overrides

--- a/Trainers/kto/train_kto.py
+++ b/Trainers/kto/train_kto.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import logging
 import os
 import sys
 import time

--- a/Trainers/kto/train_kto.py
+++ b/Trainers/kto/train_kto.py
@@ -197,14 +197,16 @@ def main():
     )
 
     # Friendly model selection shortcuts
-    # 3B models (fast iteration)
+    # 3-4B models (fast iteration)
     parser.add_argument("--qwen-3b", action="store_true", help="Use Qwen2.5 3B Instruct (fast iteration)")
     parser.add_argument("--llama-3b", action="store_true", help="Use Llama 3.2 3B Instruct (fast iteration)")
+    parser.add_argument("--qwen3-4b", action="store_true", help="Use Qwen3 4B Instruct (Phase 1 pilot pin)")
 
     # 7-8B models (production quality)
     parser.add_argument("--mistral-7b", action="store_true", help="Use Mistral 7B v0.3 (production quality)")
     parser.add_argument("--llama-8b", action="store_true", help="Use Llama 3.1 8B Instruct")
     parser.add_argument("--qwen-7b", action="store_true", help="Use Qwen2.5 7B Instruct")
+    parser.add_argument("--qwen3-8b", action="store_true", help="Use Qwen3 8B Instruct (Phase 1 confirm pin)")
     parser.add_argument("--magistral", action="store_true", help="Use Magistral Small 2509 (~7B)")
     parser.add_argument("--deepseek-7b", action="store_true", help="Use DeepSeek R1 Distill Qwen 7B (reasoning)")
     parser.add_argument("--qwen-vl-8b", action="store_true", help="Use Qwen3 VL 8B Instruct (vision-language)")
@@ -416,14 +418,16 @@ def main():
 
     # Process friendly model selection flags
     model_map = {
-        # 3B models
+        # 3-4B models
         'qwen_3b': ('3b', 'unsloth/Qwen2.5-3B-Instruct-bnb-4bit'),
         'llama_3b': ('3b', 'unsloth/Llama-3.2-3B-Instruct-bnb-4bit'),
+        'qwen3_4b': ('3b', 'unsloth/Qwen3-4B-Instruct-bnb-4bit'),
 
         # 7-8B models
         'mistral_7b': ('7b', 'unsloth/mistral-7b-v0.3-bnb-4bit'),
         'llama_8b': ('7b', 'unsloth/llama-3.1-8b-instruct-bnb-4bit'),
         'qwen_7b': ('7b', 'unsloth/Qwen2.5-7B-Instruct-bnb-4bit'),
+        'qwen3_8b': ('7b', 'unsloth/Qwen3-8B-Instruct-bnb-4bit'),
         'magistral': ('7b', 'unsloth/Magistral-Small-2509-unsloth-bnb-4bit'),
         'deepseek_7b': ('7b', 'unsloth/DeepSeek-R1-Distill-Qwen-7B-unsloth-bnb-4bit'),
         'qwen_vl_8b': ('7b', 'unsloth/Qwen3-VL-8B-Instruct-unsloth-bnb-4bit'),
@@ -1085,7 +1089,7 @@ def main():
             sync_directory_to_hf_bucket(run_dir, args.artifact_bucket, args.artifact_prefix, token=args.hf_token)
 
     print("\nTo upload to HuggingFace:")
-    print(f"  model.push_to_hub_merged('username/model-name', tokenizer, save_method='merged_16bit')")
+    print("  model.push_to_hub_merged('username/model-name', <text-encoder>, save_method='merged_16bit')")
     print(f"  # Or use: python src/upload_to_hf.py {output_path} username/model-name")
     if debugger:
         debugger.close()

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -80,6 +80,10 @@ class SFTTrainingConfig:
     group_by_length: bool
     eval_strategy: str
     eval_steps: int
+    # Generic kwargs forwarded into the tokenizer's chat template at SFT
+    # preprocessing time (e.g. {enable_thinking: false} for thinking-capable
+    # models). None ⇒ no kwargs ⇒ default rendering for every existing config.
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
 
 
 @dataclass

--- a/Trainers/sft/src/data_loader.py
+++ b/Trainers/sft/src/data_loader.py
@@ -154,6 +154,7 @@ def load_and_prepare_tokenized_dataset(
     tokenizer: Any = None,
     max_seq_length: int = 2048,
     loss_mask_mode: str = ASSISTANT_ONLY,
+    chat_template_kwargs: Optional[dict] = None,
 ) -> Tuple[Dataset, Optional[Dataset]]:
     """
     Load and prepare dataset into explicit tokenized SFT features.
@@ -209,6 +210,7 @@ def load_and_prepare_tokenized_dataset(
         loss_mask_mode=loss_mask_mode,
         num_proc=num_proc,
         include_text=False,
+        chat_template_kwargs=chat_template_kwargs,
     )
 
     eval_dataset = None

--- a/Trainers/sft/src/preprocessing.py
+++ b/Trainers/sft/src/preprocessing.py
@@ -52,6 +52,7 @@ def materialize_sft_features(
     max_seq_length: int,
     loss_mask_mode: str = ASSISTANT_ONLY,
     tool_call_mode: str = "render_text",
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> PreparedSFTExample:
     if tool_call_mode != "render_text":
         raise ValueError(f"Unsupported tool_call_mode: {tool_call_mode}")
@@ -63,6 +64,7 @@ def materialize_sft_features(
         record=record,
         max_seq_length=max_seq_length,
         assistant_only_loss=assistant_only_loss,
+        chat_template_kwargs=chat_template_kwargs,
     )
 
 
@@ -73,6 +75,7 @@ def prepare_sft_dataset(
     max_seq_length: int,
     loss_mask_mode: str = ASSISTANT_ONLY,
     backend: str = "trl_unsloth",
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> Dataset:
     del backend  # The contract is backend-agnostic; callers choose the trainer separately.
 
@@ -83,6 +86,7 @@ def prepare_sft_dataset(
             tokenizer=tokenizer,
             max_seq_length=max_seq_length,
             loss_mask_mode=loss_mask_mode,
+            chat_template_kwargs=chat_template_kwargs,
         )
         return {
             "input_ids": prepared.input_ids,
@@ -105,6 +109,7 @@ def load_and_prepare_sft_dataset(
     loss_mask_mode: str = ASSISTANT_ONLY,
     num_proc: int = 1,
     include_text: bool = False,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> Dataset:
     del num_proc
     del include_text
@@ -113,4 +118,5 @@ def load_and_prepare_sft_dataset(
         tokenizer=tokenizer,
         max_seq_length=max_seq_length,
         loss_mask_mode=loss_mask_mode,
+        chat_template_kwargs=chat_template_kwargs,
     )

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -380,6 +381,10 @@ def parse_args(argv=None):
                        help="Maximum training steps (overrides epochs)")
     parser.add_argument("--max-seq-length", type=int,
                        help="Override maximum sequence length")
+    parser.add_argument("--chat-template-kwargs", type=str, default=None,
+                       help="JSON object of kwargs forwarded into the tokenizer chat "
+                            "template at preprocessing time "
+                            "(e.g. '{\"enable_thinking\": false}').")
     parser.add_argument("--lora-r", type=int,
                        help="Override LoRA rank")
     parser.add_argument("--lora-alpha", type=int,
@@ -591,6 +596,22 @@ def run(args: argparse.Namespace):
     if args.max_seq_length is not None:
         config.training.max_seq_length = args.max_seq_length
         config.model.max_seq_length = args.max_seq_length
+    # chat_template_kwargs arrives as a JSON object string from the CLI (the
+    # recipe/handler path cannot pass a nested dict as a scalar flag). is not None
+    # so an unset flag preserves whatever the loaded config already carries.
+    if args.chat_template_kwargs is not None:
+        try:
+            parsed_chat_template_kwargs = json.loads(args.chat_template_kwargs)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"--chat-template-kwargs must be a JSON object string: {exc}"
+            ) from exc
+        if not isinstance(parsed_chat_template_kwargs, dict):
+            raise ValueError(
+                "--chat-template-kwargs must decode to a JSON object "
+                f"(got {type(parsed_chat_template_kwargs).__name__})."
+            )
+        config.training.chat_template_kwargs = parsed_chat_template_kwargs
     if args.lora_r is not None:
         config.lora.r = args.lora_r
     if args.lora_alpha is not None:
@@ -799,6 +820,7 @@ def run(args: argparse.Namespace):
         tokenizer=tokenizer,
         max_seq_length=config.training.max_seq_length,
         loss_mask_mode=loss_mask_mode,
+        chat_template_kwargs=config.training.chat_template_kwargs,
     )
     run_metadata["train_size"] = len(train_dataset)
     run_metadata["eval_size"] = len(eval_dataset) if eval_dataset else None

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -372,6 +372,8 @@ def parse_args(argv=None):
                        help="Override gradient accumulation steps")
     parser.add_argument("--learning-rate", type=float,
                        help="Override learning rate")
+    parser.add_argument("--seed", type=int,
+                       help="Override the training random seed (config.seed)")
     parser.add_argument("--num-epochs", type=int,
                        help="Override number of training epochs")
     parser.add_argument("--max-steps", type=int, default=None,
@@ -579,6 +581,9 @@ def run(args: argparse.Namespace):
         config.training.gradient_accumulation_steps = args.gradient_accumulation
     if args.learning_rate:
         config.training.learning_rate = args.learning_rate
+    # is not None so seed=0 is honored (a truthy guard would silently drop the valid seed 0)
+    if args.seed is not None:
+        config.seed = args.seed
     if args.num_epochs:
         config.training.num_train_epochs = args.num_epochs
     if args.max_seq_length:
@@ -749,7 +754,7 @@ def run(args: argparse.Namespace):
     model_name_lower = config.model.model_name.lower()
     if getattr(tokenizer, "chat_template", None):
         chat_template_name = "pretrained"
-        print("✓ Using pretrained chat template from tokenizer")
+        print("✓ Using pretrained chat template from the loaded text encoder")
     else:
         if "qwen" in model_name_lower:
             chat_template_name = "chatml"
@@ -884,7 +889,7 @@ def run(args: argparse.Namespace):
     print(f"  Alpha: {config.lora.lora_alpha}")
     print(f"  Dropout: {config.lora.lora_dropout}")
     print(f"\nSFT-specific:")
-    print("  Packing: False (explicit tokenized dataset path)")
+    print("  Packing: False (explicit pre-encoded dataset path)")
     print(f"  Completion-only loss: {config.training.completion_only_loss}")
     print(f"\nOptimizations:")
     print(f"  Optimizer: {config.training.optim}")
@@ -950,7 +955,7 @@ def run(args: argparse.Namespace):
         # Set trainer to ERROR level to suppress metrics output (we handle it in callback)
         logging.getLogger('transformers.trainer').setLevel(logging.ERROR)
 
-    print("Initializing trainer on explicit tokenized dataset...")
+    print("Initializing trainer on explicit pre-encoded dataset...")
     trainer_kwargs = {
         "model": model,
         "args": training_args,
@@ -967,7 +972,7 @@ def run(args: argparse.Namespace):
         from transformers.trainer_callback import PrinterCallback
         trainer.remove_callback(PrinterCallback)
 
-    print("[OK] Trainer initialized with explicit tokenized dataset contract")
+    print("[OK] Trainer initialized with explicit pre-encoded dataset contract")
 
     # Check if evolutionary training is enabled
     evo_wrapper = None

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -570,23 +570,25 @@ def run(args: argparse.Namespace):
             configs_dir=Path(__file__).parent / "configs",
         )
 
-    # Apply CLI overrides
-    if args.batch_size:
+    # Apply CLI overrides. Numeric overrides use is not None so an explicit falsy
+    # value (e.g. 0) is honored instead of silently dropped to the config default —
+    # the same provenance discipline as seed/save_steps/lora (a run record must
+    # never claim a value the trainer did not actually use).
+    if args.batch_size is not None:
         config.training.per_device_train_batch_size = args.batch_size
     if args.save_steps is not None:
         config.training.save_steps = args.save_steps
     if args.save_total_limit is not None:
         config.training.save_total_limit = args.save_total_limit
-    if args.gradient_accumulation:
+    if args.gradient_accumulation is not None:
         config.training.gradient_accumulation_steps = args.gradient_accumulation
-    if args.learning_rate:
+    if args.learning_rate is not None:
         config.training.learning_rate = args.learning_rate
-    # is not None so seed=0 is honored (a truthy guard would silently drop the valid seed 0)
     if args.seed is not None:
         config.seed = args.seed
-    if args.num_epochs:
+    if args.num_epochs is not None:
         config.training.num_train_epochs = args.num_epochs
-    if args.max_seq_length:
+    if args.max_seq_length is not None:
         config.training.max_seq_length = args.max_seq_length
         config.model.max_seq_length = args.max_seq_length
     if args.lora_r is not None:

--- a/shared/experiment_tracking/adapters.py
+++ b/shared/experiment_tracking/adapters.py
@@ -94,6 +94,19 @@ def kto_lineage_to_run_record(
     )
 
 
+def dpo_lineage_to_run_record(
+    lineage: dict[str, Any],
+    run_dir: str,
+    *,
+    run_id: str | None = None,
+    cloud: bool = False,
+) -> RunRecord:
+    """Convert a DPO training_lineage.json dict to a RunRecord."""
+    return _training_lineage_to_run_record(
+        lineage, run_dir, "dpo", run_id=run_id, cloud=cloud,
+    )
+
+
 def ml_tracking_to_run_record(
     tracking_data: dict[str, Any],
     run_dir: str,

--- a/shared/experiment_tracking/benchmark_ledger.py
+++ b/shared/experiment_tracking/benchmark_ledger.py
@@ -206,6 +206,56 @@ def _coerce_float(value: Any) -> Optional[float]:
         return None
 
 
+# Leading characters a spreadsheet (Excel / Google Sheets / LibreOffice) treats as
+# the start of a formula when it appears as the first character of a CSV cell. A
+# crafted cell like ``=cmd|'/c calc'!A1`` would execute on open. Tab and carriage
+# return are included because some importers strip a leading whitespace run and
+# then re-interpret the following formula trigger.
+_CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _is_numeric_string(value: str) -> bool:
+    """True if the string is a plain number (incl. a leading +/- sign).
+
+    Used to spare legitimate negative/explicitly-signed numeric cells (e.g. a
+    -0.5 loss, written as a float but read back from CSV as the string "-0.5")
+    from formula-injection neutralization — those leading +/- chars are numeric
+    signs, not formula triggers, and prefixing them would corrupt the value.
+    """
+    try:
+        float(value)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def _neutralize_csv_cell(value: Any) -> Any:
+    """Neutralize CSV formula-injection on a single cell value (OWASP guidance).
+
+    Generic, content-agnostic: any string whose first character is a spreadsheet
+    formula trigger is prefixed with a single quote so the spreadsheet renders it
+    as literal text instead of evaluating it. Two carve-outs keep the ledger's
+    numeric columns intact:
+
+    * Non-string values (ints, floats, None) are returned unchanged — they keep
+      their native type so numeric columns stay numeric.
+    * A string that is itself a plain number (e.g. "-0.5", read back from a prior
+      row by csv.DictReader) is left alone: its leading +/- is a numeric sign, not
+      a formula trigger. Without this, a round-trip upsert would corrupt a
+      negative numeric cell into "'-0.5".
+
+    Values that do not start with a trigger are returned byte-identical, so this
+    is a no-op for every well-formed cell.
+    """
+    if (
+        isinstance(value, str)
+        and value.startswith(_CSV_FORMULA_TRIGGERS)
+        and not _is_numeric_string(value)
+    ):
+        return "'" + value
+    return value
+
+
 def build_benchmark_ledger_row(
     *,
     experiment: Experiment,
@@ -341,9 +391,18 @@ def upsert_benchmark_ledger(
     if not replaced:
         existing.append({header: row.get(header, "") for header in _LEDGER_HEADERS})
 
+    # Neutralize CSV formula-injection at the write boundary so EVERY string cell
+    # across EVERY row is covered generically (notes/error text are the realistic
+    # vector, but applying it here is content-agnostic and future-proof). The
+    # dedup key column (experiment_id) is matched on the un-neutralized in-memory
+    # values ABOVE, before this pass, so neutralization never perturbs upsert
+    # matching even if a key value ever began with a trigger char.
     with ledger_path.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=_LEDGER_HEADERS)
         writer.writeheader()
-        writer.writerows(existing)
+        writer.writerows(
+            {key: _neutralize_csv_cell(value) for key, value in record.items()}
+            for record in existing
+        )
 
     return str(ledger_path)

--- a/shared/experiment_tracking/benchmark_ledger.py
+++ b/shared/experiment_tracking/benchmark_ledger.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -14,6 +15,20 @@ from .schema import LossResult, RunRecord
 
 LEDGER_CSV_RELATIVE_PATH = Path("docs/benchmarks/model_hardware_benchmark_ledger.csv")
 LEDGER_MD_RELATIVE_PATH = Path("docs/benchmarks/model_hardware_benchmark_ledger.md")
+
+# Test-isolation seam: when BENCHMARK_LEDGER_DIR is set, the ledger is written
+# under that directory instead of repo_root, so a test run can never touch the
+# committed docs/benchmarks CSV (the conftest in tests/shared/experiment_tracking
+# sets this to a tmp dir for the whole package, belt-and-suspenders alongside any
+# repo_root=tmp_path a given test already passes).
+LEDGER_DIR_ENV_VAR = "BENCHMARK_LEDGER_DIR"
+
+
+def _ledger_root(repo_root: str | Path) -> Path:
+    override = os.environ.get(LEDGER_DIR_ENV_VAR)
+    if override:
+        return Path(override)
+    return Path(repo_root)
 
 _LEDGER_HEADERS = [
     "recorded_at",
@@ -302,8 +317,7 @@ def upsert_benchmark_ledger(
     eval_payload: Optional[dict[str, Any]] = None,
     loss_results: Optional[list[LossResult]] = None,
 ) -> str:
-    repo_root = Path(repo_root)
-    ledger_path = repo_root / LEDGER_CSV_RELATIVE_PATH
+    ledger_path = _ledger_root(repo_root) / LEDGER_CSV_RELATIVE_PATH
     ledger_path.parent.mkdir(parents=True, exist_ok=True)
     row = build_benchmark_ledger_row(
         experiment=experiment,

--- a/shared/experiment_tracking/experiment_spec.py
+++ b/shared/experiment_tracking/experiment_spec.py
@@ -34,6 +34,8 @@ class TrainingStageSpec:
     batch_size: Optional[int] = None
     gradient_accumulation: Optional[int] = None
     learning_rate: Optional[float] = None
+    seed: Optional[int] = None
+    beta: Optional[float] = None
     num_epochs: Optional[int] = None
     max_steps: Optional[int] = None
     max_seq_length: Optional[int] = None
@@ -206,7 +208,7 @@ class ExperimentSpec:
             issues.append("experiment.name is required")
         if self.provider not in {"hf_jobs", "modal", "runpod", "local"}:
             issues.append(f"unsupported provider '{self.provider}'")
-        if self.method not in {"sft", "kto", "grpo"}:
+        if self.method not in {"sft", "kto", "grpo", "dpo"}:
             issues.append(f"unsupported method '{self.method}'")
         if not self.dataset.source:
             issues.append("experiment.dataset.source is required")

--- a/shared/sft_preprocessing.py
+++ b/shared/sft_preprocessing.py
@@ -114,7 +114,15 @@ def materialize_sft_example(
     max_seq_length: int,
     assistant_only_loss: bool,
     source_hash: str | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ) -> PreparedSFTExample:
+    # chat_template_kwargs is forwarded verbatim into apply_chat_template (e.g.
+    # {"enable_thinking": False} for thinking-capable models). Default None ⇒ empty
+    # dict ⇒ byte-identical rendering for callers that pass nothing. HF tokenizers
+    # forward unrecognized keys into the Jinja context and ignore them, so this is
+    # safe for any chat template that does not reference the supplied keys.
+    template_kwargs = chat_template_kwargs or {}
+
     messages, example_format = normalize_sft_messages(record)
     messages = sanitize_messages_for_chat_template(messages)
 
@@ -129,6 +137,7 @@ def materialize_sft_example(
         messages,
         tokenize=False,
         add_generation_prompt=False,
+        **template_kwargs,
     )
     full_tokens = _encoder.encode(full_str, add_special_tokens=False)
     truncation_applied = len(full_tokens) > max_seq_length
@@ -142,6 +151,7 @@ def materialize_sft_example(
             messages[:-1],
             tokenize=False,
             add_generation_prompt=True,
+            **template_kwargs,
         )
         prompt_tokens = _encoder.encode(prompt_str, add_special_tokens=False)
         mask_len = min(len(prompt_tokens), len(labels))

--- a/shared/utilities/paths.py
+++ b/shared/utilities/paths.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 
-TRAINING_METHODS = ("sft", "kto", "grpo")
+TRAINING_METHODS = ("sft", "kto", "grpo", "dpo")
 
 CANONICAL_TRAINER_DIRS = {method: method for method in TRAINING_METHODS}
 LEGACY_TRAINER_DIRS = {method: f"rtx3090_{method}" for method in TRAINING_METHODS}

--- a/tests/cli/test_local_run_handler.py
+++ b/tests/cli/test_local_run_handler.py
@@ -1,3 +1,4 @@
+import json
 from argparse import Namespace
 
 import yaml
@@ -227,3 +228,36 @@ def test_local_run_rejects_unregistered_method(tmp_path):
             tmp_path, method="grpo", trainer="Trainers/grpo/train_grpo.py",
             training={"max_steps": 1},
         )
+
+
+def test_local_run_sft_serializes_chat_template_kwargs_as_json(tmp_path):
+    # chat_template_kwargs is a nested mapping, so it cannot ride the scalar
+    # _append_flag path; the handler JSON-encodes it onto --chat-template-kwargs.
+    # The trainer parses the JSON back into config.training.chat_template_kwargs.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "chat_template_kwargs": {"enable_thinking": False}},
+    )
+    assert "--chat-template-kwargs" in command
+    payload = command[command.index("--chat-template-kwargs") + 1]
+    assert json.loads(payload) == {"enable_thinking": False}
+
+
+def test_local_run_sft_omits_chat_template_kwargs_when_absent(tmp_path):
+    # Byte-identical for recipes that do not set the key: no flag emitted.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1},
+    )
+    assert "--chat-template-kwargs" not in command
+
+
+def test_local_run_dpo_omits_chat_template_kwargs(tmp_path):
+    # --chat-template-kwargs is sft-only: the dpo/kto trainers template internally
+    # via TRL and expose no such flag, so a stray key in a dpo recipe must not be
+    # forwarded (argparse would reject it).
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "beta": 0.05, "chat_template_kwargs": {"enable_thinking": False}},
+    )
+    assert "--chat-template-kwargs" not in command

--- a/tests/cli/test_local_run_handler.py
+++ b/tests/cli/test_local_run_handler.py
@@ -36,3 +36,194 @@ def test_local_run_sft_config_compiles_repo_relative_dataset(tmp_path):
     local_file_index = plan["command"].index("--local-file") + 1
     assert plan["command"][local_file_index].startswith("../../")
     assert plan["host_artifact_path"].name == "unit"
+
+
+def _compile_local_command(tmp_path, *, method, trainer, training, lora=None):
+    """Compile a local-docker recipe and return the built trainer command list."""
+    dataset = tmp_path / "data.jsonl"
+    dataset.write_text('{"conversations":[]}\n', encoding="utf-8")
+    config = tmp_path / "job.yaml"
+    recipe = {
+        "name": "unit-local",
+        "provider": "local_docker",
+        "job": {"transfer": "copy"},
+        "run": {"method": method, "trainer": trainer},
+        "model": {"name": "Qwen/Qwen3.5-2B", "load_in_4bit": False},
+        "dataset": {"local_file": str(dataset)},
+        "training": training,
+        "artifacts": {
+            "output_root": "toolset-training-artifacts/runs/local_docker/unit",
+            "run_timestamp": "unit",
+        },
+    }
+    if lora is not None:
+        recipe["lora"] = lora
+    config.write_text(yaml.safe_dump(recipe), encoding="utf-8")
+    handler = LocalRunHandler(args=Namespace(json=True, job_config=str(config)))
+    plan = handler._compile(config, handler._load_yaml(config))
+    return plan["command"]
+
+
+def test_local_run_forwards_seed(tmp_path):
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "seed": 1234},
+    )
+    assert "--seed" in command
+    assert command[command.index("--seed") + 1] == "1234"
+
+
+def test_local_run_forwards_seed_zero(tmp_path):
+    # seed=0 must survive forwarding; _append_flag skips only None, not falsy 0.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "seed": 0},
+    )
+    assert "--seed" in command
+    assert command[command.index("--seed") + 1] == "0"
+
+
+def test_local_run_omits_seed_when_absent(tmp_path):
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1},
+    )
+    assert "--seed" not in command
+
+
+def test_local_run_omits_beta_for_sft(tmp_path):
+    # beta is gated to dpo/kto; the SFT trainer has no --beta flag, so a stray beta
+    # in an sft recipe must not be forwarded as a command argument.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "beta": 0.5},
+    )
+    assert "--beta" not in command
+
+
+# Run-control flags with no experimental meaning that dpo/kto do not expose as CLI
+# args. The handler gates these to sft so dpo/kto commands omit them (scope v2 (A)).
+RUN_CONTROL_SFT_ONLY_FLAGS = (
+    "--save-steps",
+    "--save-total-limit",
+    "--load-in-4bit",
+    "--no-load-in-4bit",
+    "--no-dashboard",
+    "--quiet",
+)
+
+# LoRA budget flags that now have parity on all three trainers (scope v2 (B)). The
+# recipe's LoRA budget is load-bearing (the identical-budget confound control), so
+# these MUST flow to dpo/kto, not be gated.
+LORA_PARITY_FLAGS = (
+    "--lora-r",
+    "--lora-alpha",
+    "--lora-dropout",
+    "--lora-target-modules",
+)
+
+_LORA_BLOCK = {"r": 64, "alpha": 128, "dropout": 0.05, "target_modules": ["q_proj", "v_proj"]}
+
+
+def test_local_run_dispatches_dpo_method(tmp_path):
+    # local-run dispatches dpo through the generic builder (no longer SFT-only).
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "seed": 7, "beta": 0.05},
+    )
+    assert command[:2] == ["python", "train_dpo.py"]
+    assert command[command.index("--seed") + 1] == "7"
+    assert command[command.index("--beta") + 1] == "0.05"
+
+
+def test_local_run_dispatches_kto_method(tmp_path):
+    command = _compile_local_command(
+        tmp_path, method="kto", trainer="Trainers/kto/train_kto.py",
+        training={"max_steps": 1, "seed": 7, "beta": 0.5},
+    )
+    assert command[:2] == ["python", "train_kto.py"]
+    assert command[command.index("--seed") + 1] == "7"
+    assert command[command.index("--beta") + 1] == "0.5"
+
+
+def test_local_run_dpo_omits_run_control_flags(tmp_path):
+    # Run-control flags (dashboard/quiet/save/4bit) have no experimental meaning and
+    # the dpo trainer's argparse rejects them, so a dpo command must omit them.
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "seed": 7, "beta": 0.05, "save_steps": 50},
+        lora=_LORA_BLOCK,
+    )
+    for flag in RUN_CONTROL_SFT_ONLY_FLAGS:
+        assert flag not in command, f"dpo command leaked run-control flag {flag}"
+
+
+def test_local_run_dpo_carries_lora_budget(tmp_path):
+    # The LoRA budget is load-bearing (identical-budget confound control): a dpo
+    # recipe's lora block MUST flow to the trainer, not silently fall back to the
+    # trainer config default. Verified end-to-end via the parity CLI flags.
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "seed": 7, "beta": 0.05},
+        lora=_LORA_BLOCK,
+    )
+    for flag in LORA_PARITY_FLAGS:
+        assert flag in command, f"dpo command dropped load-bearing LoRA flag {flag}"
+    assert command[command.index("--lora-r") + 1] == "64"
+    assert command[command.index("--lora-alpha") + 1] == "128"
+    assert command[command.index("--lora-target-modules") + 1] == "q_proj,v_proj"
+
+
+def test_local_run_kto_carries_lora_budget(tmp_path):
+    command = _compile_local_command(
+        tmp_path, method="kto", trainer="Trainers/kto/train_kto.py",
+        training={"max_steps": 1, "seed": 7, "beta": 0.5},
+        lora=_LORA_BLOCK,
+    )
+    assert command[command.index("--lora-r") + 1] == "64"
+    assert command[command.index("--lora-alpha") + 1] == "128"
+
+
+def test_local_run_sft_still_emits_its_flags(tmp_path):
+    # The sft path is byte-unchanged: it still receives the gated run-control flags.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "save_steps": 50},
+    )
+    assert "--quiet" in command
+    assert "--no-dashboard" in command
+    assert "--save-steps" in command
+
+
+def test_local_run_forwards_beta_zero_for_dpo(tmp_path):
+    # beta uses is-not-None semantics (mirroring --seed): an explicit beta: 0.0 is
+    # honored, not silently dropped to the trainer default. (Provenance: matrix
+    # never uses 0, but a silent swap is the cardinal sin this guards against.)
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "beta": 0.0},
+    )
+    assert "--beta" in command
+    assert command[command.index("--beta") + 1] == "0.0"
+
+
+def test_local_run_omits_beta_when_absent_for_dpo(tmp_path):
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "seed": 7},
+    )
+    assert "--beta" not in command
+
+
+def test_local_run_rejects_unregistered_method(tmp_path):
+    # The dispatch guard still rejects methods outside {sft, dpo, kto} (absent an
+    # explicit run.command), rather than silently building a command.
+    import pytest
+
+    from tuner.handlers.local_run_handler import LocalRunError
+
+    with pytest.raises(LocalRunError):
+        _compile_local_command(
+            tmp_path, method="grpo", trainer="Trainers/grpo/train_grpo.py",
+            training={"max_steps": 1},
+        )

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -63,7 +63,7 @@ class TestHFJobsBackendProperties:
 
     def test_available_methods(self, repo_root):
         backend = HFJobsBackend(repo_root)
-        assert backend.get_available_methods() == ["sft", "kto", "grpo"]
+        assert backend.get_available_methods() == ["sft", "kto", "grpo", "dpo"]
 
 
 class TestHFJobsValidateEnvironment:
@@ -157,7 +157,7 @@ class TestHFJobsLoadConfig:
     def test_raises_on_unknown_method(self, repo_root):
         backend = HFJobsBackend(repo_root)
         with pytest.raises(ConfigurationError, match="Unknown method"):
-            backend.load_config("dpo")
+            backend.load_config("orpo")
 
     def test_raises_on_missing_config(self, tmp_path):
         backend = HFJobsBackend(tmp_path)

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -478,6 +478,56 @@ class TestBuildTrainingCommand:
 
         assert "--beta" not in cmd
 
+    def test_command_includes_chat_template_kwargs_for_sft(self, repo_root):
+        # The cloud lane must forward chat_template_kwargs as the same JSON-string
+        # --chat-template-kwargs flag the local lane uses, so a protocol pin like
+        # enable_thinking=False reaches the trainer's preprocessing on the cloud
+        # path. One wire format across both lanes.
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(
+            method="sft", chat_template_kwargs={"enable_thinking": False}
+        )
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        # The assembled command string shell-quotes each arg; the JSON payload
+        # (which contains spaces and braces) is therefore single-quoted so it
+        # reaches the trainer as one argv element.
+        assert "--chat-template-kwargs '{\"enable_thinking\": false}'" in cmd
+
+    def test_command_omits_chat_template_kwargs_for_dpo(self, repo_root):
+        # chat_template_kwargs is an SFT-only flag: DPO/KTO template internally via
+        # TRL and expose no --chat-template-kwargs argument, so even a set value
+        # must not be emitted for a DPO run.
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(
+            method="dpo", chat_template_kwargs={"enable_thinking": False}
+        )
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--chat-template-kwargs" not in cmd
+
+    def test_command_omits_chat_template_kwargs_for_kto(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(
+            method="kto", chat_template_kwargs={"enable_thinking": False}
+        )
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--chat-template-kwargs" not in cmd
+
+    def test_command_omits_chat_template_kwargs_when_absent(self, repo_root):
+        # Default None ⇒ no flag ⇒ byte-identical command for every existing cloud
+        # config, preserving the tuner's generic default rendering.
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(method="sft")  # chat_template_kwargs defaults to None
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--chat-template-kwargs" not in cmd
+
     def test_cloud_training_config_exposes_seed_and_beta(self):
         # Regression guard: CloudTrainingConfig must carry seed/beta so recipe
         # values are not silently dropped before the command builder runs.

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -418,6 +418,75 @@ class TestBuildTrainingCommand:
         assert "--evolutionary-no-log-candidates" in cmd
         assert "--evolutionary-log-selected" in cmd
 
+    def test_command_includes_seed_when_set(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(seed=1234)
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--seed 1234" in cmd
+
+    def test_command_includes_seed_zero(self, repo_root):
+        # seed=0 is a legitimate seed; emission uses `is not None`, not a truthy
+        # guard, so it must reach the trainer command rather than being dropped.
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(seed=0)
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--seed 0" in cmd
+
+    def test_command_omits_seed_when_absent(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config()  # seed defaults to None
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--seed" not in cmd
+
+    def test_command_includes_beta_for_dpo(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(method="dpo", beta=0.5)
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--beta 0.5" in cmd
+
+    def test_command_includes_beta_for_kto(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(method="kto", beta=0.1)
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--beta 0.1" in cmd
+
+    def test_command_omits_beta_for_sft(self, repo_root):
+        # beta is a DPO/KTO-only parameter; SFT has no --beta flag, so even a
+        # set beta value must not be emitted for an SFT run.
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(method="sft", beta=0.5)
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--beta" not in cmd
+
+    def test_command_omits_beta_when_absent(self, repo_root):
+        backend = HFJobsBackend(repo_root)
+        config = _cloud_config(method="dpo")  # beta defaults to None
+
+        cmd = backend._build_training_command(config, timestamp="20260314_181946")
+
+        assert "--beta" not in cmd
+
+    def test_cloud_training_config_exposes_seed_and_beta(self):
+        # Regression guard: CloudTrainingConfig must carry seed/beta so recipe
+        # values are not silently dropped before the command builder runs.
+        config = _cloud_config()
+        assert hasattr(config, "seed")
+        assert hasattr(config, "beta")
+        assert config.seed is None
+        assert config.beta is None
+
     def test_raises_when_no_repo_url(self, repo_root, clean_env):
         backend = HFJobsBackend(repo_root)
         config = _cloud_config(repo_url="")

--- a/tests/cloud/test_stage_runner_behavior.py
+++ b/tests/cloud/test_stage_runner_behavior.py
@@ -168,6 +168,46 @@ class TestTrainingRunnerHappyPath:
         backend.execute.assert_called_once()
 
     @patch("tuner.handlers.stages.hf_training_stage.TrainingBackendRegistry")
+    def test_run_maps_seed_and_beta_onto_config(self, mock_registry, tmp_path):
+        """spec.training.seed/beta must be mapped onto the loaded cloud config."""
+        service = TrackingService(tmp_path)
+        runner = HFTrainingStageRunner(repo_root=tmp_path, tracking_service=service)
+
+        experiment = _make_experiment()
+        spec = _make_spec(method="dpo")
+        spec.training.seed = 7
+        spec.training.beta = 0.5
+        backend = _mock_backend(exit_code=0)
+        backend.load_config.return_value.method = "dpo"
+        mock_registry.get.return_value = backend
+        runner._resolve_bucket_id = MagicMock(return_value="user/bucket")
+
+        runner.run(spec, experiment)
+
+        config = backend.load_config.return_value
+        assert config.seed == 7
+        assert config.beta == 0.5
+
+    @patch("tuner.handlers.stages.hf_training_stage.TrainingBackendRegistry")
+    def test_run_does_not_map_beta_for_sft(self, mock_registry, tmp_path):
+        """beta is DPO/KTO-only; an SFT run must not have beta mapped onto config."""
+        service = TrackingService(tmp_path)
+        runner = HFTrainingStageRunner(repo_root=tmp_path, tracking_service=service)
+
+        experiment = _make_experiment()
+        spec = _make_spec(method="sft")
+        spec.training.beta = 0.5
+        backend = _mock_backend(exit_code=0)
+        backend.load_config.return_value.method = "sft"
+        mock_registry.get.return_value = backend
+        runner._resolve_bucket_id = MagicMock(return_value="user/bucket")
+
+        runner.run(spec, experiment)
+
+        config = backend.load_config.return_value
+        assert "beta" not in config.__dict__
+
+    @patch("tuner.handlers.stages.hf_training_stage.TrainingBackendRegistry")
     def test_run_records_failure_on_nonzero_exit(self, mock_registry, tmp_path):
         """run() should return failed StageResult when backend returns exit_code=1."""
         service = TrackingService(tmp_path)

--- a/tests/handlers/test_handlers.py
+++ b/tests/handlers/test_handlers.py
@@ -282,6 +282,32 @@ class TestCloudTrainHandler:
         assert mock_config.model_name == "new-model"
         assert mock_config.batch_size == 8
 
+    def test_apply_training_overrides_sets_seed(self):
+        # --train-seed wins over the recipe-loaded config.seed, including seed=0.
+        args = Namespace(json=True, train_seed=0)
+        handler = self._make_handler(args)
+        mock_config = MagicMock()
+        mock_config.method = "sft"
+        handler._apply_training_overrides(mock_config)
+        assert mock_config.seed == 0
+
+    def test_apply_training_overrides_sets_beta_for_dpo(self):
+        args = Namespace(json=True, train_beta=0.5)
+        handler = self._make_handler(args)
+        mock_config = MagicMock()
+        mock_config.method = "dpo"
+        handler._apply_training_overrides(mock_config)
+        assert mock_config.beta == 0.5
+
+    def test_apply_training_overrides_skips_beta_for_sft(self):
+        # beta is DPO/KTO-only; a --train-beta override must not touch an SFT config.
+        args = Namespace(json=True, train_beta=0.5)
+        handler = self._make_handler(args)
+        mock_config = MagicMock()
+        mock_config.method = "sft"
+        handler._apply_training_overrides(mock_config)
+        assert "beta" not in mock_config.__dict__
+
     def test_method_labels(self):
         args = Namespace(json=True)
         handler = self._make_handler(args)

--- a/tests/shared/experiment_tracking/conftest.py
+++ b/tests/shared/experiment_tracking/conftest.py
@@ -5,6 +5,21 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from shared.experiment_tracking.benchmark_ledger import LEDGER_DIR_ENV_VAR
+
+
+@pytest.fixture(autouse=True)
+def isolate_benchmark_ledger(tmp_path_factory, monkeypatch):
+    """Redirect every benchmark-ledger write under this package to a tmp dir.
+
+    The ledger writer honors BENCHMARK_LEDGER_DIR; setting it here guarantees no
+    test run touches the committed docs/benchmarks CSV even if a test forgets to
+    pass repo_root=tmp_path. Belt-and-suspenders for the isolation gap (#41).
+    """
+    ledger_dir = tmp_path_factory.mktemp("benchmark_ledger")
+    monkeypatch.setenv(LEDGER_DIR_ENV_VAR, str(ledger_dir))
+
+
 @pytest.fixture
 def tracking_fixtures_dir() -> Path:
     return Path(__file__).parent.parent.parent / "fixtures" / "tracking"

--- a/tests/shared/experiment_tracking/test_benchmark_ledger.py
+++ b/tests/shared/experiment_tracking/test_benchmark_ledger.py
@@ -9,6 +9,48 @@ from shared.experiment_tracking.experiment import Experiment
 from shared.experiment_tracking.schema import LossResult, RunRecord
 
 
+def _minimal_experiment() -> Experiment:
+    return Experiment(
+        experiment_id="exp_isolation",
+        name="isolation",
+        created_at="2026-03-22T20:00:00+00:00",
+        dataset_path="repo/dataset_variant.jsonl",
+        dataset_hash="hash",
+        base_model_name="Qwen/Qwen3-4B",
+        provider="hf_jobs",
+        method="sft",
+        objective="speed_cost_round",
+        status="completed",
+    )
+
+
+def test_ledger_dir_env_var_redirects_write_away_from_repo_root(tmp_path, monkeypatch):
+    """The BENCHMARK_LEDGER_DIR seam redirects the write off repo_root.
+
+    With the env override set, a real repo_root passed to upsert must NOT be
+    written under — the ledger lands in the override dir instead, so a test run
+    can never pollute the committed docs/benchmarks CSV. (The autouse
+    isolate_benchmark_ledger fixture already sets the var; this test pins the
+    contract directly with its own override dir.)
+    """
+    monkeypatch.setattr(benchmark_ledger, "load_live_hf_hardware_rows", lambda: [])
+    override_dir = tmp_path / "override"
+    fake_repo_root = tmp_path / "repo_root"
+    fake_repo_root.mkdir()
+    monkeypatch.setenv(benchmark_ledger.LEDGER_DIR_ENV_VAR, str(override_dir))
+
+    ledger_path = benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=fake_repo_root,
+        experiment=_minimal_experiment(),
+        runs=[],
+    )
+
+    # Written under the override dir, not the passed repo_root.
+    assert Path(ledger_path) == override_dir / benchmark_ledger.LEDGER_CSV_RELATIVE_PATH
+    assert Path(ledger_path).exists()
+    assert not (fake_repo_root / benchmark_ledger.LEDGER_CSV_RELATIVE_PATH).exists()
+
+
 def test_upsert_benchmark_ledger_materializes_row(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(benchmark_ledger, "LEDGER_CSV_RELATIVE_PATH", Path("docs/benchmarks/model_hardware_benchmark_ledger.csv"))
     monkeypatch.setattr(benchmark_ledger, "load_live_hf_hardware_rows", lambda: [])

--- a/tests/shared/experiment_tracking/test_benchmark_ledger.py
+++ b/tests/shared/experiment_tracking/test_benchmark_ledger.py
@@ -236,3 +236,157 @@ def test_upsert_benchmark_ledger_prefers_stage_lineage_payloads(tmp_path: Path, 
     assert rows[0]["eval_passed"] == "45"
     assert rows[0]["loss_examples"] == "9378"
     assert rows[0]["loss_mean"] == "0.42"
+
+
+def test_neutralize_csv_cell_prefixes_formula_triggers_only():
+    """The cell-level helper single-quotes every spreadsheet formula trigger and
+    leaves everything else byte-identical (and non-strings untouched)."""
+    for trigger in ("=", "+", "-", "@", "\t", "\r"):
+        payload = f"{trigger}SUM(A1:A9)"
+        assert benchmark_ledger._neutralize_csv_cell(payload) == "'" + payload
+
+    # Normal text, empty string, and non-string scalars must pass through as-is so
+    # numeric columns stay numeric and well-formed cells are unchanged.
+    assert benchmark_ledger._neutralize_csv_cell("a100-large") == "a100-large"
+    assert benchmark_ledger._neutralize_csv_cell("") == ""
+    assert benchmark_ledger._neutralize_csv_cell(0.42) == 0.42
+    assert benchmark_ledger._neutralize_csv_cell(13) == 13
+    assert benchmark_ledger._neutralize_csv_cell(None) is None
+
+    # Numeric strings with a leading sign (read back from a prior CSV row) keep
+    # their value — the +/- is a numeric sign, not a formula trigger.
+    assert benchmark_ledger._neutralize_csv_cell("-0.5") == "-0.5"
+    assert benchmark_ledger._neutralize_csv_cell("-5") == "-5"
+    assert benchmark_ledger._neutralize_csv_cell("+1.0") == "+1.0"
+    # But a sign-led NON-number (formula payload) is still neutralized.
+    assert benchmark_ledger._neutralize_csv_cell("-cmd|calc") == "'-cmd|calc"
+    assert benchmark_ledger._neutralize_csv_cell("+SUM(A1)") == "'+SUM(A1)"
+
+
+def test_upsert_benchmark_ledger_preserves_negative_numeric_across_roundtrip(tmp_path: Path, monkeypatch):
+    """A negative numeric cell (e.g. a -0.5 loss_mean) must survive a second
+    upsert un-neutralized — the round-trip read-back as the string "-0.5" must
+    NOT be mistaken for a formula trigger (regression guard for the leading-'-'
+    collision)."""
+    monkeypatch.setattr(benchmark_ledger, "load_live_hf_hardware_rows", lambda: [])
+
+    negative_loss = [
+        LossResult(index=0, loss=-0.5, num_completion_tokens=5, num_total_tokens=10, jsonl_hash="a"),
+    ]
+    first = Experiment(
+        experiment_id="exp_negative",
+        name="neg",
+        created_at="2026-03-22T20:00:00+00:00",
+        dataset_path="repo/dataset_variant.jsonl",
+        dataset_hash="hash",
+        base_model_name="Qwen/Qwen3-4B",
+        provider="hf_jobs",
+        method="sft",
+        objective="speed_cost_round",
+        status="completed",
+    )
+    benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=tmp_path, experiment=first, runs=[], loss_results=negative_loss
+    )
+
+    # A second upsert of a DIFFERENT experiment rewrites the whole file, so the
+    # first row's -0.5 is read back as a string and re-passed through the writer.
+    second = Experiment(
+        experiment_id="exp_other_row",
+        name="other",
+        created_at="2026-03-22T20:00:00+00:00",
+        dataset_path="repo/dataset_variant.jsonl",
+        dataset_hash="hash",
+        base_model_name="Qwen/Qwen3-4B",
+        provider="hf_jobs",
+        method="sft",
+        objective="speed_cost_round",
+        status="completed",
+    )
+    ledger_path = benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=tmp_path, experiment=second, runs=[]
+    )
+
+    with Path(ledger_path).open("r", encoding="utf-8", newline="") as handle:
+        rows = {r["experiment_id"]: r for r in csv.DictReader(handle)}
+
+    assert rows["exp_negative"]["loss_mean"] == "-0.5"  # NOT "'-0.5"
+
+
+def test_upsert_benchmark_ledger_neutralizes_formula_injection_in_notes(tmp_path: Path, monkeypatch):
+    """A notes value originating from a stage error_message that begins with a
+    formula trigger round-trips NEUTRALIZED (single-quote-prefixed), while the
+    dedup key and normal cells are unchanged (FS1, PR #1 security review)."""
+    monkeypatch.setattr(benchmark_ledger, "load_live_hf_hardware_rows", lambda: [])
+
+    injection = "=SUM(1+9)*cmd|'/c calc'!A1"
+    experiment = Experiment(
+        experiment_id="exp_injection",
+        name="injection",
+        created_at="2026-03-22T20:00:00+00:00",
+        dataset_path="repo/dataset_variant.jsonl",
+        dataset_hash="hash",
+        base_model_name="Qwen/Qwen3-4B",
+        provider="hf_jobs",
+        method="sft",
+        objective="speed_cost_round",
+        status="failed",
+        stage_details={
+            # A failed stage routes its error_message into the notes column
+            # (build_benchmark_ledger_row :263-270) — the realistic free-text sink.
+            "loss": {"status": "failed", "error_message": injection},
+        },
+    )
+
+    ledger_path = benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=tmp_path,
+        experiment=experiment,
+        runs=[],
+    )
+
+    with Path(ledger_path).open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    assert len(rows) == 1
+    # The dangerous notes cell is neutralized: the spreadsheet sees literal text.
+    assert rows[0]["notes"] == "'" + injection
+    # The dedup key (never a free-text trigger) round-trips untouched, so upsert
+    # matching is unaffected.
+    assert rows[0]["experiment_id"] == "exp_injection"
+
+
+def test_upsert_benchmark_ledger_dedup_survives_neutralization(tmp_path: Path, monkeypatch):
+    """Upserting the same experiment_id twice replaces (not appends) even though
+    the notes column carries a neutralized formula trigger — confirms the write-
+    boundary neutralization does not perturb the experiment_id dedup key."""
+    monkeypatch.setattr(benchmark_ledger, "load_live_hf_hardware_rows", lambda: [])
+
+    def _experiment_with_note(note: str) -> Experiment:
+        return Experiment(
+            experiment_id="exp_dedup",
+            name="dedup",
+            created_at="2026-03-22T20:00:00+00:00",
+            dataset_path="repo/dataset_variant.jsonl",
+            dataset_hash="hash",
+            base_model_name="Qwen/Qwen3-4B",
+            provider="hf_jobs",
+            method="sft",
+            objective="speed_cost_round",
+            status="failed",
+            stage_details={"loss": {"status": "failed", "error_message": note}},
+        )
+
+    benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=tmp_path, experiment=_experiment_with_note("=first"), runs=[]
+    )
+    ledger_path = benchmark_ledger.upsert_benchmark_ledger(
+        repo_root=tmp_path, experiment=_experiment_with_note("=second"), runs=[]
+    )
+
+    with Path(ledger_path).open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+
+    # Exactly one row (replaced, not duplicated), carrying the latest neutralized note.
+    assert len(rows) == 1
+    assert rows[0]["experiment_id"] == "exp_dedup"
+    assert rows[0]["notes"] == "'=second"

--- a/tests/shared/experiment_tracking/test_experiment_spec.py
+++ b/tests/shared/experiment_tracking/test_experiment_spec.py
@@ -62,6 +62,62 @@ def test_load_experiment_spec_round_trip(tmp_path):
     assert spec.execution.selected_stages() == ["evaluation", "loss", "analysis", "recommendation"]
 
 
+def test_load_experiment_spec_carries_seed_and_beta(tmp_path):
+    # Recipe-set training.seed/training.beta must populate the spec so they can
+    # be forwarded to the trainer instead of silently defaulting.
+    spec_path = tmp_path / "experiment.yaml"
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            experiment:
+              name: dpo-seed-beta
+              provider: hf_jobs
+              method: dpo
+              dataset:
+                source: org/dataset
+                file: sample.jsonl
+              training:
+                model_name: HuggingFaceTB/SmolLM2-1.7B-Instruct
+                max_steps: 20
+                seed: 7
+                beta: 0.5
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    spec = load_experiment_spec(spec_path)
+
+    assert spec.training.seed == 7
+    assert spec.training.beta == 0.5
+
+
+def test_load_experiment_spec_seed_beta_default_none(tmp_path):
+    spec_path = tmp_path / "experiment.yaml"
+    spec_path.write_text(
+        textwrap.dedent(
+            """
+            experiment:
+              name: no-seed-beta
+              provider: hf_jobs
+              method: sft
+              dataset:
+                source: org/dataset
+                file: sample.jsonl
+              training:
+                model_name: HuggingFaceTB/SmolLM2-1.7B-Instruct
+                max_steps: 20
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    spec = load_experiment_spec(spec_path)
+
+    assert spec.training.seed is None
+    assert spec.training.beta is None
+
+
 def test_load_experiment_spec_rejects_invalid_provider(tmp_path):
     spec_path = tmp_path / "bad_experiment.yaml"
     spec_path.write_text(

--- a/tests/trainers/dpo/test_config_loader.py
+++ b/tests/trainers/dpo/test_config_loader.py
@@ -1,0 +1,54 @@
+"""Smoke tests for the DPO config loader (DPOTrainingConfig).
+
+Imports only yaml/dataclasses via config_loader; no ML stack.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "dpo"))
+
+from configs import config_loader  # noqa: E402
+
+
+def test_default_config_yaml_loads_into_dpo_dataclasses():
+    config = config_loader.load_config()  # defaults to Trainers/dpo/configs/config.yaml
+
+    # DPO-specific fields present, KTO-only fields absent.
+    assert hasattr(config.training, "beta")
+    assert hasattr(config.training, "loss_type")
+    assert config.training.loss_type == "sigmoid"
+    assert not hasattr(config.training, "desirable_weight")
+    assert not hasattr(config.training, "undesirable_weight")
+    assert not hasattr(config.training, "use_kto_s")
+
+
+def test_default_lora_budget_matches_4b_pilot():
+    config = config_loader.load_config()
+    assert config.lora.r == 32
+    assert config.lora.lora_alpha == 64
+    assert config.lora.target_modules == [
+        "q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj",
+    ]
+
+
+def test_default_model_is_qwen3_4b_thinking_off_pin():
+    config = config_loader.load_config()
+    assert "Qwen3-4B" in config.model.model_name
+
+
+def test_string_numeric_fields_are_coerced(tmp_path):
+    # mirrors KTO loader's dict_to_dataclass numeric coercion
+    import yaml
+
+    cfg = config_loader.load_yaml_config()
+    cfg["training"]["learning_rate"] = "5e-6"  # string -> float
+    cfg["training"]["save_steps"] = "25"       # string -> int
+    path = tmp_path / "config.yaml"
+    with open(path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(cfg, f)
+
+    config = config_loader.load_config(str(path))
+    assert isinstance(config.training.learning_rate, float)
+    assert isinstance(config.training.save_steps, int)

--- a/tests/trainers/dpo/test_data_loader.py
+++ b/tests/trainers/dpo/test_data_loader.py
@@ -1,0 +1,89 @@
+"""Smoke tests for the DPO data loader (prompt/chosen/rejected schema).
+
+These import only `datasets` (no trl/unsloth/torch), so they exercise the
+config-validation dry-run contract without the ML stack.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "dpo" / "src"))
+
+import data_loader  # noqa: E402
+
+
+def _write_jsonl(path: Path, rows):
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def _valid_pair(question="Who wrote Paradise Lost?"):
+    return {
+        "prompt": [
+            {"role": "system", "content": "Answer if you know; otherwise say you do not."},
+            {"role": "user", "content": question},
+        ],
+        "chosen": [{"role": "assistant", "content": "John Milton."}],
+        "rejected": [{"role": "assistant", "content": "I don't know the answer."}],
+    }
+
+
+def test_load_and_validate_well_formed_dpo_pairs(tmp_path):
+    path = tmp_path / "dpo_train.jsonl"
+    _write_jsonl(path, [_valid_pair("q1"), _valid_pair("q2")])
+
+    train, eval_ds = data_loader.load_and_prepare_dataset(local_file=str(path))
+
+    assert eval_ds is None
+    assert sorted(train.column_names) == sorted(data_loader.REQUIRED_DPO_COLUMNS)
+    assert len(train) == 2
+    assert data_loader.validate_dpo_dataset(train) is True
+
+
+def test_extra_provenance_columns_are_dropped(tmp_path):
+    path = tmp_path / "dpo_train.jsonl"
+    row = _valid_pair()
+    row["question_id"] = "tqa_train_000123"  # builder provenance, not a DPO column
+    row["source_label"] = "unknown"
+    _write_jsonl(path, [row])
+
+    train, _ = data_loader.load_and_prepare_dataset(local_file=str(path))
+
+    assert "question_id" not in train.column_names
+    assert "source_label" not in train.column_names
+    assert sorted(train.column_names) == sorted(data_loader.REQUIRED_DPO_COLUMNS)
+
+
+def test_split_dataset_produces_eval(tmp_path):
+    path = tmp_path / "dpo_train.jsonl"
+    _write_jsonl(path, [_valid_pair(f"q{i}") for i in range(10)])
+
+    train, eval_ds = data_loader.load_and_prepare_dataset(
+        local_file=str(path), split_dataset=True, test_size=0.2,
+    )
+
+    assert eval_ds is not None
+    assert len(train) + len(eval_ds) == 10
+
+
+def test_validate_rejects_missing_columns(tmp_path):
+    from datasets import Dataset
+
+    bad = Dataset.from_dict({"prompt": [[{"role": "user", "content": "hi"}]],
+                             "chosen": [[{"role": "assistant", "content": "yes"}]]})
+    # rejected column missing
+    assert data_loader.validate_dpo_dataset(bad) is False
+
+
+def test_validate_rejects_malformed_message_lists(tmp_path):
+    from datasets import Dataset
+
+    bad = Dataset.from_dict({
+        "prompt": [[{"role": "user", "content": "hi"}]],
+        "chosen": [[{"role": "assistant", "content": "yes"}]],
+        "rejected": [[]],  # empty -> not a valid message list
+    })
+    assert data_loader.validate_dpo_dataset(bad) is False

--- a/tests/trainers/dpo/test_dpo_method_registration.py
+++ b/tests/trainers/dpo/test_dpo_method_registration.py
@@ -1,0 +1,89 @@
+"""Registration-sweep test: 'dpo' must be registered at every method-enumeration
+site discovered in the WS-3 grep sweep.
+
+The design doc named 4 sites; the actual surface is ~11, anchored on
+shared/utilities/paths.py:TRAINING_METHODS (which auto-derives the trainer-dir
+and output-dir maps that the cloud backends use to dispatch dpo -> Trainers/dpo).
+This test pins the full set so a future edit that drops 'dpo' from any site
+fails loudly. Source-scanning sites import-light; logic sites import the module.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# ---- Central registration: paths.py TRAINING_METHODS (the auto-derive anchor) ----
+
+def test_paths_training_methods_includes_dpo():
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    from shared.utilities import paths
+
+    assert "dpo" in paths.TRAINING_METHODS
+    # Auto-derived maps must resolve dpo -> Trainers/dpo and dpo_output.
+    assert paths.CANONICAL_TRAINER_DIRS["dpo"] == "dpo"
+    assert paths.CANONICAL_OUTPUT_DIRS["dpo"] == "dpo_output"
+    assert paths.get_canonical_trainer_dir_name("dpo") == "dpo"
+
+
+# ---- Cloud / CLI gate sites (the doc's named 4) ----
+
+def test_base_cloud_supported_methods_includes_dpo():
+    import sys
+    sys.path.insert(0, str(REPO_ROOT))
+    from tuner.backends.training.cloud import base_cloud
+
+    assert "dpo" in base_cloud.SUPPORTED_METHODS
+
+
+def test_named_gate_sites_source_contains_dpo():
+    sites = {
+        "tuner/cli/parser.py": '"sft", "kto", "grpo", "dpo"',
+        "tuner/backends/training/cloud/hf_jobs_backend.py": '["sft", "kto", "grpo", "dpo"]',
+        "tuner/backends/training/rtx_backend.py": '["sft", "kto", "grpo", "dpo"]',
+    }
+    for rel, needle in sites.items():
+        source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert needle in source, f"{rel} missing dpo registration ({needle!r})"
+
+
+# ---- Lifecycle-parity iteration sites (eval discovery, model discovery, handlers) ----
+
+def test_lifecycle_iteration_sites_include_dpo():
+    sites = [
+        "tuner/backends/evaluation/unsloth_backend.py",
+        "tuner/backends/evaluation/mlc_backend.py",
+        "tuner/backends/evaluation/llamacpp_backend.py",
+        "tuner/discovery/base_models.py",
+        "tuner/handlers/merge_handler.py",
+        "tuner/handlers/doctor_handler.py",
+        "tuner/handlers/train_handler.py",
+    ]
+    for rel in sites:
+        source = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert '"dpo"' in source or "'dpo'" in source, f"{rel} missing 'dpo' in its method enumeration"
+
+
+# ---- No method-tuple enumeration site left without dpo ----
+
+def test_no_three_method_tuple_left_unregistered():
+    """Fail if any (sft, kto, grpo) tuple WITHOUT dpo remains under tuner/ or shared/.
+
+    Catches a missed enumeration site. Skips comments/docstrings by checking the
+    canonical literal forms only.
+    """
+    stale_forms = [
+        '("sft", "kto", "grpo")',
+        '("sft","kto","grpo")',
+        '["sft", "kto", "grpo"]',
+        "['sft', 'kto', 'grpo']",
+    ]
+    offenders = []
+    for root in ("tuner", "shared"):
+        for py in (REPO_ROOT / root).rglob("*.py"):
+            text = py.read_text(encoding="utf-8")
+            for form in stale_forms:
+                if form in text:
+                    offenders.append(f"{py.relative_to(REPO_ROOT)}: {form}")
+    assert not offenders, "Stale 3-method tuples (missing dpo):\n" + "\n".join(offenders)

--- a/tests/trainers/dpo/test_model_presets.py
+++ b/tests/trainers/dpo/test_model_presets.py
@@ -1,0 +1,39 @@
+"""Smoke tests for DPO model-preset resolution (no ML stack)."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "dpo"))
+
+from configs import model_presets  # noqa: E402
+
+
+def _args(**flags):
+    # All MODEL_MAP flags default False; override the ones under test.
+    defaults = {flag: False for flag in model_presets.MODEL_MAP}
+    defaults.update(flags)
+    return SimpleNamespace(**defaults)
+
+
+def test_qwen3_4b_resolves_to_pilot_pin():
+    size, repo = model_presets.resolve_model_flag(_args(qwen3_4b=True))
+    assert size == "3b"
+    assert repo == "unsloth/Qwen3-4B-Instruct-bnb-4bit"
+
+
+def test_qwen3_8b_resolves_to_confirm_pin():
+    size, repo = model_presets.resolve_model_flag(_args(qwen3_8b=True))
+    assert size == "7b"
+    assert repo == "unsloth/Qwen3-8B-Instruct-bnb-4bit"
+
+
+def test_no_flag_returns_none():
+    assert model_presets.resolve_model_flag(_args()) is None
+
+
+def test_first_flag_in_map_order_wins():
+    # qwen_3b precedes qwen3_8b in MODEL_MAP; both set -> first wins.
+    size, repo = model_presets.resolve_model_flag(_args(qwen_3b=True, qwen3_8b=True))
+    assert repo == "unsloth/Qwen2.5-3B-Instruct-bnb-4bit"

--- a/tests/trainers/dpo/test_model_presets.py
+++ b/tests/trainers/dpo/test_model_presets.py
@@ -20,13 +20,13 @@ def _args(**flags):
 def test_qwen3_4b_resolves_to_pilot_pin():
     size, repo = model_presets.resolve_model_flag(_args(qwen3_4b=True))
     assert size == "3b"
-    assert repo == "unsloth/Qwen3-4B-Instruct-bnb-4bit"
+    assert repo == "unsloth/Qwen3-4B-bnb-4bit"
 
 
 def test_qwen3_8b_resolves_to_confirm_pin():
     size, repo = model_presets.resolve_model_flag(_args(qwen3_8b=True))
     assert size == "7b"
-    assert repo == "unsloth/Qwen3-8B-Instruct-bnb-4bit"
+    assert repo == "unsloth/Qwen3-8B-bnb-4bit"
 
 
 def test_no_flag_returns_none():

--- a/tests/trainers/dpo/test_model_presets_live_hub.py
+++ b/tests/trainers/dpo/test_model_presets_live_hub.py
@@ -1,0 +1,60 @@
+"""Live HF-hub existence check for the pinned Qwen3 model presets.
+
+TEST-phase finding (phase1-pipeline, focus item 9 + arch §5.3 VERIFY item).
+The DPO/KTO model presets pin the hybrid Qwen3 bnb-4bit repos:
+
+    qwen3_4b -> unsloth/Qwen3-4B-bnb-4bit
+    qwen3_8b -> unsloth/Qwen3-8B-bnb-4bit
+
+The original pins (`unsloth/Qwen3-{4B,8B}-Instruct-bnb-4bit`) were 404 on the
+hub: a live huggingface_hub.HfApi().model_info() query (2026-06-11, real backend
+Request IDs) returned RepositoryNotFoundError for both, so every real run would
+have failed at model-download time. The user-ratified repoint moved both presets
+to the hybrid models above (enable_thinking=False matches PROTOCOL v0.3's
+'thinking mode OFF' literally), both verified 200.
+
+This test pins those repos against the live hub so a future preset edit cannot
+silently reintroduce a 404. It is NETWORK-GATED and SKIPPED by default (no
+network in the normal suite, per the TEST-phase network boundary: item 9 is the
+only network-permitted check). Run it explicitly when verifying the pins:
+
+    RUN_LIVE_HUB=1 pytest tests/trainers/dpo/test_model_presets_live_hub.py
+
+It must PASS now (the hybrid names resolve 200). Do not "fix" a future failure
+by relaxing the existence check — the check is the point; repoint the presets to
+a repo that actually exists.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("RUN_LIVE_HUB") != "1",
+    reason="network-gated; set RUN_LIVE_HUB=1 to verify pinned repo names exist",
+)
+
+PINNED_PRESET_REPOS = [
+    "unsloth/Qwen3-4B-bnb-4bit",
+    "unsloth/Qwen3-8B-bnb-4bit",
+]
+
+
+@pytest.mark.parametrize("repo_id", PINNED_PRESET_REPOS)
+def test_pinned_preset_repo_exists_on_hub(repo_id):
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    try:
+        info = api.model_info(repo_id)
+    except Exception as exc:  # RepositoryNotFoundError / HTTP 404 / auth-wrapped 404
+        pytest.fail(
+            f"[{type(exc).__name__}] "
+            f"Pinned model preset '{repo_id}' does NOT exist on the HF hub (404). "
+            f"Phase-1 runs would fail at model download. Repoint the DPO/KTO "
+            f"presets + the 7 recipe model.name fields to an existing repo "
+            f"(e.g. unsloth/Qwen3-4B-Instruct-2507-bnb-4bit or "
+            f"unsloth/Qwen3-4B-bnb-4bit), then update the sibling "
+            f"test_model_presets.py assertions."
+        )
+    assert info.id == repo_id

--- a/tests/trainers/dpo/test_numeric_override_silent_substitution.py
+++ b/tests/trainers/dpo/test_numeric_override_silent_substitution.py
@@ -1,0 +1,86 @@
+"""Regression tests for the FIFTH silent-substitution instance (now HARDENED).
+
+TEST-phase finding (phase1-pipeline, focus item 7), hardened in #41. The DPO/KTO
+trainers' `apply_cli_overrides` hardened seed/beta/lora to `is not None` guards
+so that an explicit falsy value (seed=0, beta=0.0, lora-dropout=0.0) overrides
+the config default instead of being silently dropped (the provenance discipline
+of arch §(b.2): a run record must never claim a value the trainer didn't use).
+
+The three sibling NUMERIC hyperparameters in the SAME function originally still
+used the older truthy guard (`if args.X:`), so an explicit `--max-seq-length 0` /
+`--batch-size 0` / `--num-epochs 0` was silently dropped to the config default —
+the same silent-substitution SIGNATURE. #41 hardened them to `is not None` across
+ALL THREE trainers:
+
+    train_dpo.py  apply_cli_overrides:  max_seq_length / batch_size / num_epochs
+    train_kto.py  apply_cli_overrides:  same three (elif batch_size keeps adaptive precedence)
+    train_sft.py  same convention (pre-existing tuner-wide)
+
+SEVERITY (TEST-phase calibration): was YELLOW, latent — NOT an active corruption
+path for the pre-registered PROTOCOL v0.3 matrix (the Phase-1 recipes pin these
+fields to non-zero values and the WS-5 materializer only overrides
+seed / learning_rate / beta). The lead ruled HARDEN under the same no-silent-
+override discipline as seed/beta: a silent-substitution hole is worth closing
+regardless of whether today's matrix exercises the falsy value.
+
+These tests now PIN the hardened contract: an explicit 0 reaches config rather
+than being dropped. They exercise the DPO trainer directly (import-light); the
+KTO/SFT hardening is verified by source-scan in the sibling trainer test files.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "dpo"))
+
+import train_dpo  # noqa: E402
+
+
+def _config_after(argv):
+    config = train_dpo.load_config()
+    args = train_dpo.build_arg_parser().parse_args(argv)
+    return train_dpo.apply_cli_overrides(config, args)
+
+
+# --- Non-falsy values forward correctly (the guard is not broken in general) ---
+
+def test_num_epochs_nonzero_overrides():
+    config = _config_after(["--num-epochs", "3"])
+    assert config.training.num_train_epochs == 3
+
+
+def test_batch_size_nonzero_overrides():
+    config = _config_after(["--batch-size", "8"])
+    assert config.training.per_device_train_batch_size == 8
+
+
+def test_max_seq_length_nonzero_overrides():
+    config = _config_after(["--max-seq-length", "4096"])
+    assert config.model.max_seq_length == 4096
+
+
+# --- The fifth silent-substitution instance: falsy values now FORWARD (hardened) ---
+# These pin the HARDENED behavior, matching test_seed_override_honors_zero /
+# test_beta_override_honors_zero in the sibling test_seed_override.py.
+
+def test_num_epochs_zero_overrides_hardened_guard():
+    """`if args.num_epochs is not None:` forwards --num-epochs 0 to config.
+
+    The provenance-correct guard sets num_train_epochs == 0 rather than silently
+    keeping the config default (closes the fifth silent-substitution instance).
+    """
+    config = _config_after(["--num-epochs", "0"])
+    assert config.training.num_train_epochs == 0
+
+
+def test_batch_size_zero_overrides_hardened_guard():
+    """`if args.batch_size is not None:` forwards --batch-size 0 to config."""
+    config = _config_after(["--batch-size", "0"])
+    assert config.training.per_device_train_batch_size == 0
+
+
+def test_max_seq_length_zero_overrides_hardened_guard():
+    """`if args.max_seq_length is not None:` forwards --max-seq-length 0 to config."""
+    config = _config_after(["--max-seq-length", "0"])
+    assert config.model.max_seq_length == 0

--- a/tests/trainers/dpo/test_seed_override.py
+++ b/tests/trainers/dpo/test_seed_override.py
@@ -1,0 +1,80 @@
+"""Behavioral tests for the DPO trainer's --seed CLI override.
+
+train_dpo's parser + apply_cli_overrides are import-light (config/presets only,
+no trl/unsloth/torch), so the seed-override precedence can be exercised directly.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "dpo"))
+
+import train_dpo  # noqa: E402
+
+
+def _config_after(argv):
+    config = train_dpo.load_config()
+    args = train_dpo.build_arg_parser().parse_args(argv)
+    return train_dpo.apply_cli_overrides(config, args)
+
+
+def test_seed_override_sets_config_seed():
+    config = _config_after(["--seed", "1234"])
+    assert config.seed == 1234
+
+
+def test_seed_override_honors_zero():
+    # `is not None` guard: seed=0 is a legitimate seed and must override the default.
+    config = _config_after(["--seed", "0"])
+    assert config.seed == 0
+
+
+def test_seed_absent_preserves_default():
+    default_seed = train_dpo.load_config().seed
+    config = _config_after([])
+    assert config.seed == default_seed
+
+
+def test_beta_override_sets_config_beta():
+    config = _config_after(["--beta", "0.05"])
+    assert config.training.beta == 0.05
+
+
+def test_beta_override_honors_zero():
+    # `is not None` guard mirrors --seed: an explicit --beta 0.0 forwarded by the
+    # handler must override the config default, not be silently swapped (provenance).
+    # A truthy guard would drop it — the silent-substitution class this guards against.
+    config = _config_after(["--beta", "0.0"])
+    assert config.training.beta == 0.0
+
+
+def test_beta_absent_preserves_default():
+    default_beta = train_dpo.load_config().training.beta
+    config = _config_after([])
+    assert config.training.beta == default_beta
+
+
+def test_lora_overrides_set_config_lora():
+    # The recipe LoRA budget is the SSOT (§5.2 identical-budget confound control):
+    # the --lora-* parity flags must override config.lora.* so a recipe pinning
+    # r=64/alpha=128 trains at that budget, not the trainer config.yaml default.
+    config = _config_after(
+        [
+            "--lora-r", "64",
+            "--lora-alpha", "128",
+            "--lora-dropout", "0.05",
+            "--lora-target-modules", "q_proj,v_proj",
+        ]
+    )
+    assert config.lora.r == 64
+    assert config.lora.lora_alpha == 128
+    assert config.lora.lora_dropout == 0.05
+    assert config.lora.target_modules == ["q_proj", "v_proj"]
+
+
+def test_lora_overrides_absent_preserve_default():
+    default = train_dpo.load_config().lora
+    config = _config_after([])
+    assert config.lora.r == default.r
+    assert config.lora.lora_alpha == default.lora_alpha

--- a/tests/trainers/dpo/test_train_dpo_source.py
+++ b/tests/trainers/dpo/test_train_dpo_source.py
@@ -1,0 +1,66 @@
+"""Source-level smoke tests for train_dpo.py.
+
+These assert on the trainer source text (no import), mirroring
+tests/trainers/sft/test_train_sft_source.py, so they verify the DPO API choices
+without loading trl/unsloth/torch.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRAIN_DPO = REPO_ROOT / "Trainers" / "dpo" / "train_dpo.py"
+
+
+def _source() -> str:
+    return TRAIN_DPO.read_text(encoding="utf-8")
+
+
+def test_uses_trl_dpo_api_not_kto():
+    source = _source()
+    assert "from trl import DPOConfig, DPOTrainer" in source
+    assert "DPOConfig(" in source
+    assert "DPOTrainer(" in source
+    # No KTO API is actually invoked (the docstring may *mention* KTO to explain
+    # the deltas, so check for instantiation/import forms, not the bare word).
+    assert "KTOConfig(" not in source
+    assert "KTOTrainer(" not in source
+    assert "KTOSTrainer(" not in source
+    assert "from trl import KTOConfig" not in source
+
+
+def test_dpo_config_drops_kto_only_fields():
+    source = _source()
+    assert "loss_type=config.training.loss_type" in source
+    assert "desirable_weight" not in source
+    assert "undesirable_weight" not in source
+    assert "use_kto_s" not in source
+
+
+def test_reuses_reference_model_seam():
+    source = _source()
+    assert "create_reference_model" in source
+    assert "USE_EXPLICIT_REF_MODEL" in source
+
+
+def test_no_interleaving_for_paired_dpo():
+    source = _source()
+    # KTO's interleave step must NOT be present (DPO is paired, not binary).
+    assert "interleave_dataset" not in source
+    assert "validate_dpo_dataset" in source
+
+
+def test_dry_run_exits_before_model_load():
+    source = _source()
+    # The dry-run guard must precede the heavy trl/unsloth imports + model load.
+    dry_idx = source.find("if args.dry_run:")
+    model_load_idx = source.find("load_model_and_tokenizer(")
+    trl_import_idx = source.find("from trl import DPOConfig, DPOTrainer")
+    assert dry_idx != -1 and model_load_idx != -1 and trl_import_idx != -1
+    assert dry_idx < trl_import_idx
+    assert dry_idx < model_load_idx
+
+
+def test_uses_modern_trl_processing_class_kwarg():
+    source = _source()
+    # Cloud recipes pin modern trl (>=0.22) where DPOTrainer takes processing_class.
+    assert "processing_class=tokenizer" in source

--- a/tests/trainers/kto/test_train_kto_source.py
+++ b/tests/trainers/kto/test_train_kto_source.py
@@ -30,6 +30,21 @@ def test_train_kto_beta_override_is_wired_with_is_not_none() -> None:
     assert "if args.beta:" not in source
 
 
+def test_train_kto_numeric_overrides_are_hardened_is_not_none() -> None:
+    # The fifth silent-substitution instance (focus item 7), hardened in #41:
+    # max_seq_length / batch_size / num_epochs override guards must use is not None
+    # so an explicit 0 forwards to config rather than being dropped to the default.
+    source = (REPO_ROOT / "Trainers" / "kto" / "train_kto.py").read_text(encoding="utf-8")
+
+    assert "if args.max_seq_length is not None:" in source
+    assert "elif args.batch_size is not None:" in source
+    assert "if args.num_epochs is not None:" in source
+    # The pre-hardening truthy guards must be gone for these three.
+    assert "if args.max_seq_length:" not in source
+    assert "elif args.batch_size:" not in source
+    assert "if args.num_epochs:" not in source
+
+
 def test_train_kto_lora_parity_flags_are_wired() -> None:
     # LoRA flag parity (§5.2 identical-budget confound control): the handler emits
     # --lora-* for dpo/kto, so the KTO trainer must accept them and thread the value

--- a/tests/trainers/kto/test_train_kto_source.py
+++ b/tests/trainers/kto/test_train_kto_source.py
@@ -1,0 +1,45 @@
+"""Source-level tests for the KTO trainer's --seed CLI override.
+
+train_kto imports unsloth at module load, so the --seed flag and its
+is-not-None override (honoring seed=0) are verified at the source level,
+mirroring tests/trainers/sft/test_train_sft_source.py.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_train_kto_seed_override_is_wired_with_is_not_none() -> None:
+    source = (REPO_ROOT / "Trainers" / "kto" / "train_kto.py").read_text(encoding="utf-8")
+
+    assert '"--seed"' in source
+    assert "if args.seed is not None:" in source
+    assert "config.seed = args.seed" in source
+
+
+def test_train_kto_beta_override_is_wired_with_is_not_none() -> None:
+    # The handler forwards an explicit --beta 0.0 (is-not-None at the boundary); the
+    # trainer must honor it with the same is-not-None guard, not a truthy guard that
+    # would silently swap 0.0 for the config default (provenance: no silent override).
+    source = (REPO_ROOT / "Trainers" / "kto" / "train_kto.py").read_text(encoding="utf-8")
+
+    assert "if args.beta is not None:" in source
+    assert "config.training.beta = args.beta" in source
+    assert "if args.beta:" not in source
+
+
+def test_train_kto_lora_parity_flags_are_wired() -> None:
+    # LoRA flag parity (§5.2 identical-budget confound control): the handler emits
+    # --lora-* for dpo/kto, so the KTO trainer must accept them and thread the value
+    # into config.lora.* (the SSOT), not silently fall back to config.yaml.
+    source = (REPO_ROOT / "Trainers" / "kto" / "train_kto.py").read_text(encoding="utf-8")
+
+    for flag in ('"--lora-r"', '"--lora-alpha"', '"--lora-dropout"', '"--lora-target-modules"'):
+        assert flag in source, f"KTO trainer missing argparse for {flag}"
+
+    assert "if args.lora_r is not None:" in source
+    assert "config.lora.r = args.lora_r" in source
+    assert "if args.lora_target_modules is not None:" in source
+    assert "config.lora.target_modules = " in source

--- a/tests/trainers/kto/test_train_kto_source.py
+++ b/tests/trainers/kto/test_train_kto_source.py
@@ -30,6 +30,13 @@ def test_train_kto_beta_override_is_wired_with_is_not_none() -> None:
     assert "if args.beta:" not in source
 
 
+def test_train_kto_imports_logging_when_using_get_logger() -> None:
+    source = (REPO_ROOT / "Trainers" / "kto" / "train_kto.py").read_text(encoding="utf-8")
+
+    assert "logging.getLogger(" in source
+    assert "import logging" in source
+
+
 def test_train_kto_numeric_overrides_are_hardened_is_not_none() -> None:
     # The fifth silent-substitution instance (focus item 7), hardened in #41:
     # max_seq_length / batch_size / num_epochs override guards must use is not None

--- a/tests/trainers/sft/test_chat_template_kwargs_passthrough.py
+++ b/tests/trainers/sft/test_chat_template_kwargs_passthrough.py
@@ -1,0 +1,202 @@
+"""chat_template_kwargs passthrough — SFT preprocessing.
+
+Covers the generic ``chat_template_kwargs`` parameter added to
+``shared.sft_preprocessing.materialize_sft_example`` and threaded through the
+SFT preprocessing wrappers (arch ruling #43). The kwarg is forwarded verbatim
+into BOTH ``apply_chat_template`` calls (full-sequence and the prompt-only
+loss-mask prefix), so a recipe can set e.g. ``{enable_thinking: false}`` for a
+thinking-capable model without any model-specific code in shared/.
+
+Two layers:
+
+1. Fast, no-network forwarding/byte-identity tests with a recording fake
+   tokenizer (run in the normal suite). These pin the contract: the kwargs reach
+   both call sites, and the default (None) forwards NOTHING (byte-identical
+   behavior for every existing caller).
+
+2. A network-gated runtime render assertion (RUN_LIVE_HUB=1) against the real
+   Qwen3-0.6B tokenizer — the same chat-template family as the hybrid Qwen3
+   4B/8B presets (architect-verified). It converts 'verified-by-source' into
+   'verified-by-execution' per arch open-risk #1.
+
+   GROUND TRUTH (tester #49, live Qwen3-0.6B template): the empty think-off
+   marker '<think>\\n\\n</think>\\n\\n' is injected UNCONDITIONALLY into the
+   assistant turn — it appears in the full-sequence render identically for
+   enable_thinking False / True / default. So the contract is NOT "no <think> in
+   the full render" (that is false against the live template). The real contract
+   is a MASKING one: the marker lands in the prompt PREFIX, which the
+   assistant-only loss mask zeroes out, so the unmasked TRAINING TARGET decodes
+   to exactly the clean completion 'I don't know.<|im_end|>\\n' with no <think>.
+   The prompt-only render (== eval-time prompt) carries the marker, aligning the
+   train prompt prefix with the eval prompt. This test asserts BOTH: the unmasked
+   target is <think>-free, and the prompt render carries the marker.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
+
+preprocessing = pytest.importorskip("preprocessing")
+
+from shared.sft_preprocessing import materialize_sft_example
+
+
+class _RecordingTokenizer:
+    """Fake tokenizer that records every apply_chat_template kwargs payload.
+
+    Accepts arbitrary **kwargs so the forwarded chat_template_kwargs land in
+    ``self.calls`` for assertion. encode() is a deterministic char-based stub.
+    """
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False, **kwargs):
+        self.calls.append(
+            {"add_generation_prompt": add_generation_prompt, "kwargs": dict(kwargs)}
+        )
+        rendered = "\n".join(f"{m['role']}::{m['content']}" for m in messages)
+        if add_generation_prompt:
+            rendered += "\nassistant::"
+        return rendered
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(char) % 97 for char in text]
+
+
+_EXAMPLE = {
+    "messages": [
+        {"role": "user", "content": "What is the capital of Atlantis?"},
+        {"role": "assistant", "content": "I don't know."},
+    ]
+}
+
+
+def test_chat_template_kwargs_forwarded_to_both_call_sites():
+    tokenizer = _RecordingTokenizer()
+
+    materialize_sft_example(
+        tokenizer=tokenizer,
+        record=_EXAMPLE,
+        max_seq_length=128,
+        assistant_only_loss=True,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    # Two render calls: full-sequence (add_generation_prompt=False) and the
+    # prompt-only loss-mask prefix (add_generation_prompt=True). BOTH must carry
+    # the forwarded kwarg so the loss-mask prefix matches the eval-time prompt.
+    assert len(tokenizer.calls) == 2
+    full_call = next(c for c in tokenizer.calls if c["add_generation_prompt"] is False)
+    prompt_call = next(c for c in tokenizer.calls if c["add_generation_prompt"] is True)
+    assert full_call["kwargs"] == {"enable_thinking": False}
+    assert prompt_call["kwargs"] == {"enable_thinking": False}
+
+
+def test_default_none_forwards_no_kwargs_byte_identical():
+    tokenizer = _RecordingTokenizer()
+
+    materialize_sft_example(
+        tokenizer=tokenizer,
+        record=_EXAMPLE,
+        max_seq_length=128,
+        assistant_only_loss=True,
+        # chat_template_kwargs omitted ⇒ default None ⇒ no extra kwargs.
+    )
+
+    assert len(tokenizer.calls) == 2
+    for call in tokenizer.calls:
+        assert call["kwargs"] == {}
+
+
+def test_preprocessing_wrappers_thread_chat_template_kwargs():
+    """The SFT-facing wrappers forward the kwarg down to materialize."""
+    tokenizer = _RecordingTokenizer()
+
+    normalized = preprocessing.normalize_sft_example(_EXAMPLE)
+    preprocessing.materialize_sft_features(
+        normalized,
+        tokenizer=tokenizer,
+        max_seq_length=128,
+        loss_mask_mode="assistant_only",
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert tokenizer.calls
+    assert all(call["kwargs"] == {"enable_thinking": False} for call in tokenizer.calls)
+
+
+# ---------------------------------------------------------------------------
+# Network-gated runtime render assertion (arch open-risk #1).
+# ---------------------------------------------------------------------------
+
+_LIVE_HUB = os.environ.get("RUN_LIVE_HUB") == "1"
+
+# Qwen3-0.6B ships the same chat-template family as the hybrid 4B/8B presets and
+# is the smallest model the architect verified the template logic against.
+_QWEN3_TEMPLATE_MODEL = "Qwen/Qwen3-0.6B"
+_THINK_OFF_MARKER = "<think>\n\n</think>"
+
+
+@pytest.mark.skipif(
+    not _LIVE_HUB,
+    reason="network-gated; set RUN_LIVE_HUB=1 to download the Qwen3 tokenizer and render",
+)
+def test_enable_thinking_false_masks_marker_out_of_target_keeps_it_in_prompt():
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(_QWEN3_TEMPLATE_MODEL)
+
+    # The unmasked TRAINING TARGET (the only span that contributes loss) must
+    # decode to the clean completion with NO <think> scaffolding. The Qwen3
+    # template injects the empty think-off marker UNCONDITIONALLY, but it lands
+    # in the prompt prefix, which the assistant-only loss mask zeroes out — so it
+    # never reaches the supervised target. We exercise the real preprocessing
+    # path (not a raw render) so the mask is applied exactly as in training.
+    prepared = materialize_sft_example(
+        tokenizer=tokenizer,
+        record=_EXAMPLE,
+        max_seq_length=512,
+        assistant_only_loss=True,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+    assert prepared.loss_mask_mode == "assistant_only"
+
+    target_ids = [
+        tok
+        for tok, label in zip(prepared.input_ids, prepared.labels)
+        if label != -100
+    ]
+    assert target_ids, "expected a non-empty unmasked training target span"
+    target_str = tokenizer.decode(target_ids)
+    assert "<think>" not in target_str, (
+        "Unmasked training target must not contain a <think> block — the "
+        "unconditional think-off marker belongs to the masked prompt prefix; "
+        f"got target:\n{target_str}"
+    )
+    assert "I don't know." in target_str, (
+        "Unmasked training target must carry the clean IDK completion; "
+        f"got target:\n{target_str}"
+    )
+
+    # Prompt-only (the loss-mask prefix == eval-time prompt): with
+    # enable_thinking=False the Qwen3 template injects the empty think-off marker
+    # at the generation prompt. This is what aligns train and eval prompts.
+    prompt_str = tokenizer.apply_chat_template(
+        _EXAMPLE["messages"][:-1],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    assert _THINK_OFF_MARKER in prompt_str, (
+        "Prompt-only render must carry the think-off marker "
+        f"{_THINK_OFF_MARKER!r} at the generation prompt; got:\n{prompt_str}"
+    )

--- a/tests/trainers/sft/test_train_sft_source.py
+++ b/tests/trainers/sft/test_train_sft_source.py
@@ -12,3 +12,13 @@ def test_train_sft_uses_runtime_compatible_trl_tokenizer_kwarg() -> None:
     assert "Trainer(" in source
     assert '"dataset_representation": "tokenized"' in source
     assert "dataset_text_field" not in source
+
+
+def test_train_sft_seed_override_is_wired_with_is_not_none() -> None:
+    # train_sft imports unsloth at module load, so verify the --seed flag and its
+    # is-not-None override (honoring seed=0) at the source level.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+
+    assert '"--seed"' in source
+    assert "if args.seed is not None:" in source
+    assert "config.seed = args.seed" in source

--- a/tests/trainers/sft/test_train_sft_source.py
+++ b/tests/trainers/sft/test_train_sft_source.py
@@ -22,3 +22,29 @@ def test_train_sft_seed_override_is_wired_with_is_not_none() -> None:
     assert '"--seed"' in source
     assert "if args.seed is not None:" in source
     assert "config.seed = args.seed" in source
+
+
+def test_train_sft_numeric_overrides_are_hardened_is_not_none() -> None:
+    # The fifth silent-substitution instance (focus item 7), hardened in #41:
+    # batch_size / num_epochs / max_seq_length / gradient_accumulation /
+    # learning_rate override guards must use is not None so an explicit 0 forwards
+    # to config rather than being dropped to the default.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+
+    for guard in (
+        "if args.batch_size is not None:",
+        "if args.num_epochs is not None:",
+        "if args.max_seq_length is not None:",
+        "if args.gradient_accumulation is not None:",
+        "if args.learning_rate is not None:",
+    ):
+        assert guard in source, f"SFT trainer missing hardened guard: {guard}"
+    # The pre-hardening truthy guards must be gone.
+    for stale in (
+        "if args.batch_size:",
+        "if args.num_epochs:",
+        "if args.max_seq_length:",
+        "if args.gradient_accumulation:",
+        "if args.learning_rate:",
+    ):
+        assert stale not in source, f"SFT trainer still has truthy guard: {stale}"

--- a/tuner/backends/evaluation/llamacpp_backend.py
+++ b/tuner/backends/evaluation/llamacpp_backend.py
@@ -128,7 +128,7 @@ class LlamaCppBackend(IEvaluationBackend):
         """
         models = []
 
-        for method in ("sft", "kto", "grpo"):
+        for method in ("sft", "kto", "grpo", "dpo"):
             for output_dir in iter_training_output_dirs(method, self._repo_root):
                 if not output_dir.exists():
                     continue

--- a/tuner/backends/evaluation/mlc_backend.py
+++ b/tuner/backends/evaluation/mlc_backend.py
@@ -66,7 +66,7 @@ class MLCBackend(IEvaluationBackend):
         """
         models = []
 
-        for method in ("sft", "kto", "grpo"):
+        for method in ("sft", "kto", "grpo", "dpo"):
             for output_dir in iter_training_output_dirs(method, self._repo_root):
                 if not output_dir.exists():
                     continue

--- a/tuner/backends/evaluation/unsloth_backend.py
+++ b/tuner/backends/evaluation/unsloth_backend.py
@@ -52,7 +52,7 @@ class UnslothBackend(IEvaluationBackend):
         """List available LoRA adapters from training outputs.
 
         Searches for final_model directories containing adapter_config.json in
-        the canonical SFT, KTO, and GRPO output directories.
+        the canonical SFT, KTO, GRPO, and DPO output directories.
 
         Returns:
             List of adapter directory paths (absolute paths)
@@ -60,7 +60,7 @@ class UnslothBackend(IEvaluationBackend):
         """
         models = []
 
-        for method in ("sft", "kto", "grpo"):
+        for method in ("sft", "kto", "grpo", "dpo"):
             for output_dir in iter_training_output_dirs(method, self._repo_root):
                 if not output_dir.exists():
                     continue

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -137,6 +137,10 @@ class HFCommandBuilderMixin:
             training_args.extend(["--gradient-accumulation", str(config.gradient_accumulation_steps)])
         if config.learning_rate:
             training_args.extend(["--learning-rate", str(config.learning_rate)])
+        if config.seed is not None:
+            training_args.extend(["--seed", str(config.seed)])
+        if config.method in ("dpo", "kto") and config.beta is not None:
+            training_args.extend(["--beta", str(config.beta)])
         if config.epochs is not None:
             training_args.extend(["--num-epochs", str(config.epochs)])
         if config.max_steps is not None:

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -10,6 +10,7 @@ the HF Jobs container: dependency installation, repo checkout, training
 script invocation, and GRPO virtual-env bootstrapping.
 """
 
+import json
 import shlex
 import yaml
 
@@ -147,6 +148,13 @@ class HFCommandBuilderMixin:
             training_args.extend(["--max-steps", str(config.max_steps)])
         if config.max_seq_length is not None:
             training_args.extend(["--max-seq-length", str(config.max_seq_length)])
+        # chat_template_kwargs is a nested mapping; serialize to the same JSON-string
+        # --chat-template-kwargs flag the local lane uses (one wire format, both
+        # lanes). sft-only: dpo/kto template internally via TRL and expose no flag.
+        if config.method == "sft" and config.chat_template_kwargs is not None:
+            training_args.extend(
+                ["--chat-template-kwargs", json.dumps(config.chat_template_kwargs)]
+            )
         if config.method == "sft" and config.load_in_4bit is not None:
             training_args.append("--load-in-4bit" if config.load_in_4bit else "--no-load-in-4bit")
         if config.method == "sft" and config.lora_r is not None:

--- a/tuner/backends/training/cloud/base_cloud.py
+++ b/tuner/backends/training/cloud/base_cloud.py
@@ -107,7 +107,7 @@ def load_gpu_pricing(cloud_config_path: Optional[Path] = None) -> dict:
 
 
 # Supported training methods across all cloud backends
-SUPPORTED_METHODS = ("sft", "kto", "grpo")
+SUPPORTED_METHODS = ("sft", "kto", "grpo", "dpo")
 
 
 def validate_training_method(method: str, backend_name: str) -> None:

--- a/tuner/backends/training/cloud/hf_jobs_backend.py
+++ b/tuner/backends/training/cloud/hf_jobs_backend.py
@@ -120,9 +120,9 @@ class HFJobsBackend(
         the scripts run unchanged in the cloud environment.
 
         Returns:
-            List of method names: ['sft', 'kto', 'grpo']
+            List of method names: ['sft', 'kto', 'grpo', 'dpo']
         """
-        return ["sft", "kto", "grpo"]
+        return ["sft", "kto", "grpo", "dpo"]
 
     def validate_environment(self) -> Tuple[bool, str]:
         """

--- a/tuner/backends/training/cloud/hf_jobs_backend.py
+++ b/tuner/backends/training/cloud/hf_jobs_backend.py
@@ -235,6 +235,7 @@ class HFJobsBackend(
             batch_size=training_config.get("per_device_train_batch_size", 4),
             learning_rate=training_config.get("learning_rate", 0.0),
             gradient_accumulation_steps=training_config.get("gradient_accumulation_steps"),
+            chat_template_kwargs=training_config.get("chat_template_kwargs"),
             save_steps=training_config.get("save_steps"),
             save_total_limit=training_config.get("save_total_limit"),
             max_seq_length=training_config.get("max_seq_length") or training_config.get("max_prompt_length") or model_config.get("max_seq_length"),

--- a/tuner/backends/training/rtx_backend.py
+++ b/tuner/backends/training/rtx_backend.py
@@ -101,9 +101,9 @@ class RTXBackend(ITrainingBackend):
         Get available training methods for RTX backend.
 
         Returns:
-            List of method names: ['sft', 'kto', 'grpo']
+            List of method names: ['sft', 'kto', 'grpo', 'dpo']
         """
-        return ["sft", "kto", "grpo"]
+        return ["sft", "kto", "grpo", "dpo"]
 
     def load_config(self, method: str) -> TrainingConfig:
         """

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -219,7 +219,7 @@ Examples:
 
     # Cloud-specific flags
     parser.add_argument("--run", help="Cloud run slug or prefix to use (cloud-eval, cloud-gym only). Use 'latest' for newest.")
-    parser.add_argument("--method", choices=["sft", "kto", "grpo"], help="Training method for cloud-pipeline, or training method filter for cloud-eval/cloud-gym.")
+    parser.add_argument("--method", choices=["sft", "kto", "grpo", "dpo"], help="Training method for cloud-pipeline, or training method filter for cloud-eval/cloud-gym.")
     parser.add_argument("--bucket", help="Override HF bucket identifier for cloud-eval/cloud-gym/bucket.")
     parser.add_argument("--path", help="Bucket-relative, hf://, or local path for bucket commands.")
     parser.add_argument("--dest", help="Destination for bucket pull/push. Local dir for pull, remote bucket path for push.")

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -288,6 +288,8 @@ Examples:
     parser.add_argument("--train-save-total-limit", type=int, help="Override max checkpoints kept for cloud/cloud-pipeline training.")
     parser.add_argument("--train-gradient-accumulation", type=int, help="Override gradient accumulation steps for cloud/cloud-pipeline training.")
     parser.add_argument("--train-learning-rate", type=float, help="Override learning rate for cloud/cloud-pipeline training.")
+    parser.add_argument("--train-seed", type=int, help="Override the training random seed for cloud/cloud-pipeline training.")
+    parser.add_argument("--train-beta", type=float, help="Override the DPO/KTO beta parameter for cloud/cloud-pipeline training.")
     parser.add_argument("--train-num-epochs", type=int, help="Override epochs for cloud/cloud-pipeline training.")
     parser.add_argument("--train-max-steps", type=int, help="Override max training steps for cloud/cloud-pipeline training.")
     parser.add_argument("--train-max-seq-length", type=int, help="Override max sequence length for cloud/cloud-pipeline training.")

--- a/tuner/core/config.py
+++ b/tuner/core/config.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -259,6 +259,11 @@ class CloudTrainingConfig(TrainingConfig):
     gradient_accumulation_steps: Optional[int] = None
     seed: Optional[int] = None
     beta: Optional[float] = None
+    # Generic kwargs forwarded into the tokenizer chat template at preprocessing
+    # time (e.g. {"enable_thinking": False}). Mirrors the SFT local lane; the
+    # builder serializes it as the JSON-string --chat-template-kwargs flag. None
+    # ⇒ no flag ⇒ default rendering for every existing cloud config.
+    chat_template_kwargs: Optional[Dict[str, Any]] = None
     save_steps: Optional[int] = None
     save_total_limit: Optional[int] = None
     max_steps: Optional[int] = None

--- a/tuner/core/config.py
+++ b/tuner/core/config.py
@@ -257,6 +257,8 @@ class CloudTrainingConfig(TrainingConfig):
     repo_commit: Optional[str] = None
     dataset_name: Optional[str] = None
     gradient_accumulation_steps: Optional[int] = None
+    seed: Optional[int] = None
+    beta: Optional[float] = None
     save_steps: Optional[int] = None
     save_total_limit: Optional[int] = None
     max_steps: Optional[int] = None

--- a/tuner/discovery/base_models.py
+++ b/tuner/discovery/base_models.py
@@ -146,7 +146,7 @@ class BaseModelDiscovery:
         results: List[ModelInfo] = []
 
         # Trainer output directories
-        for trainer_type in ("sft", "kto", "grpo"):
+        for trainer_type in ("sft", "kto", "grpo", "dpo"):
             for output_dir in iter_training_output_dirs(trainer_type, self.repo_root):
                 if not output_dir.exists():
                     continue

--- a/tuner/handlers/cloud_train_handler.py
+++ b/tuner/handlers/cloud_train_handler.py
@@ -317,6 +317,14 @@ class CloudTrainHandler(BaseHandler):
         if train_learning_rate is not None:
             config.learning_rate = train_learning_rate
 
+        train_seed = getattr(args, "train_seed", None)
+        if train_seed is not None:
+            config.seed = train_seed
+
+        train_beta = getattr(args, "train_beta", None)
+        if train_beta is not None and config.method in ("dpo", "kto"):
+            config.beta = train_beta
+
         train_num_epochs = getattr(args, "train_num_epochs", None)
         if train_num_epochs is not None:
             config.epochs = train_num_epochs

--- a/tuner/handlers/doctor_handler.py
+++ b/tuner/handlers/doctor_handler.py
@@ -649,7 +649,7 @@ class DoctorHandler(BaseHandler):
                 ))
 
         # Training output folders
-        for trainer in ["sft", "kto", "grpo"]:
+        for trainer in ["sft", "kto", "grpo", "dpo"]:
             for output_folder in iter_training_output_dirs(trainer, self.repo_root):
                 if output_folder.exists():
                     run_count = len([d for d in output_folder.iterdir() if d.is_dir()])

--- a/tuner/handlers/local_run_handler.py
+++ b/tuner/handlers/local_run_handler.py
@@ -475,7 +475,14 @@ class LocalRunHandler(BaseHandler):
             return {str(k): self._render_value(v, variables) for k, v in value.items()}
         return value
 
-    def _build_sft_command(self, cfg: dict[str, Any], variables: dict[str, str]) -> tuple[list[str], str, Path]:
+    def _build_trainer_command(
+        self, cfg: dict[str, Any], variables: dict[str, str], method: str
+    ) -> tuple[list[str], str, Path]:
+        # Builds the trainer invocation for any registered method. The trainer
+        # script is selected by run.trainer; the per-method flag dialect differs,
+        # so SFT-only flags (LoRA scalars, dashboard/quiet toggles, 4bit, save
+        # cadence) are gated to sft, beta is gated to dpo/kto, and the shared
+        # hyperparameter flags forward for all methods. See _flag_dialect below.
         model_cfg = cfg.get("model", {}) if isinstance(cfg.get("model"), dict) else {}
         dataset_cfg = cfg.get("dataset", {}) if isinstance(cfg.get("dataset"), dict) else {}
         training_cfg = cfg.get("training", {}) if isinstance(cfg.get("training"), dict) else {}
@@ -483,15 +490,21 @@ class LocalRunHandler(BaseHandler):
         run_cfg = cfg.get("run", {}) if isinstance(cfg.get("run"), dict) else {}
         artifacts_cfg = cfg.get("artifacts", {}) if isinstance(cfg.get("artifacts"), dict) else {}
 
-        trainer_path = Path(str(run_cfg.get("trainer", "Trainers/sft/train_sft.py")))
+        default_trainer = f"Trainers/{method}/train_{method}.py"
+        trainer_path = Path(str(run_cfg.get("trainer", default_trainer)))
         trainer_dir = trainer_path.parent
         trainer_file = trainer_path.name
         workdir = "/workspace/repo/" + trainer_dir.as_posix()
 
+        # Flags the dpo/kto trainers do not expose as CLI args (they read these
+        # from their YAML config instead). Emitting them would make argparse
+        # reject the command, so they are forwarded only for sft.
+        sft_only = method == "sft"
+
         command = ["python", trainer_file]
         _append_flag(command, "model_name", model_cfg.get("name") or model_cfg.get("model_name"))
         _append_flag(command, "model_size", model_cfg.get("size"))
-        if "load_in_4bit" in model_cfg:
+        if sft_only and "load_in_4bit" in model_cfg:
             command.append("--load-in-4bit" if bool(model_cfg["load_in_4bit"]) else "--no-load-in-4bit")
         _append_flag(command, "max_seq_length", model_cfg.get("max_seq_length") or training_cfg.get("max_seq_length"))
 
@@ -510,24 +523,40 @@ class LocalRunHandler(BaseHandler):
             "batch_size",
             "gradient_accumulation",
             "learning_rate",
+            "seed",
             "num_epochs",
             "max_steps",
-            "save_steps",
-            "save_total_limit",
         ):
             _append_flag(command, key, training_cfg.get(key))
+        if sft_only:
+            for key in ("save_steps", "save_total_limit"):
+                _append_flag(command, key, training_cfg.get(key))
 
+        # beta forwards only for dpo/kto (sft has no --beta argparse). is not None
+        # so an explicit beta: 0.0 is honored, not silently swapped for the trainer
+        # default — mirroring the --seed semantics (provenance: no silent override).
+        if method in ("dpo", "kto"):
+            beta = training_cfg.get("beta")
+            if beta is not None:
+                _append_flag(command, "beta", beta)
+
+        # LoRA scalars forward for all methods: the recipe's lora budget is the
+        # SSOT and must flow end-to-end (gating these would silently run dpo/kto at
+        # the trainer-default budget, breaking the identical-LoRA-budget control).
+        # All three trainers accept these CLI flags.
         _append_flag(command, "lora_r", lora_cfg.get("r"))
         _append_flag(command, "lora_alpha", lora_cfg.get("alpha") or lora_cfg.get("lora_alpha"))
         _append_flag(command, "lora_dropout", lora_cfg.get("dropout") or lora_cfg.get("lora_dropout"))
         _append_flag(command, "lora_target_modules", lora_cfg.get("target_modules"))
+        _append_flag(command, "init_lora_weights", lora_cfg.get("init_lora_weights"))
         if bool(lora_cfg.get("use_dora", False)):
             command.append("--use-dora")
         if bool(lora_cfg.get("use_rslora", False)):
             command.append("--use-rslora")
-        _append_flag(command, "init_lora_weights", lora_cfg.get("init_lora_weights"))
 
-        output_root = artifacts_cfg.get("output_root", "toolset-training-artifacts/runs/local_docker/sft/{name}")
+        output_root = artifacts_cfg.get(
+            "output_root", "toolset-training-artifacts/runs/local_docker/" + method + "/{name}"
+        )
         output_root = str(self._render_value(output_root, variables))
         run_timestamp = str(
             self._render_value(
@@ -542,10 +571,12 @@ class LocalRunHandler(BaseHandler):
             _append_flag(command, key, training_cfg.get(key))
         if bool(run_cfg.get("dry_run", False)):
             command.append("--dry-run")
-        if not bool(run_cfg.get("dashboard", False)):
-            command.append("--no-dashboard")
-        if bool(run_cfg.get("quiet", True)):
-            command.append("--quiet")
+        # --no-dashboard / --quiet are sft-only CLI toggles; dpo/kto do not expose them.
+        if sft_only:
+            if not bool(run_cfg.get("dashboard", False)):
+                command.append("--no-dashboard")
+            if bool(run_cfg.get("quiet", True)):
+                command.append("--quiet")
         command.extend(_as_list(run_cfg.get("extra_args")))
 
         host_artifact_path = self._rel_path(Path(output_root) / run_timestamp)
@@ -577,10 +608,12 @@ class LocalRunHandler(BaseHandler):
             host_artifact_path = self._rel_path(
                 artifacts_cfg.get("host_path", f"toolset-training-artifacts/runs/local_docker/custom/{name}")
             )
-        elif method == "sft":
-            command, workdir, host_artifact_path = self._build_sft_command(cfg, variables)
+        elif method in ("sft", "dpo", "kto"):
+            command, workdir, host_artifact_path = self._build_trainer_command(cfg, variables, method)
         else:
-            raise LocalRunError("local-run currently supports run.method: sft or an explicit run.command list.")
+            raise LocalRunError(
+                "local-run supports run.method: sft, dpo, kto, or an explicit run.command list."
+            )
 
         transfer_mode = str(job_cfg.get("transfer", "auto")).lower()
         if transfer_mode == "auto":
@@ -592,7 +625,10 @@ class LocalRunHandler(BaseHandler):
 
         copy_paths = [Path(path) for path in _as_list(setup_cfg.get("copy"))]
         if transfer_mode == "copy" and not copy_paths:
-            copy_paths = [Path("Trainers/sft"), Path("shared"), Path("tuner")]
+            # Copy the trainer directory the dispatched method actually runs from
+            # (run.trainer selects it per method) rather than always Trainers/sft.
+            trainer_dir = Path(str(run_cfg.get("trainer", f"Trainers/{method}/train_{method}.py"))).parent
+            copy_paths = [trainer_dir, Path("shared"), Path("tuner")]
             dataset_cfg = cfg.get("dataset", {}) if isinstance(cfg.get("dataset"), dict) else {}
             if dataset_cfg.get("local_file"):
                 copy_paths.append(Path(str(dataset_cfg["local_file"])))

--- a/tuner/handlers/local_run_handler.py
+++ b/tuner/handlers/local_run_handler.py
@@ -531,6 +531,16 @@ class LocalRunHandler(BaseHandler):
         if sft_only:
             for key in ("save_steps", "save_total_limit"):
                 _append_flag(command, key, training_cfg.get(key))
+            # chat_template_kwargs is a nested mapping, not a scalar, so it cannot
+            # ride the _append_flag scalar/list path. Serialize to a JSON object
+            # string and forward via --chat-template-kwargs (sft-only: the dpo/kto
+            # trainers template internally via TRL and expose no such flag). Omitted
+            # entirely when unset so existing recipes are byte-identical.
+            chat_template_kwargs = training_cfg.get("chat_template_kwargs")
+            if chat_template_kwargs is not None:
+                command.extend(
+                    ["--chat-template-kwargs", json.dumps(chat_template_kwargs)]
+                )
 
         # beta forwards only for dpo/kto (sft has no --beta argparse). is not None
         # so an explicit beta: 0.0 is honored, not silently swapped for the trainer

--- a/tuner/handlers/merge_handler.py
+++ b/tuner/handlers/merge_handler.py
@@ -62,7 +62,7 @@ class MergeHandler(BaseHandler):
 
         checkpoints = []
 
-        for trainer_type in ['sft', 'kto', 'grpo']:
+        for trainer_type in ['sft', 'kto', 'grpo', 'dpo']:
             runs = discovery.discover(trainer_type, limit=20)
 
             for run_path in runs:

--- a/tuner/handlers/stages/hf_training_stage.py
+++ b/tuner/handlers/stages/hf_training_stage.py
@@ -150,6 +150,10 @@ class HFTrainingStageRunner:
             config.gradient_accumulation_steps = spec.training.gradient_accumulation
         if spec.training.learning_rate is not None:
             config.learning_rate = spec.training.learning_rate
+        if spec.training.seed is not None:
+            config.seed = spec.training.seed
+        if spec.method in ("dpo", "kto") and spec.training.beta is not None:
+            config.beta = spec.training.beta
         if spec.training.num_epochs is not None:
             config.epochs = spec.training.num_epochs
         if spec.training.max_steps is not None:

--- a/tuner/handlers/train_handler.py
+++ b/tuner/handlers/train_handler.py
@@ -139,7 +139,7 @@ class TrainHandler(BaseHandler):
             platforms.append({
                 "id": "rtx",
                 "name": "NVIDIA GPU (CUDA)",
-                "methods": ["sft", "kto", "grpo"]
+                "methods": ["sft", "kto", "grpo", "dpo"]
             })
         if has_mlx:
             platforms.append({


### PR DESCRIPTION
Summary:
- Add the missing logging import used by the KTO trainer's registry/logging path.
- Add a regression test that pins logging.getLogger usage to an import.
- Correct dataset-publishing skill examples to call the checked-in script path from repo root.

Validation:
- python -m pytest synaptic-tuner\tests\trainers\kto\test_train_kto_source.py -q
- C:\Users\Joseph\miniconda3\envs\kto\python.exe .skills\scripts\sync_skill_trees.py --check