### PR TITLE
[codex] Isolate HF Jobs bucket sync xet dependency

### DIFF
--- a/.agents/skills/fine-tuning/SKILL.md
+++ b/.agents/skills/fine-tuning/SKILL.md
@@ -502,6 +502,10 @@ Provider-native storage defaults:
 
 - Launch from a clean tracked worktree and a pushed commit only; the remote container checks out that exact SHA.
 - Keep the main training interpreter compatible with Unsloth and Transformers; any Buckets-only `huggingface_hub` upgrade must stay isolated from the trainer runtime.
+- Keep the bucket-sync overlay self-contained for the Hub client stack: install
+  `huggingface_hub>=1.5.0`, `hf_transfer`, and `hf_xet` into the overlay. Do
+  not rely on the base Unsloth image's `hf_xet`; older system copies can fail
+  final sync with `ImportError: cannot import name 'SKIP_SHA256'`.
 - Pass `HF_TOKEN` into the cloud job explicitly; do not assume HF Jobs injects it automatically.
 - Treat blank `HF_TOKEN` / `HF_API_KEY` values as unset, otherwise bucket sync can fail with `Authorization: Bearer `.
 - For post-training cloud evaluation, prefer `python tuner.py cloud-eval --run latest --preset full`.

--- a/.claude/skills/fine-tuning/SKILL.md
+++ b/.claude/skills/fine-tuning/SKILL.md
@@ -502,6 +502,10 @@ Provider-native storage defaults:
 
 - Launch from a clean tracked worktree and a pushed commit only; the remote container checks out that exact SHA.
 - Keep the main training interpreter compatible with Unsloth and Transformers; any Buckets-only `huggingface_hub` upgrade must stay isolated from the trainer runtime.
+- Keep the bucket-sync overlay self-contained for the Hub client stack: install
+  `huggingface_hub>=1.5.0`, `hf_transfer`, and `hf_xet` into the overlay. Do
+  not rely on the base Unsloth image's `hf_xet`; older system copies can fail
+  final sync with `ImportError: cannot import name 'SKIP_SHA256'`.
 - Pass `HF_TOKEN` into the cloud job explicitly; do not assume HF Jobs injects it automatically.
 - Treat blank `HF_TOKEN` / `HF_API_KEY` values as unset, otherwise bucket sync can fail with `Authorization: Bearer `.
 - For post-training cloud evaluation, prefer `python tuner.py cloud-eval --run latest --preset full`.

--- a/.skills/fine-tuning/SKILL.md
+++ b/.skills/fine-tuning/SKILL.md
@@ -502,6 +502,10 @@ Provider-native storage defaults:
 
 - Launch from a clean tracked worktree and a pushed commit only; the remote container checks out that exact SHA.
 - Keep the main training interpreter compatible with Unsloth and Transformers; any Buckets-only `huggingface_hub` upgrade must stay isolated from the trainer runtime.
+- Keep the bucket-sync overlay self-contained for the Hub client stack: install
+  `huggingface_hub>=1.5.0`, `hf_transfer`, and `hf_xet` into the overlay. Do
+  not rely on the base Unsloth image's `hf_xet`; older system copies can fail
+  final sync with `ImportError: cannot import name 'SKIP_SHA256'`.
 - Pass `HF_TOKEN` into the cloud job explicitly; do not assume HF Jobs injects it automatically.
 - Treat blank `HF_TOKEN` / `HF_API_KEY` values as unset, otherwise bucket sync can fail with `Authorization: Bearer `.
 - For post-training cloud evaluation, prefer `python tuner.py cloud-eval --run latest --preset full`.

--- a/Trainers/recipes/qwen3_4b_a100_large_loss_only_benchmark.yaml
+++ b/Trainers/recipes/qwen3_4b_a100_large_loss_only_benchmark.yaml
@@ -26,7 +26,7 @@ run:
     PYTHONPATH: "{repo_dir}"
   steps:
     - "mkdir -p /tmp/hf-bucket-sync-site"
-    - "cd {repo_dir} && python -m pip install --upgrade --target /tmp/hf-bucket-sync-site huggingface_hub>=1.5.0 hf_transfer"
+    - "cd {repo_dir} && python -m pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer hf_xet"
     - "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)"
     - "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site"
     - "export HF_HUB_ENABLE_HF_TRANSFER=1"

