### PR TITLE
Harden HF cloud eval timeout and stage logging

### DIFF
--- a/Evaluator/cloud_hf_job.py
+++ b/Evaluator/cloud_hf_job.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -126,6 +127,41 @@ def _finalize_cloud_exit_code(exit_code: int, output_json: Path) -> int:
     return 0 if output_json.exists() else exit_code
 
 
+def _install_termination_handler(
+    *,
+    stage_logger: StageLogger,
+    progress_syncer=None,
+    results_dir: Path,
+    bucket_id: str,
+    eval_prefix: str,
+    token: str,
+) -> None:
+    def _handle_signal(signum, _frame) -> None:
+        signal_name = signal.Signals(signum).name
+        message = f"Evaluation job terminated by {signal_name}"
+        print(message, flush=True)
+        try:
+            stage_logger.emit(
+                "terminated",
+                status="failed",
+                message=message,
+                details={"signal": signal_name, "signal_number": int(signum)},
+            )
+            if progress_syncer is not None:
+                progress_syncer.sync_once()
+            else:
+                _sync_bucket(
+                    str(results_dir),
+                    f"hf://buckets/{bucket_id}/{eval_prefix.strip('/')}",
+                    token=token,
+                )
+        finally:
+            raise SystemExit(128 + int(signum))
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+
 class _PeriodicBucketSyncer:
     """Best-effort periodic sync for incremental evaluation progress."""
 
@@ -223,11 +259,20 @@ def main() -> int:
         run_prefix=args.run_prefix,
         job_ref=stage_logger.job_ref,
         bucket_id=args.bucket_id,
+        log_dir=progress_dir,
     )
     partial_output_json = results_dir / "evaluation_results.partial.json"
     partial_output_md = results_dir / "evaluation_results.partial.md"
     failure_json = results_dir / "evaluation_failure.json"
     analysis_dir = results_dir / "analysis"
+
+    _install_termination_handler(
+        stage_logger=stage_logger,
+        results_dir=results_dir,
+        bucket_id=args.bucket_id,
+        eval_prefix=args.eval_prefix,
+        token=hf_token,
+    )
 
     # Download only the adapter payload needed for direct Unsloth LoRA evaluation.
     stage_logger.emit("bootstrap_started", message="Cloud eval bootstrap started")
@@ -309,6 +354,14 @@ def main() -> int:
         hf_token,
         interval_seconds=15,
         stage_logger=stage_logger,
+    )
+    _install_termination_handler(
+        stage_logger=stage_logger,
+        progress_syncer=progress_syncer,
+        results_dir=results_dir,
+        bucket_id=args.bucket_id,
+        eval_prefix=args.eval_prefix,
+        token=hf_token,
     )
 
     try:

--- a/Evaluator/cloud_hf_job_vllm.py
+++ b/Evaluator/cloud_hf_job_vllm.py
@@ -15,6 +15,7 @@ import sys
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
+from time import perf_counter
 from typing import Optional
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -33,7 +34,7 @@ from shared.experiment_tracking.lineage_enrichment import (
 from shared.experiment_tracking.per_example_loss import compute_per_example_losses_parallel
 from shared.utilities.env import get_hf_token
 
-from .cloud_hf_job import _PeriodicBucketSyncer, _finalize_cloud_exit_code
+from .cloud_hf_job import _PeriodicBucketSyncer, _finalize_cloud_exit_code, _install_termination_handler
 
 
 def _parse_args() -> argparse.Namespace:
@@ -298,10 +299,19 @@ def main() -> int:
         run_prefix=args.run_prefix,
         job_ref=stage_logger.job_ref,
         bucket_id=args.bucket_id,
+        log_dir=progress_dir,
     )
     partial_output_json = results_dir / "evaluation_results.partial.json"
     partial_output_md = results_dir / "evaluation_results.partial.md"
     failure_json = results_dir / "evaluation_failure.json"
+
+    _install_termination_handler(
+        stage_logger=stage_logger,
+        results_dir=results_dir,
+        bucket_id=args.bucket_id,
+        eval_prefix=args.eval_prefix,
+        token=hf_token,
+    )
 
     stage_logger.emit("bootstrap_started", message="Cloud vLLM eval bootstrap started")
     _sync_from_bucket(args.bucket_id, f"{args.run_prefix}/final_model", model_dir, hf_token)
