### PR TITLE
[codex] Quote HF Jobs bucket sync dependencies

### DIFF
--- a/.agents/skills/fine-tuning/reference/cloud-training.md
+++ b/.agents/skills/fine-tuning/reference/cloud-training.md
@@ -182,6 +182,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
 - Resolve and, if needed, create the bucket once before training starts. During steady-state log sync, use the resolved bucket ID directly.
 - Keep HF job labels conservative. Do not put slash-heavy values like raw `bucket_id` or `artifact_prefix` into labels; HF Jobs can reject submission. Recover those values from command args or other metadata instead.
 - Polling and identity checks should be conservative. Frequent bucket creation attempts or repeated `whoami-v2` calls can hit Hugging Face rate limits.
+- On Windows launch hosts, set `PYTHONIOENCODING=utf-8` for non-JSON cloud
+  launches. Rich UI output can contain glyphs such as `★`, and the default
+  `cp1252` console path can crash before job submission with
+  `UnicodeEncodeError`.
+- Keep HF Jobs launcher dependencies isolated from the trainer runtime. A
+  launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
+  `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
+  Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Quote remote pip requirements that contain shell metacharacters. In HF Jobs
+  bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
+  as output redirection rather than a pip requirement. Use shell quoting, e.g.
+  `'huggingface_hub>=1.5.0'`.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/.claude/skills/fine-tuning/reference/cloud-training.md
+++ b/.claude/skills/fine-tuning/reference/cloud-training.md
@@ -182,6 +182,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
 - Resolve and, if needed, create the bucket once before training starts. During steady-state log sync, use the resolved bucket ID directly.
 - Keep HF job labels conservative. Do not put slash-heavy values like raw `bucket_id` or `artifact_prefix` into labels; HF Jobs can reject submission. Recover those values from command args or other metadata instead.
 - Polling and identity checks should be conservative. Frequent bucket creation attempts or repeated `whoami-v2` calls can hit Hugging Face rate limits.
+- On Windows launch hosts, set `PYTHONIOENCODING=utf-8` for non-JSON cloud
+  launches. Rich UI output can contain glyphs such as `★`, and the default
+  `cp1252` console path can crash before job submission with
+  `UnicodeEncodeError`.
+- Keep HF Jobs launcher dependencies isolated from the trainer runtime. A
+  launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
+  `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
+  Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Quote remote pip requirements that contain shell metacharacters. In HF Jobs
+  bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
+  as output redirection rather than a pip requirement. Use shell quoting, e.g.
+  `'huggingface_hub>=1.5.0'`.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/.skills/fine-tuning/reference/cloud-training.md
+++ b/.skills/fine-tuning/reference/cloud-training.md
@@ -182,6 +182,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
 - Resolve and, if needed, create the bucket once before training starts. During steady-state log sync, use the resolved bucket ID directly.
 - Keep HF job labels conservative. Do not put slash-heavy values like raw `bucket_id` or `artifact_prefix` into labels; HF Jobs can reject submission. Recover those values from command args or other metadata instead.
 - Polling and identity checks should be conservative. Frequent bucket creation attempts or repeated `whoami-v2` calls can hit Hugging Face rate limits.
+- On Windows launch hosts, set `PYTHONIOENCODING=utf-8` for non-JSON cloud
+  launches. Rich UI output can contain glyphs such as `★`, and the default
+  `cp1252` console path can crash before job submission with
+  `UnicodeEncodeError`.
+- Keep HF Jobs launcher dependencies isolated from the trainer runtime. A
+  launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
+  `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
+  Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Quote remote pip requirements that contain shell metacharacters. In HF Jobs
+  bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
+  as output redirection rather than a pip requirement. Use shell quoting, e.g.
+  `'huggingface_hub>=1.5.0'`.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -326,7 +326,8 @@ class TestBuildTrainingCommand:
         cmd = backend._build_training_command(config, timestamp="20260314_181946")
         assert "$(command -v python3 || command -v python) -m pip install --upgrade" in cmd
         assert "mkdir -p /tmp/hf-bucket-sync-site" in cmd
-        assert "$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site huggingface_hub>=1.5.0 hf_transfer" in cmd
+        assert "$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer" in cmd
+        assert " huggingface_hub>=1.5.0 " not in cmd
         assert "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)" in cmd
         assert "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site" in cmd
         assert "export CLOUD_PROVIDER=hf_jobs" in cmd

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -91,6 +91,10 @@ class HFCommandBuilderMixin:
         # Read project-specific deps from cloud_config.yaml (single source of truth)
         cloud_config_path = self.repo_root / "Trainers" / "cloud" / "cloud_config.yaml"
         project_deps = load_project_deps(cloud_config_path)
+        quoted_project_deps = " ".join(shlex.quote(dep) for dep in project_deps)
+        sync_deps = " ".join(
+            shlex.quote(dep) for dep in ("huggingface_hub>=1.5.0", "hf_transfer")
+        )
         checkout_steps = build_repo_checkout_steps(
             RepoCheckoutSpec(
                 url=config.repo_url,
@@ -103,9 +107,9 @@ class HFCommandBuilderMixin:
         parts = [
             # Install project-specific deps only; unsloth, trl, transformers,
             # datasets, peft, and PyTorch are pre-installed in the Docker image
-            f"{python_cmd} -m pip install --upgrade {' '.join(project_deps)}",
+            f"{python_cmd} -m pip install --upgrade {quoted_project_deps}",
             "mkdir -p /tmp/hf-bucket-sync-site",
-            f"{python_cmd} -m pip install --upgrade --target /tmp/hf-bucket-sync-site huggingface_hub>=1.5.0 hf_transfer",
+            f"{python_cmd} -m pip install --upgrade --target /tmp/hf-bucket-sync-site {sync_deps}",
             f"export HF_BUCKET_SYNC_PYTHON={python_cmd}",
             "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site",
             f"export CLOUD_PROVIDER={config.provider}",


### PR DESCRIPTION
Summary:
- Shell-quote HF Jobs remote pip requirements before joining command strings.
- Pin a regression test so huggingface_hub>=1.5.0 is quoted and cannot be parsed as bash redirection.
- Document launcher gotchas: isolated launcher venv, PYTHONIOENCODING=utf-8, and quoted pip requirements.

Validation:
- python -m pytest tests\\cloud\\test_hf_jobs_backend.py -q
- C:\\tmp\\hfjobs-launcher\\Scripts\\python.exe .skills\\scripts\\sync_skill_trees.py --check