--- a/Trainers/recipes/qwen3_4b_a100x4_loss_only_benchmark.yaml
+++ b/Trainers/recipes/qwen3_4b_a100x4_loss_only_benchmark.yaml
@@ -26,7 +26,7 @@ run:
     PYTHONPATH: "{repo_dir}"
   steps:
     - "mkdir -p /tmp/hf-bucket-sync-site"
-    - "cd {repo_dir} && python -m pip install --upgrade --target /tmp/hf-bucket-sync-site huggingface_hub>=1.5.0 hf_transfer"
+    - "cd {repo_dir} && python -m pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer hf_xet"
     - "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)"
     - "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site"
     - "export HF_HUB_ENABLE_HF_TRANSFER=1"

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -21,12 +21,13 @@ Historical context from past development sessions. Non-obvious gotchas and runti
 **Key Lessons**:
 - HF Jobs runs the exact pushed commit; remote `HEAD` output is the fastest way to confirm whether you are debugging the right code
 - Hugging Face Buckets support and Unsloth/Transformers compatibility can require different `huggingface_hub` versions, so bucket sync must stay isolated from the training interpreter
+- The isolated bucket-sync overlay must include the Hub client's native xet helper dependency (`hf_xet`). If only `huggingface_hub>=1.5.0` is overlaid, the helper can import an incompatible base-image `hf_xet` and fail final sync with `ImportError: cannot import name 'SKIP_SHA256'`
 - Never assume HF Jobs injects the local `HF_TOKEN` into the container; pass it explicitly
 - Empty `HF_TOKEN` or `HF_API_KEY` values are worse than missing values because they generate `Authorization: Bearer ` and fail in `httpx` before the request reaches HF
 - Repeated bucket creation or `whoami-v2` checks during steady-state sync are enough to hit HF rate limits; resolve once, reuse the canonical bucket ID, and keep polling conservative
 - Local cloud TUI parity for HF Jobs depends on syncing training JSONL logs into the bucket during the run and replaying them locally
 
-**Decisions**: Resolve/create the bucket once before launch and normalize bare bucket names to the canonical namespaced bucket ID, remove the `HfFileSystem` fallback for bucket sync, keep the main Unsloth runtime on the image-compatible `huggingface_hub` version, isolate Buckets-only Hub functionality in a helper path installed with `pip --target`, pass `HF_TOKEN` into `run_job(...)` explicitly via job secrets, normalize blank auth values to unset, cache bucket resolution to reduce identity calls, and slow HF Jobs dashboard polling to reduce rate-limit pressure.
+**Decisions**: Resolve/create the bucket once before launch and normalize bare bucket names to the canonical namespaced bucket ID, remove the `HfFileSystem` fallback for bucket sync, keep the main Unsloth runtime on the image-compatible `huggingface_hub` version, isolate Buckets-only Hub functionality in a helper path installed with `pip --target`, install `hf_xet` in that helper path with the Hub client and transfer helper, pass `HF_TOKEN` into `run_job(...)` explicitly via job secrets, normalize blank auth values to unset, cache bucket resolution to reduce identity calls, and slow HF Jobs dashboard polling to reduce rate-limit pressure.
 
 ---
 

--- a/tests/cloud/test_cloud_eval_handler.py
+++ b/tests/cloud/test_cloud_eval_handler.py
@@ -41,6 +41,8 @@ def test_build_eval_command_uses_cloud_job_helper(repo_root):
     assert "--env-backend" in command
     assert "local" in command
     assert "huggingface_hub>=1.5.0" in command
+    assert "hf_transfer" in command
+    assert "hf_xet" in command
     assert "$(command -v python3 || command -v python)" in command
     assert "python3 -m Evaluator.cloud_hf_job" in command
     assert "export PYTHONPATH=/tmp/hf-eval-site${PYTHONPATH:+:$PYTHONPATH}" in command