@@ -311,7 +321,7 @@ def main() -> int:
         details={"last_sync_path": f"hf://buckets/{args.bucket_id}/{args.run_prefix.strip('/')}/final_model"},
     )
     base_model_name = _load_base_model_name(model_dir)
-    stage_logger.emit("model_loaded", message="Resolved base model for vLLM", details={"model": base_model_name, "backend": "vllm"})
+    stage_logger.emit("model_resolved", message="Resolved base model for vLLM", details={"model": base_model_name, "backend": "vllm"})
 
     output_json = results_dir / "evaluation_results.json"
     output_md = results_dir / "evaluation_results.md"
@@ -325,12 +335,26 @@ def main() -> int:
         interval_seconds=15,
         stage_logger=stage_logger,
     )
+    _install_termination_handler(
+        stage_logger=stage_logger,
+        progress_syncer=progress_syncer,
+        results_dir=results_dir,
+        bucket_id=args.bucket_id,
+        eval_prefix=args.eval_prefix,
+        token=hf_token,
+    )
 
     server_started = False
     try:
         progress_syncer.start()
         stage_logger.emit("runtime_ready", message="Starting vLLM runtime", details={"backend": "vllm"})
         eval_started_at = datetime.now(timezone.utc).isoformat()
+        stage_logger.emit(
+            "model_load_started",
+            message="Starting vLLM server model load",
+            details={"backend": "vllm", "model": base_model_name, "timeout_seconds": args.vllm_timeout},
+        )
+        model_load_start = perf_counter()
         server_started = start_vllm_server(
             model=base_model_name,
             host=args.vllm_host,
@@ -343,6 +367,16 @@ def main() -> int:
         )
         if not server_started:
             raise RuntimeError("Failed to start the vLLM server in the cloud eval job.")
