### PR TITLE
[codex] Isolate HF Jobs bucket sync overlay deps

### DIFF
--- a/.agents/skills/fine-tuning/reference/cloud-training.md
+++ b/.agents/skills/fine-tuning/reference/cloud-training.md
@@ -200,6 +200,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.
   `'huggingface_hub>=1.5.0'`.
+- Keep bucket-sync overlay installs dependency-isolated. The overlay exists to
+  provide a newer Hub/Buckets client to the sync helper, not to replace the
+  training image's dependency graph; install it with `--target` and `--no-deps`
+  so global image packages remain authoritative.
+- Image-profile blockers should be classified before changing training
+  hyperparameters. In the Phase 1 HF Jobs smoke, `unsloth/unsloth:latest`
+  failed before trainer import with an Unsloth NumPy mid-session mismatch
+  (`loaded: 2.2.6, installed: 2.4.1`), while
+  `unsloth/unsloth:2026.2.1-pt2.9.0-cu12.8-fixed-numba-numpy-error` failed
+  before trainer import at `ModuleNotFoundError: numpy._core.tests` through
+  SciPy/Transformers. Treat those as image/runtime-profile failures, not
+  dataset or LoRA failures.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/.claude/skills/fine-tuning/reference/cloud-training.md
+++ b/.claude/skills/fine-tuning/reference/cloud-training.md
@@ -200,6 +200,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.
   `'huggingface_hub>=1.5.0'`.
+- Keep bucket-sync overlay installs dependency-isolated. The overlay exists to
+  provide a newer Hub/Buckets client to the sync helper, not to replace the
+  training image's dependency graph; install it with `--target` and `--no-deps`
+  so global image packages remain authoritative.
+- Image-profile blockers should be classified before changing training
+  hyperparameters. In the Phase 1 HF Jobs smoke, `unsloth/unsloth:latest`
+  failed before trainer import with an Unsloth NumPy mid-session mismatch
+  (`loaded: 2.2.6, installed: 2.4.1`), while
+  `unsloth/unsloth:2026.2.1-pt2.9.0-cu12.8-fixed-numba-numpy-error` failed
+  before trainer import at `ModuleNotFoundError: numpy._core.tests` through
+  SciPy/Transformers. Treat those as image/runtime-profile failures, not
+  dataset or LoRA failures.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/.skills/fine-tuning/reference/cloud-training.md
+++ b/.skills/fine-tuning/reference/cloud-training.md
@@ -200,6 +200,18 @@ For `hf_jobs`, a few patterns matter enough to treat as hard rules:
   bash commands, an unquoted token like `huggingface_hub>=1.5.0` can be parsed
   as output redirection rather than a pip requirement. Use shell quoting, e.g.
   `'huggingface_hub>=1.5.0'`.
+- Keep bucket-sync overlay installs dependency-isolated. The overlay exists to
+  provide a newer Hub/Buckets client to the sync helper, not to replace the
+  training image's dependency graph; install it with `--target` and `--no-deps`
+  so global image packages remain authoritative.
+- Image-profile blockers should be classified before changing training
+  hyperparameters. In the Phase 1 HF Jobs smoke, `unsloth/unsloth:latest`
+  failed before trainer import with an Unsloth NumPy mid-session mismatch
+  (`loaded: 2.2.6, installed: 2.4.1`), while
+  `unsloth/unsloth:2026.2.1-pt2.9.0-cu12.8-fixed-numba-numpy-error` failed
+  before trainer import at `ModuleNotFoundError: numpy._core.tests` through
+  SciPy/Transformers. Treat those as image/runtime-profile failures, not
+  dataset or LoRA failures.
 
 If the training process itself is healthy but uploads fail, inspect bucket auth and sync isolation before touching trainer code.
 

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -327,7 +327,7 @@ class TestBuildTrainingCommand:
         assert "$(command -v python3 || command -v python) -m pip install --disable-pip-version-check" in cmd
         assert "$(command -v python3 || command -v python) -m pip install --upgrade pyyaml" not in cmd
         assert "mkdir -p /tmp/hf-bucket-sync-site" in cmd
-        assert "$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer" in cmd
+        assert "$(command -v python3 || command -v python) -m pip install --upgrade --no-deps --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer" in cmd
         assert " huggingface_hub>=1.5.0 " not in cmd
         assert "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)" in cmd
         assert "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site" in cmd

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -109,7 +109,7 @@ class HFCommandBuilderMixin:
             # datasets, peft, and PyTorch are pre-installed in the Docker image
             f"{python_cmd} -m pip install --disable-pip-version-check {quoted_project_deps}",
             "mkdir -p /tmp/hf-bucket-sync-site",
-            f"{python_cmd} -m pip install --upgrade --target /tmp/hf-bucket-sync-site {sync_deps}",
+            f"{python_cmd} -m pip install --upgrade --no-deps --target /tmp/hf-bucket-sync-site {sync_deps}",
             f"export HF_BUCKET_SYNC_PYTHON={python_cmd}",
             "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site",
             f"export CLOUD_PROVIDER={config.provider}",


### PR DESCRIPTION
Summary:
- Install HF bucket-sync overlay packages with --no-deps so the overlay cannot shadow or replace the active training image dependency graph.
- Keep the newer Hub/Buckets client isolated to the sync helper path.
- Document current Unsloth image-profile failures observed during Phase 1 HF Jobs smoke testing.

Validation:
- python -m pytest tests\\cloud\\test_hf_jobs_backend.py -q
- C:\\tmp\\hfjobs-launcher\\Scripts\\python.exe .skills\\scripts\\sync_skill_trees.py