--- a/tests/cloud/test_experiment_handler.py
+++ b/tests/cloud/test_experiment_handler.py
@@ -922,6 +922,7 @@ def test_loss_stage_runner_build_command_uses_python3_and_dataset_file(tmp_path:
     assert "python3 -m shared.experiment_tracking.cloud_loss_job" in command
     assert "--dataset-name professorsynapse/claudesidian-synthetic-dataset" in command
     assert "--dataset-file train.jsonl" in command
+    assert "pip install --upgrade --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer hf_xet" in command
     assert "pip install --upgrade transformers==5.3.0" in command
 
 

--- a/tests/cloud/test_hf_jobs_backend.py
+++ b/tests/cloud/test_hf_jobs_backend.py
@@ -24,6 +24,7 @@ from tuner.backends.training.cloud.hf_jobs_backend import (
     HFJobsBackend,
     _parse_timeout,
 )
+from tuner.cloud import HF_BUCKET_SYNC_OVERLAY_PACKAGES
 from tuner.core.config import CloudTrainingConfig, TrainingConfig
 from tuner.core.exceptions import CloudProviderError, ConfigurationError
 
@@ -327,7 +328,7 @@ class TestBuildTrainingCommand:
         assert "$(command -v python3 || command -v python) -m pip install --disable-pip-version-check" in cmd
         assert "$(command -v python3 || command -v python) -m pip install --upgrade pyyaml" not in cmd
         assert "mkdir -p /tmp/hf-bucket-sync-site" in cmd
-        assert "$(command -v python3 || command -v python) -m pip install --upgrade --no-deps --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer" in cmd
+        assert "$(command -v python3 || command -v python) -m pip install --upgrade --no-deps --target /tmp/hf-bucket-sync-site 'huggingface_hub>=1.5.0' hf_transfer hf_xet" in cmd
         assert " huggingface_hub>=1.5.0 " not in cmd
         assert "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)" in cmd
         assert "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site" in cmd
@@ -341,6 +342,13 @@ class TestBuildTrainingCommand:
         assert "--artifact-backend hf_bucket" in cmd
         assert "--artifact-bucket toolset-training-artifacts" in cmd
         assert "--artifact-prefix runs/hf_jobs/sft/20260314_181946-abc12345" in cmd
+
+    def test_bucket_sync_overlay_packages_include_xet(self):
+        assert HF_BUCKET_SYNC_OVERLAY_PACKAGES == (
+            "huggingface_hub>=1.5.0",
+            "hf_transfer",
+            "hf_xet",
+        )
 
     def test_command_installs_stage_pip_packages(self, repo_root):
         backend = HFJobsBackend(repo_root)

--- a/tuner/backends/training/cloud/_hf_command_builder.py
+++ b/tuner/backends/training/cloud/_hf_command_builder.py
@@ -16,7 +16,7 @@ import yaml
 
 from shared.utilities.paths import get_canonical_trainer_dir_name
 from shared.utilities.unique_ids import unique_utc_timestamp
-from tuner.cloud import RepoCheckoutSpec, build_repo_checkout_steps
+from tuner.cloud import HF_BUCKET_SYNC_OVERLAY_PACKAGES, RepoCheckoutSpec, build_repo_checkout_steps
 from tuner.core.config import CloudTrainingConfig
 from tuner.core.exceptions import CloudProviderError
 
@@ -92,9 +92,7 @@ class HFCommandBuilderMixin:
         cloud_config_path = self.repo_root / "Trainers" / "cloud" / "cloud_config.yaml"
         project_deps = load_project_deps(cloud_config_path)
         quoted_project_deps = " ".join(shlex.quote(dep) for dep in project_deps)
-        sync_deps = " ".join(
-            shlex.quote(dep) for dep in ("huggingface_hub>=1.5.0", "hf_transfer")
-        )
+        sync_deps = " ".join(shlex.quote(dep) for dep in HF_BUCKET_SYNC_OVERLAY_PACKAGES)
         checkout_steps = build_repo_checkout_steps(
             RepoCheckoutSpec(
                 url=config.repo_url,

--- a/tuner/cloud/__init__.py
+++ b/tuner/cloud/__init__.py
@@ -2,6 +2,7 @@
 
 from .hf_jobs import (
     CloudJobSpec,
+    HF_BUCKET_SYNC_OVERLAY_PACKAGES,
     HFJobExecutor,
     HFJobSubmission,
     RepoCheckoutSpec,
@@ -18,6 +19,7 @@ from .hf_jobs import (
 
 __all__ = [
     "CloudJobSpec",
+    "HF_BUCKET_SYNC_OVERLAY_PACKAGES",
     "HFJobExecutor",
     "HFJobSubmission",
     "RepoCheckoutSpec",

--- a/tuner/cloud/hf_jobs.py
+++ b/tuner/cloud/hf_jobs.py
@@ -12,6 +12,12 @@ from shared.cloud_artifacts import normalize_hf_bucket_id
 from shared.utilities.env import get_env_var, get_hf_token
 from tuner.core.exceptions import CloudProviderError
 
+HF_BUCKET_SYNC_OVERLAY_PACKAGES: tuple[str, ...] = (
+    "huggingface_hub>=1.5.0",
+    "hf_transfer",
+    "hf_xet",
+)
+
 
 @dataclass(frozen=True)
 class RepoCheckoutSpec:

--- a/tuner/handlers/cloud_eval_handler.py
+++ b/tuner/handlers/cloud_eval_handler.py
@@ -22,6 +22,7 @@ from shared.utilities.unique_ids import unique_utc_timestamp
 from Evaluator.config_loader import ConfigLoader
 from tuner.cloud import (
     CloudJobSpec,
+    HF_BUCKET_SYNC_OVERLAY_PACKAGES,
     HFJobExecutor,
     RepoCheckoutSpec,
     build_bash_command,
@@ -62,8 +63,7 @@ _HF_EVAL_PIP_PACKAGES = [
     "-r",
     "Evaluator/requirements.txt",
     "peft",
-    "huggingface_hub>=1.5.0",
-    "hf_transfer",
+    *HF_BUCKET_SYNC_OVERLAY_PACKAGES,
 ]
 
 

--- a/tuner/handlers/cloud_run_handler.py
+++ b/tuner/handlers/cloud_run_handler.py
@@ -13,6 +13,7 @@ from shared.utilities.unique_ids import unique_utc_timestamp
 from tuner.backends.training.cloud.base_cloud import load_cloud_config, load_project_deps, resolve_repo_source
 from tuner.cloud import (
     CloudJobSpec,
+    HF_BUCKET_SYNC_OVERLAY_PACKAGES,
     HFJobExecutor,
     RepoCheckoutSpec,
     build_bash_command,
@@ -180,10 +181,11 @@ class CloudRunHandler(BaseHandler):
             steps.append(f"cd {shlex.quote(repo_dir)} && python -m pip install --upgrade {quoted}")
 
         if resolved_bucket:
+            sync_deps = " ".join(shlex.quote(dep) for dep in HF_BUCKET_SYNC_OVERLAY_PACKAGES)
             steps.extend(
                 [
                     f"mkdir -p {_HF_SYNC_OVERLAY}",
-                    f"cd {shlex.quote(repo_dir)} && python -m pip install --upgrade --target {_HF_SYNC_OVERLAY} huggingface_hub>=1.5.0 hf_transfer",
+                    f"cd {shlex.quote(repo_dir)} && python -m pip install --upgrade --target {_HF_SYNC_OVERLAY} {sync_deps}",
                     f"mkdir -p {shlex.quote(output_dir)}",
                 ]
             )

--- a/tuner/handlers/stages/hf_loss_stage.py
+++ b/tuner/handlers/stages/hf_loss_stage.py
@@ -25,6 +25,7 @@ from shared.utilities.env import get_hf_token
 from tuner.backends.registry import TrainingBackendRegistry
 from tuner.cloud import (
     CloudJobSpec,
+    HF_BUCKET_SYNC_OVERLAY_PACKAGES,
     HFJobExecutor,
     RepoCheckoutSpec,
     build_bash_command,
@@ -62,10 +63,11 @@ class HFLossStageRunner:
             )
         )
 
+        sync_deps = " ".join(shlex.quote(dep) for dep in HF_BUCKET_SYNC_OVERLAY_PACKAGES)
         parts = [
             f"$(command -v python3 || command -v python) -m pip install --upgrade {' '.join(shlex.quote(dep) for dep in project_deps)}",
             "mkdir -p /tmp/hf-bucket-sync-site",
-            "$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site huggingface_hub>=1.5.0 hf_transfer",
+            f"$(command -v python3 || command -v python) -m pip install --upgrade --target /tmp/hf-bucket-sync-site {sync_deps}",
             "export HF_BUCKET_SYNC_PYTHON=$(command -v python3 || command -v python)",
             "export HF_BUCKET_SYNC_PYTHONPATH=/tmp/hf-bucket-sync-site",
             "export HF_HUB_ENABLE_HF_TRANSFER=1",


### PR DESCRIPTION
## Summary
- add a shared HF bucket-sync overlay package set including hf_xet
- use that package set across training, eval, loss-stage, and benchmark HF Jobs bootstrap paths
- document the SKIP_SHA256 / base-image hf_xet mismatch gotcha

## Why
The Phase 1 SFT max_steps=2 HF Jobs smoke completed training on the stable Unsloth image, then failed during final bucket sync because the isolated huggingface_hub overlay imported an incompatible system hf_xet: cannot import name SKIP_SHA256.

## Validation
- python -m pytest tests/cloud/test_hf_jobs_backend.py tests/cloud/test_cloud_eval_handler.py tests/cloud/test_experiment_handler.py -q
- python .skills/scripts/sync_skill_trees.py --check