+        stage_logger.emit(
+            "model_load_completed",
+            message="vLLM server model load completed",
+            details={
+                "backend": "vllm",
+                "model": base_model_name,
+                "timeout_seconds": args.vllm_timeout,
+                "elapsed_seconds": round(perf_counter() - model_load_start, 3),
+            },
+        )
         stage_logger.emit("runtime_ready", message="vLLM server ready", details={"backend": "vllm"})
 
         cli_args = [

--- a/Evaluator/shared_llm_adapters.py
+++ b/Evaluator/shared_llm_adapters.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Mapping, Optional, Sequence
 
 from shared.llm import create_client, LLMError
 from shared.llm.base import BaseLLMClient
+from shared.cloud_stage_logging import stage_logger_from_env
 
 from .config import LMStudioSettings, OllamaSettings, OpenRouterSettings, OpenAIResponsesSettings, UnslothSettings
 from .protocols import BackendError, BackendResponse
@@ -385,12 +386,34 @@ class SharedUnslothAdapter:
         try:
             from shared.llm.providers.unsloth import UnslothClient as SharedUnslothClient
 
+            stage_logger = stage_logger_from_env()
+            model_load_details = {
+                "backend": "unsloth",
+                "adapter_path": settings.model,
+                "max_seq_length": settings.max_seq_length,
+                "load_in_4bit": settings.load_in_4bit,
+            }
+            if stage_logger is not None:
+                stage_logger.emit(
+                    "model_load_started",
+                    message="Starting Unsloth model load",
+                    details=model_load_details,
+                )
+            model_load_start = time.perf_counter()
             self.client = SharedUnslothClient(
                 adapter_path=settings.model,
                 max_seq_length=settings.max_seq_length,
                 load_in_4bit=settings.load_in_4bit,
                 top_p=settings.top_p,
             )
+            if stage_logger is not None:
+                completed_details = dict(model_load_details)
+                completed_details["elapsed_seconds"] = round(time.perf_counter() - model_load_start, 3)
+                stage_logger.emit(
+                    "model_load_completed",
+                    message="Unsloth model load completed",
+                    details=completed_details,
+                )
         except LLMError as e:
             raise BackendError(f"Failed to create Unsloth client: {e}")
         except Exception as e:

--- a/Trainers/cloud/cloud_config.yaml
+++ b/Trainers/cloud/cloud_config.yaml
@@ -93,6 +93,7 @@ cloud:
     evaluation:
       runtime: unsloth
       image_profile: stable_unsloth
+      timeout: 4h
 
   modal:
     gpu: L40S

--- a/shared/cloud_stage_logging.py
+++ b/shared/cloud_stage_logging.py
@@ -19,6 +19,7 @@ ENV_STAGE_PROVIDER = "CLOUD_STAGE_PROVIDER"
 ENV_STAGE_RUN_PREFIX = "CLOUD_STAGE_RUN_PREFIX"
 ENV_STAGE_JOB_REF = "CLOUD_STAGE_JOB_REF"
 ENV_STAGE_BUCKET_ID = "CLOUD_STAGE_BUCKET_ID"
+ENV_STAGE_LOG_DIR = "CLOUD_STAGE_LOG_DIR"
 
 
 def _utcnow_iso() -> str:
@@ -47,6 +48,7 @@ def apply_stage_logging_env(
     run_prefix: Optional[str] = None,
     job_ref: Optional[str] = None,
     bucket_id: Optional[str] = None,
+    log_dir: Optional[Path | str] = None,
 ) -> None:
     os.environ[ENV_STAGE_NAME] = stage
     if provider:
@@ -57,6 +59,8 @@ def apply_stage_logging_env(
         os.environ[ENV_STAGE_JOB_REF] = job_ref
     if bucket_id:
         os.environ[ENV_STAGE_BUCKET_ID] = bucket_id
+    if log_dir:
+        os.environ[ENV_STAGE_LOG_DIR] = str(log_dir)
 
 
 def normalize_failure(
@@ -270,5 +274,8 @@ class CloudStageLogger:
 StageLogger = CloudStageLogger
 
 
-def stage_logger_from_env(log_dir: Path | str) -> CloudStageLogger:
-    return CloudStageLogger.from_env(log_dir)
+def stage_logger_from_env(log_dir: Optional[Path | str] = None) -> Optional[CloudStageLogger]:
+    resolved_log_dir = log_dir or str(os.environ.get(ENV_STAGE_LOG_DIR, "")).strip()
+    if not resolved_log_dir:
+        return None
+    return CloudStageLogger.from_env(resolved_log_dir)

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -185,6 +185,15 @@ def test_cloud_method_flag_accepts_grpo():
     assert args.method == "grpo"
 
 
+def test_cloud_eval_timeout_flag_parses():
+    parser = create_parser()
+
+    args = parser.parse_args(["cloud-pipeline", "--eval-timeout-hours", "7.5"])
+
+    assert args.command == "cloud-pipeline"
+    assert args.eval_timeout_hours == 7.5
+
+
 def test_bucket_command_parses():
     parser = create_parser()
 

--- a/tests/cloud/test_cloud_eval_handler.py
+++ b/tests/cloud/test_cloud_eval_handler.py
@@ -219,6 +219,31 @@ def test_resolve_eval_helper_module_supports_vllm(repo_root):
     assert handler._resolve_eval_helper_module("vllm") == "Evaluator.cloud_hf_job_vllm"
 
 
+def test_resolve_eval_timeout_prefers_explicit_eval_timeout(repo_root):
+    handler = CloudEvalHandler(args=Namespace(eval_timeout_hours=8.0, timeout_hours=2.0))
+    handler._repo_root = repo_root
+
+    assert handler._resolve_eval_timeout_hours() == 8.0
+
+
+def test_resolve_eval_timeout_uses_eval_config_before_provider(repo_root):
+    handler = CloudEvalHandler(args=Namespace(eval_timeout_hours=None, timeout_hours=None))
+    handler._repo_root = repo_root
+
+    with patch.object(handler, "_hf_eval_settings", return_value={"timeout": "90m"}):
+        with patch.object(handler, "_hf_jobs_settings", return_value={"timeout": "6h"}):
+            assert handler._resolve_eval_timeout_hours() == 1.5
+
+
+def test_resolve_eval_timeout_uses_provider_timeout(repo_root):
+    handler = CloudEvalHandler(args=Namespace(eval_timeout_hours=None, timeout_hours=None))
+    handler._repo_root = repo_root
+
+    with patch.object(handler, "_hf_eval_settings", return_value={}):
+        with patch.object(handler, "_hf_jobs_settings", return_value={"timeout": "6h"}):
+            assert handler._resolve_eval_timeout_hours() == 6.0
+
+
 def test_new_eval_timestamp_includes_nonce(repo_root):
     handler = CloudEvalHandler(args=Namespace())
     handler._repo_root = repo_root
@@ -245,6 +270,7 @@ def test_handle_submits_hf_eval_job(repo_root, clean_env):
         update_model_card=False,
         gpu=None,
         timeout_hours=2.0,
+        eval_timeout_hours=None,
         eval_runtime=None,
         eval_image_profile=None,
         eval_cloud_image=None,

--- a/tests/cloud/test_cloud_hf_job.py
+++ b/tests/cloud/test_cloud_hf_job.py
@@ -1,8 +1,13 @@
 import json
+import signal
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
-from Evaluator.cloud_hf_job import _PeriodicBucketSyncer, _finalize_cloud_exit_code
+import pytest
+
+from Evaluator import cloud_hf_job
+from Evaluator.cloud_hf_job import _PeriodicBucketSyncer, _finalize_cloud_exit_code, _install_termination_handler
 from shared.cloud_stage_logging import StageLogger
 
 
@@ -51,3 +56,73 @@ def test_periodic_bucket_syncer_emits_stage_sync_event(tmp_path: Path):
     assert mock_sync.call_count == 1
     assert summary["event"] == "artifacts_synced"
     assert summary["details"]["last_sync_path"] == "hf://buckets/bucket-id/runs/demo/evaluations/vllm/ts"
+
+
+def test_termination_handler_without_progress_syncer_syncs_results(tmp_path: Path):
+    logger = StageLogger(tmp_path / "logs", stage="evaluation", provider="hf_jobs", run_prefix="runs/demo")
+    handlers = {}
+
+    with patch("Evaluator.cloud_hf_job.signal.signal", side_effect=lambda sig, handler: handlers.setdefault(sig, handler)):
+        _install_termination_handler(
+            stage_logger=logger,
+            results_dir=tmp_path / "results",
+            bucket_id="bucket-id",
+            eval_prefix="runs/demo/evaluations/unsloth/ts",
+            token="hf-token",
+        )
+
+    with patch("Evaluator.cloud_hf_job._sync_bucket") as mock_sync:
+        with pytest.raises(SystemExit) as exc_info:
+            handlers[signal.SIGTERM](signal.SIGTERM, None)
+
+    assert exc_info.value.code == 128 + signal.SIGTERM
+    mock_sync.assert_called_once_with(
+        str(tmp_path / "results"),
+        "hf://buckets/bucket-id/runs/demo/evaluations/unsloth/ts",
+        token="hf-token",
+    )
+    summary = json.loads((tmp_path / "logs" / "stage_summary.json").read_text(encoding="utf-8"))
+    assert summary["event"] == "terminated"
+
+
+def test_main_installs_termination_handler_before_initial_download(tmp_path: Path):
+    args = Namespace(
+        bucket_id="bucket-id",
+        run_prefix="runs/demo",
+        eval_prefix="runs/demo/evaluations/unsloth/ts",
+        config_dir="Evaluator/config",
+        output_root=str(tmp_path / "eval_outputs"),
+        preset=None,
+        scenarios=None,
+        tags=None,
+        env_backend="none",
+        env_template=None,
+        env_tool_schema=None,
+        env_exec_config=None,
+        upload_to_hf=None,
+        update_model_card=False,
+        with_loss=False,
+        loss_dataset_path=None,
+        loss_dataset_name=None,
+        loss_dataset_file=None,
+        loss_max_seq_length=2048,
+        loss_no_completion_only=False,
+    )
+    installed = []
+
+    def _fake_install(**kwargs):
+        installed.append(kwargs.get("progress_syncer"))
+
+    def _fake_sync_from_bucket(*_args, **_kwargs):
+        assert installed == [None]
+        raise RuntimeError("stop after bootstrap ordering check")
+
+    with patch.object(cloud_hf_job, "_parse_args", return_value=args), patch.object(
+        cloud_hf_job, "get_hf_token", return_value="hf-token"
+    ), patch.object(cloud_hf_job, "_log_runtime_versions"), patch.object(
+        cloud_hf_job, "_install_termination_handler", side_effect=_fake_install
+    ), patch.object(
+        cloud_hf_job, "_sync_from_bucket", side_effect=_fake_sync_from_bucket
+    ):
+        with pytest.raises(RuntimeError, match="stop after bootstrap ordering check"):
+            cloud_hf_job.main()

--- a/tests/cloud/test_cloud_hf_job_vllm.py
+++ b/tests/cloud/test_cloud_hf_job_vllm.py
@@ -3,6 +3,9 @@ from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from Evaluator import cloud_hf_job_vllm
 from Evaluator.cloud_hf_job_vllm import _compute_exact_loss_outputs, _load_base_model_name, _parse_args
 from shared.cloud_stage_logging import StageLogger
 from shared.experiment_tracking.schema import LossResult
@@ -93,3 +96,52 @@ def test_compute_exact_loss_outputs_emits_progress_events(tmp_path: Path):
     assert summary["event"] == "progress"
     assert summary["details"]["phase"] == "exact_loss"
     assert summary["details"]["examples_done"] == 2
+
+
+def test_main_installs_termination_handler_before_initial_download(tmp_path: Path):
+    args = Namespace(
+        bucket_id="bucket-id",
+        run_prefix="runs/demo",
+        eval_prefix="runs/demo/evaluations/vllm/ts",
+        config_dir="Evaluator/config",
+        output_root=str(tmp_path / "eval_outputs"),
+        preset=None,
+        scenarios=None,
+        tags=None,
+        env_backend="none",
+        env_template=None,
+        env_tool_schema=None,
+        env_exec_config=None,
+        upload_to_hf=None,
+        update_model_card=False,
+        with_loss=False,
+        loss_dataset_path=None,
+        loss_dataset_name=None,
+        loss_dataset_file=None,
+        loss_max_seq_length=2048,
+        loss_no_completion_only=False,
+        vllm_host="127.0.0.1",
+        vllm_port=8000,
+        vllm_timeout=600,
+        vllm_gpu_memory_utilization=0.85,
+        vllm_tensor_parallel_size=0,
+        loss_workers=0,
+    )
+    installed = []
+
+    def _fake_install(**kwargs):
+        installed.append(kwargs.get("progress_syncer"))
+
+    def _fake_sync_from_bucket(*_args, **_kwargs):
+        assert installed == [None]
+        raise RuntimeError("stop after bootstrap ordering check")
+
+    with patch.object(cloud_hf_job_vllm, "_parse_args", return_value=args), patch.object(
+        cloud_hf_job_vllm, "get_hf_token", return_value="hf-token"
+    ), patch.object(cloud_hf_job_vllm, "_log_runtime_versions"), patch.object(
+        cloud_hf_job_vllm, "_install_termination_handler", side_effect=_fake_install
+    ), patch.object(
+        cloud_hf_job_vllm, "_sync_from_bucket", side_effect=_fake_sync_from_bucket
+    ):
+        with pytest.raises(RuntimeError, match="stop after bootstrap ordering check"):
+            cloud_hf_job_vllm.main()

--- a/tests/cloud/test_cloud_pipeline_handler.py
+++ b/tests/cloud/test_cloud_pipeline_handler.py
@@ -16,6 +16,16 @@ def test_cloud_pipeline_runs_training_then_eval(repo_root, clean_env):
         update_model_card=False,
         gpu=None,
         timeout_hours=2.0,
+        eval_timeout_hours=5.0,
+        eval_runtime="vllm",
+        eval_image_profile="fast_vllm",
+        eval_cloud_image="custom/eval:latest",
+        eval_pip_packages=["vllm==0.12.0"],
+        with_loss=True,
+        loss_dataset_name="test/dataset",
+        loss_dataset_file="train.jsonl",
+        loss_max_seq_length=1024,
+        loss_no_completion_only=True,
     )
     handler = CloudPipelineHandler(args=args)
     handler._repo_root = repo_root
@@ -53,6 +63,17 @@ def test_cloud_pipeline_runs_training_then_eval(repo_root, clean_env):
     assert eval_args.run == "runs/hf_jobs/sft/20260315_010000-abc12345"
     assert eval_args.method == "sft"
     assert eval_args.bucket == "test-user/toolset-training-artifacts"
+    assert eval_args.timeout_hours == 5.0
+    assert eval_args.eval_timeout_hours == 5.0
+    assert eval_args.eval_runtime == "vllm"
+    assert eval_args.eval_image_profile == "fast_vllm"
+    assert eval_args.eval_cloud_image == "custom/eval:latest"
+    assert eval_args.eval_pip_packages == ["vllm==0.12.0"]
+    assert eval_args.with_loss is True
+    assert eval_args.loss_dataset_name == "test/dataset"
+    assert eval_args.loss_dataset_file == "train.jsonl"
+    assert eval_args.loss_max_seq_length == 1024
+    assert eval_args.loss_no_completion_only is True
     assert eval_args.auto_confirm is True
 
 

--- a/tests/cloud/test_cloud_stage_logging.py
+++ b/tests/cloud/test_cloud_stage_logging.py
@@ -1,6 +1,17 @@
 import json
+import os
 
-from shared.cloud_stage_logging import CloudStageLogger
+from shared.cloud_stage_logging import (
+    ENV_STAGE_BUCKET_ID,
+    ENV_STAGE_JOB_REF,
+    ENV_STAGE_LOG_DIR,
+    ENV_STAGE_NAME,
+    ENV_STAGE_PROVIDER,
+    ENV_STAGE_RUN_PREFIX,
+    CloudStageLogger,
+    apply_stage_logging_env,
+    stage_logger_from_env,
+)
 
 
 def test_stage_logger_appends_events_and_rolls_summary(tmp_path):
@@ -44,3 +55,42 @@ def test_stage_logger_normalizes_failures(tmp_path):
     assert summary["details"]["error_type"] == "RuntimeError"
     assert summary["details"]["error_message"] == "boom"
     assert summary["details"]["traceback"] == "traceback text"
+
+
+def test_stage_logger_from_env_uses_env_log_dir(tmp_path):
+    log_dir = tmp_path / "logs"
+    env_keys = [
+        ENV_STAGE_NAME,
+        ENV_STAGE_PROVIDER,
+        ENV_STAGE_RUN_PREFIX,
+        ENV_STAGE_JOB_REF,
+        ENV_STAGE_BUCKET_ID,
+        ENV_STAGE_LOG_DIR,
+    ]
+    previous_env = {key: os.environ.get(key) for key in env_keys}
+    try:
+        apply_stage_logging_env(
+            stage="evaluation",
+            provider="hf_jobs",
+            run_prefix="runs/demo",
+            job_ref="job-123",
+            bucket_id="bucket-1",
+            log_dir=log_dir,
+        )
+
+        logger = stage_logger_from_env()
+        logger.emit("model_load_started", details={"backend": "unsloth"})
+    finally:
+        for key, value in previous_env.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    summary = json.loads((log_dir / "stage_summary.json").read_text(encoding="utf-8"))
+    assert summary["stage"] == "evaluation"
+    assert summary["provider"] == "hf_jobs"
+    assert summary["job_ref"] == "job-123"
+    assert summary["run_prefix"] == "runs/demo"
+    assert summary["bucket_id"] == "bucket-1"
+    assert summary["event"] == "model_load_started"

--- a/tests/cloud/test_shared_llm_adapters.py
+++ b/tests/cloud/test_shared_llm_adapters.py
@@ -1,0 +1,78 @@
+import json
+import sys
+import types
+
+from Evaluator.config import UnslothSettings
+from Evaluator.shared_llm_adapters import SharedUnslothAdapter
+from shared.cloud_stage_logging import (
+    ENV_STAGE_BUCKET_ID,
+    ENV_STAGE_JOB_REF,
+    ENV_STAGE_LOG_DIR,
+    ENV_STAGE_NAME,
+    ENV_STAGE_PROVIDER,
+    ENV_STAGE_RUN_PREFIX,
+    apply_stage_logging_env,
+)
+
+
+def test_shared_unsloth_adapter_emits_model_load_events(tmp_path, monkeypatch):
+    calls = []
+    fake_module = types.ModuleType("shared.llm.providers.unsloth")
+
+    class _FakeUnslothClient:
+        provider_name = "unsloth"
+
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        def unload(self):
+            pass
+
+    fake_module.UnslothClient = _FakeUnslothClient
+    monkeypatch.setitem(sys.modules, "shared.llm.providers.unsloth", fake_module)
+    for key in (
+        ENV_STAGE_NAME,
+        ENV_STAGE_PROVIDER,
+        ENV_STAGE_RUN_PREFIX,
+        ENV_STAGE_JOB_REF,
+        ENV_STAGE_BUCKET_ID,
+        ENV_STAGE_LOG_DIR,
+    ):
+        monkeypatch.delenv(key, raising=False)
+    apply_stage_logging_env(
+        stage="evaluation",
+        provider="hf_jobs",
+        run_prefix="runs/demo",
+        job_ref="job-123",
+        bucket_id="bucket-1",
+        log_dir=tmp_path / "logs",
+    )
+
+    adapter = SharedUnslothAdapter(
+        UnslothSettings(
+            model=str(tmp_path / "final_model"),
+            max_seq_length=2048,
+            load_in_4bit=False,
+            top_p=0.8,
+        )
+    )
+    adapter.unload()
+
+    events = [
+        json.loads(line)
+        for line in (tmp_path / "logs" / "stage_events.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    assert [event["event"] for event in events] == ["model_load_started", "model_load_completed"]
+    assert events[0]["details"]["backend"] == "unsloth"
+    assert events[0]["details"]["adapter_path"] == str(tmp_path / "final_model")
+    assert events[0]["details"]["max_seq_length"] == 2048
+    assert events[0]["details"]["load_in_4bit"] is False
+    assert "elapsed_seconds" in events[1]["details"]
+    assert calls == [
+        {
+            "adapter_path": str(tmp_path / "final_model"),
+            "max_seq_length": 2048,
+            "load_in_4bit": False,
+            "top_p": 0.8,
+        }
+    ]

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -240,6 +240,7 @@ Examples:
     )
     parser.add_argument("--gpu", help="Override HF Jobs hardware flavor for cloud-eval/cloud-gym.")
     parser.add_argument("--timeout-hours", type=float, help="Override timeout in hours for cloud-eval/cloud-gym.")
+    parser.add_argument("--eval-timeout-hours", type=float, help="Override evaluation timeout in hours for cloud-eval/cloud-pipeline.")
     parser.add_argument(
         "--eval-runtime",
         choices=["unsloth", "vllm"],
@@ -247,11 +248,11 @@ Examples:
     )
     parser.add_argument(
         "--eval-image-profile",
-        help="Override the cloud evaluation image profile for cloud-eval (for example: stable_unsloth, latest_unsloth, fast_vllm).",
+        help="Override the cloud evaluation image profile for cloud-eval/cloud-pipeline (for example: stable_unsloth, latest_unsloth, fast_vllm).",
     )
     parser.add_argument(
         "--eval-cloud-image",
-        help="Override the exact cloud evaluation Docker image for cloud-eval.",
+        help="Override the exact cloud evaluation Docker image for cloud-eval/cloud-pipeline.",
     )
     parser.add_argument(
         "--with-loss",

--- a/tuner/handlers/cloud_eval_handler.py
+++ b/tuner/handlers/cloud_eval_handler.py
@@ -135,6 +135,35 @@ class CloudEvalHandler(BaseHandler):
     def _hf_eval_settings(self) -> dict:
         return self._hf_jobs_settings().get("evaluation", {})
 
+    @staticmethod
+    def _parse_timeout_hours(value, *, fallback: Optional[float] = None) -> Optional[float]:
+        if value is None:
+            return fallback
+        raw = str(value).strip().lower()
+        if not raw:
+            return fallback
+        try:
+            if raw.endswith("h"):
+                return float(raw[:-1])
+            if raw.endswith("m"):
+                return float(raw[:-1]) / 60.0
+            return float(raw)
+        except (TypeError, ValueError):
+            return fallback
+
+    def _resolve_eval_timeout_hours(self) -> float:
+        for value in (
+            getattr(self.args, "eval_timeout_hours", None),
+            getattr(self.args, "timeout_hours", None),
+            self._hf_eval_settings().get("timeout_hours"),
+            self._hf_eval_settings().get("timeout"),
+            self._hf_jobs_settings().get("timeout"),
+        ):
+            timeout_hours = self._parse_timeout_hours(value)
+            if timeout_hours is not None:
+                return timeout_hours
+        return 4.0
+
     def _validate_environment(self):
         hf_token = get_hf_token()
         if not hf_token:
@@ -716,7 +745,7 @@ class CloudEvalHandler(BaseHandler):
         upload_to_hf = getattr(self.args, "upload_to_hf", None)
         update_model_card = bool(getattr(self.args, "update_model_card", False))
         flavor = getattr(self.args, "gpu", None) or hf_settings.get("flavor", "a10g-small")
-        timeout_hours = float(getattr(self.args, "timeout_hours", None) or 4.0)
+        timeout_hours = self._resolve_eval_timeout_hours()
         eval_runtime = self._resolve_eval_runtime()
         helper_module = self._resolve_eval_helper_module(eval_runtime)
         eval_image, eval_image_profile = self._resolve_eval_image()
@@ -769,7 +798,7 @@ class CloudEvalHandler(BaseHandler):
                 "Run": selected_run["prefix"],
                 "Bucket": bucket_id,
                 "Runtime": eval_runtime,
-                "Backend": "unsloth",
+                "Backend": eval_runtime,
                 "Preset": preset or "-",
                 "Scenarios": ", ".join(display_scenarios) if display_scenarios else "-",
                 "Tags": tags or "-",

--- a/tuner/handlers/cloud_pipeline_handler.py
+++ b/tuner/handlers/cloud_pipeline_handler.py
@@ -78,7 +78,17 @@ class CloudPipelineHandler(BaseHandler):
             upload_to_hf=getattr(self.args, "upload_to_hf", None),
             update_model_card=bool(getattr(self.args, "update_model_card", False)),
             gpu=getattr(self.args, "gpu", None),
-            timeout_hours=getattr(self.args, "timeout_hours", None),
+            timeout_hours=getattr(self.args, "eval_timeout_hours", None) or getattr(self.args, "timeout_hours", None),
+            eval_timeout_hours=getattr(self.args, "eval_timeout_hours", None),
+            eval_runtime=getattr(self.args, "eval_runtime", None),
+            eval_image_profile=getattr(self.args, "eval_image_profile", None),
+            eval_cloud_image=getattr(self.args, "eval_cloud_image", None),
+            eval_pip_packages=getattr(self.args, "eval_pip_packages", None),
+            with_loss=bool(getattr(self.args, "with_loss", False)),
+            loss_dataset_name=getattr(self.args, "loss_dataset_name", None),
+            loss_dataset_file=getattr(self.args, "loss_dataset_file", None),
+            loss_max_seq_length=getattr(self.args, "loss_max_seq_length", None),
+            loss_no_completion_only=bool(getattr(self.args, "loss_no_completion_only", False)),
             auto_confirm=True,
         )
 


### PR DESCRIPTION
## Summary
- add explicit eval timeout resolution and --eval-timeout-hours so cloud-pipeline eval can have a different budget than tiny training smokes
- forward cloud-pipeline eval runtime/image/pip/loss args into CloudEvalHandler
- emit model-load lifecycle events for Unsloth and vLLM eval, and capture SIGTERM/SIGINT as terminated stage events including bootstrap downloads

## Context
This is a generic fix from the HF Jobs smoke where eval reached untime_ready and then exited 143 during slow base model download/load without a traceback or useful final stage marker.

## Verification
- python -m py_compile Evaluator/cloud_hf_job.py Evaluator/cloud_hf_job_vllm.py Evaluator/shared_llm_adapters.py shared/cloud_stage_logging.py tuner/cli/parser.py tuner/handlers/cloud_eval_handler.py tuner/handlers/cloud_pipeline_handler.py
- python -m pytest -s tests/cli/test_parser.py tests/cloud/test_cloud_eval_handler.py tests/cloud/test_cloud_pipeline_handler.py tests/cloud/test_cloud_stage_logging.py tests/cloud/test_cloud_hf_job.py tests/cloud/test_cloud_hf_job_vllm.py tests/cloud/test_shared_llm_adapters.py -q (45 passed)
- PYTHONUTF8=1 PYTHONIOENCODING=utf-8 python -m pytest -s -p no:cacheprovider --basetemp <repo-local-temp> tests/cloud/test_hf_jobs_backend.py tests/cloud/test_cloud_eval_handler.py tests/cloud/test_cloud_pipeline_handler.py tests/cloud/test_experiment_handler.py tests/cloud/test_stage_runner_behavior.py -q (131 passed)