### PR TITLE
[codex] Avoid upgrading HF Jobs training runtime deps

### DIFF
--- a/.agents/skills/fine-tuning/reference/cloud-training.md
+++ b/.agents/skills/fine-tuning/reference/cloud-training.md
@@ -190,6 +190,12 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
   `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
   Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Do not upgrade generic project dependencies in the active training image
+  during HF Jobs bootstrap. Install missing project deps only; curated Unsloth
+  images can carry tightly coupled NumPy/SciPy/Transformers/Unsloth stacks, and
+  in-place upgrades before `import unsloth` can leave C-extension packages in a
+  mixed state. Use explicit stage-local `pip_packages` only when a run is
+  intentionally testing a new runtime.
 - Quote remote pip requirements that contain shell metacharacters. In HF Jobs
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.

--- a/.claude/skills/fine-tuning/reference/cloud-training.md
+++ b/.claude/skills/fine-tuning/reference/cloud-training.md
@@ -190,6 +190,12 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
   `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
   Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Do not upgrade generic project dependencies in the active training image
+  during HF Jobs bootstrap. Install missing project deps only; curated Unsloth
+  images can carry tightly coupled NumPy/SciPy/Transformers/Unsloth stacks, and
+  in-place upgrades before `import unsloth` can leave C-extension packages in a
+  mixed state. Use explicit stage-local `pip_packages` only when a run is
+  intentionally testing a new runtime.
 - Quote remote pip requirements that contain shell metacharacters. In HF Jobs
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.

--- a/.skills/fine-tuning/reference/cloud-training.md
+++ b/.skills/fine-tuning/reference/cloud-training.md
@@ -190,6 +190,12 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   launcher-only venv with `huggingface_hub>=1.5.0`, `transformers` 5.x, and CPU
   `torch` can satisfy local CLI imports and Buckets APIs without upgrading the
   Unsloth/KTO training env, which may still require `huggingface_hub<1.0`.
+- Do not upgrade generic project dependencies in the active training image
+  during HF Jobs bootstrap. Install missing project deps only; curated Unsloth
+  images can carry tightly coupled NumPy/SciPy/Transformers/Unsloth stacks, and
+  in-place upgrades before `import unsloth` can leave C-extension packages in a
+  mixed state. Use explicit stage-local `pip_packages` only when a run is
+  intentionally testing a new runtime.
 - Quote remote pip requirements that contain shell metacharacters. In HF Jobs
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -324,7 +324,8 @@ class TestBuildTrainingCommand:
         backend = HFJobsBackend(repo_root)
         config = _cloud_config()
         cmd = backend._build_training_command(config, timestamp="20260314_181946")
-        assert "$(command -v python3 || command -v python) -m pip install --upgrade" in cmd
+        assert "$(command -v python3 || command -v python) -m pip install --disable-pip-version-check" in cmd
+        assert "$(command -v python3 || command -v python) -m pip install --upgrade pyyaml" not in cmd
         assert "mkdir -p /tmp/hf-bucket-sync-site" in cmd
         assert "$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer" in cmd
         assert " huggingface_hub>=1.5.0 " not in cmd

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -107,7 +107,7 @@ class HFCommandBuilderMixin:
         parts = [
             # Install project-specific deps only; unsloth, trl, transformers,
             # datasets, peft, and PyTorch are pre-installed in the Docker image
-            f"{python_cmd} -m pip install --upgrade {quoted_project_deps}",
+            f"{python_cmd} -m pip install --disable-pip-version-check {quoted_project_deps}",
             "mkdir -p /tmp/hf-bucket-sync-site",
             f"{python_cmd} -m pip install --upgrade --target /tmp/hf-bucket-sync-site {sync_deps}",
             f"export HF_BUCKET_SYNC_PYTHON={python_cmd}",


### PR DESCRIPTION
Summary:
- Stop using --upgrade for generic project dependency installation in HF Jobs training commands.
- Keep explicit run-level pip_packages upgrade-capable, but avoid mutating curated Unsloth image stacks during baseline bootstrap.
- Document the NumPy/SciPy/Transformers/Unsloth mixed-runtime failure mode observed during HF Jobs smoke testing.

Validation:
- python -m pytest tests\\cloud\\test_hf_jobs_backend.py -q
- C:\\tmp\\hfjobs-launcher\\Scripts\\python.exe .skills\\scripts\\sync_skill_trees.py --check