### PR TITLE
Add transcript-distillation skill

### DIFF
--- a/.agents/skills/transcript-distillation/SKILL.md
+++ b/.agents/skills/transcript-distillation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: transcript-distillation
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+allowed-tools: Read, Bash, Write, Edit, Grep, Glob
+---
+
+# Transcript Distillation
+
+Mine local agent transcripts into training data. You point it at a directory of
+conversation logs; it emits one row per assistant turn, scrubs secrets, labels
+each turn (accept / borderline / reject), scores each *session* by how it ended
+up (tests passed, clean build, commit, PR, approval), drops ceremony/filler/
+duplicates, and stamps a quality tier (gold/silver/bronze) on every row.
+
+**Format-agnostic.** The engine knows nothing about Claude or Codex — that lives
+in small pluggable *adapters*. Two ship built-in (`claude_code`, `codex`); add
+more in ~40 lines (see `reference/writing-adapters.md`).
+
+## Quickstart
+
+```bash
+SKILL=.skills/transcript-distillation
+
+# 1. copy the template config and (optionally) edit scope/paths
+cp $SKILL/configs/template.yaml my_distill.yaml
+
+# 2. smoke test on a few files first — ALWAYS do this before a full run
+python $SKILL/scripts/distill.py --config my_distill.yaml --smoke --limit 20 --show 3
+
+# 3. full run
+python $SKILL/scripts/distill.py --config my_distill.yaml
+```
+
+Out of the box the template grabs **all** local Claude Code (`~/.claude/projects`)
+and Codex (`~/.codex/sessions`) transcripts and writes to
+`./transcript_distill_out/rows.jsonl`. Only dependency: `pyyaml`.
+
+## CLI
+
+| Flag | Meaning |
+|------|---------|
+| `--config PATH` | distill config YAML (required) |
+| `--smoke` | write to a `smoke/` subdir (keeps full runs separate) |
+| `--limit N` | cap files **per source** (0 = all) — use for smoke tests |
+| `--sources a,b` | restrict to named sources from config |
+| `--show N` | print N sample rows to eyeball quality |
+| `--max-context-tokens N` | override `context_budget.max_context_tokens` for this run |
+
+## Pipeline (all config-driven)
+
+```
+adapter.parse(file)            # format-specific -> normalized events
+  -> one row per assistant turn
+  -> secret scrub at emit time (raw secrets never hit disk)
+  -> context filled most-recent-first under a TOKEN budget
+  -> deterministic label: accept / borderline(->judge) / reject
+  -> quality funnel: drop ceremony tools, trivial filler, duplicates
+  -> session-outcome tiering: gold / silver / bronze
+  -> JSONL
+```
+
+Each knob is documented in `reference/config-schema.md`. Highlights:
+
+- **`scope`** — include/exclude projects by substring (Claude: project slug;
+  Codex: recorded cwd). Empty include = everything.
+- **`context_budget.max_context_tokens`** — set to your training seq length.
+  This caps context DEPTH per row, *not* the number of rows; training cost is
+  ~O(seq²), so keep it real (8192 is a good default; 32768 is ~16× the compute).
+- **`session_outcome`** — regexes that detect tests-passed / clean-build /
+  commit / PR / approval from tool commands + their output. The strongest
+  quality signal: it judges the whole path by where it ended up.
+- **`quality_tiers`** — map outcomes to gold (verified-correct) / silver
+  (saved/shipped) / bronze (no signal). Subagents inherit their parent
+  session's tier.
+- **`quality_filter`** — drop ceremony tools (orchestration), trivial text
+  turns, and duplicate completions. Set `require_outcomes` to keep ONLY
+  verified-good sessions.
+
+## Output row schema
+
+One JSON object per line, shaped for SFT/KTO:
+
+```json
+{
+  "conversations": [{"role": "...", "content": "..."}],
+  "prompt": "...", "completion": "...",
+  "label": true | false | null,        // accept / reject / borderline(->judge)
+  "score_tier": "good|bad|borderline",
+  "failure_labels": ["tool_error", "user_corrected", ...],
+  "source_example_id": "claude_main:<file>:<turn>",
+  "metadata": {
+    "quality_tier": "gold|silver|bronze",
+    "session_outcome": ["clean_build", "committed"],
+    "good_path": true,
+    "tool_names": ["Edit"], "est_tokens": 5948, "oversize": false, ...
+  }
+}
+```
+
+Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
+SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
+LLM-as-judge to mint KTO negatives.
+
+## Privacy
+
+- Secret scrubbing is **on by default** and runs at emit time, so raw API
+  keys/tokens never reach disk. Verify with a residual grep after a run.
+- Transcript-derived output is private. Keep the output dir gitignored.
+- A trained model on frontier-agent transcripts is distillation — keep it
+  private (provider ToS).
+
+## References
+
+| File | When |
+|------|------|
+| `reference/config-schema.md` | Every config knob explained |
+| `reference/writing-adapters.md` | Add support for a new transcript format |
+| `reference/case-study-claude-codex.md` | Worked example: 538k turns → ~102k tiered rows |
+
+## Discipline
+
+- **Always `--smoke --limit` first**, eyeball `--show` samples, then full run.
+- Keep everything in config — never hardcode a tool name, scope, or format
+  assumption in the engine. Format specifics belong in an adapter.

--- a/.agents/skills/transcript-distillation/configs/template.yaml
+++ b/.agents/skills/transcript-distillation/configs/template.yaml
@@ -1,0 +1,101 @@
+# transcript-distillation — portable template config.
+# Copy this, adjust, and run:
+#   python .../scripts/distill.py --config my_config.yaml --smoke --limit 20 --show 3
+#
+# Out of the box this grabs ALL local Claude Code + Codex transcripts (empty
+# scope = match everything) and writes deduped, quality-tiered rows to
+# ./transcript_distill_out/. Tighten `scope` to target specific projects.
+
+sources:
+  claude_main:
+    format: claude_code          # adapter name (see scripts/adapters/)
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*.jsonl"            # main session transcripts
+  claude_subagent:
+    format: claude_code
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*/subagents/*.jsonl"   # Task-tool / subagent runs (inherit parent outcome)
+  codex:
+    format: codex
+    enabled: true
+    root: "~/.codex/sessions"
+    glob: "**/*.jsonl"
+
+# Which projects to include. Claude is matched by project-slug, Codex by the
+# cwd in session_meta. EMPTY include = match everything (good for a first run).
+scope:
+  include_substrings: []         # e.g. ["documents-code-", "/documents/code/"]
+  exclude_substrings: []         # e.g. ["secret-client", "personal"]
+
+output:
+  dir: "transcript_distill_out"  # relative to where you run distill.py
+  rows_file: "rows.jsonl"
+  smoke_subdir: "smoke"
+
+# ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
+sanitize:
+  enabled: true
+  replacement: "[REDACTED:{name}]"
+  patterns:
+    openai_key: "sk-(?:proj-)?[A-Za-z0-9_-]{20,}"
+    openrouter_key: "sk-or-v1-[A-Za-z0-9]{32,}"
+    anthropic_key: "sk-ant-[A-Za-z0-9_-]{20,}"
+    hf_token: "hf_[A-Za-z0-9]{30,}"
+    github_token: "gh[pousr]_[A-Za-z0-9]{36,}"
+    aws_access_key: "AKIA[0-9A-Z]{16}"
+    google_api_key: "AIza[0-9A-Za-z_-]{35}"
+    slack_token: "xox[baprs]-[0-9A-Za-z-]{10,}"
+    bearer_token: "[Bb]earer\\s+[A-Za-z0-9._-]{20,}"
+    jwt: "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}"
+    private_key_block: "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+  env_assignment:
+    sensitive_key_re: "(?i)(?:api[_-]?key|secret|token|password|passwd|private[_-]?key|access[_-]?key|client[_-]?secret)"
+    replacement: "[REDACTED:env_secret]"
+
+# ---- one row per assistant turn; context filled most-recent-first to budget ----
+context_budget:
+  max_context_tokens: 8192       # your training seq length (override: --max-context-tokens)
+  chars_per_token: 4.0
+  max_context_messages: 120
+
+# ---- deterministic labels: accept / borderline(->judge) / reject ----
+labeling:
+  correction_markers: ["no,", "no.", "no ", "nope", "stop", "wrong", "that's wrong",
+                       "thats wrong", "that's not", "thats not", "incorrect", "undo",
+                       "revert", "not what i"]
+  max_correction_chars: 180
+  interrupt_markers: ["[request interrupted by user]", "[request interrupted"]
+
+# ---- session-outcome classifier (the strongest quality signal) ----
+session_outcome:
+  enabled: true
+  test_command_re: "\\b(pytest|jest|vitest|mocha|go test|cargo test|cargo nextest|npm (?:run )?test|yarn test|pnpm test|tox|rspec|phpunit|gradle test|mvn test|unittest|ctest|python -m pytest)\\b"
+  build_command_re: "\\b(tsc|cargo (?:build|check|clippy)|go build|make\\b|cmake|vite build|next build|webpack|gradle build|mvn (?:package|compile)|eslint|ruff|mypy)\\b"
+  commit_command_re: "git commit"
+  pass_re: "\\b(\\d+ passed|all tests passed|tests? passed|build succeeded|0 errors?|passing|PASS)\\b"
+  fail_re: "\\b(\\d+ failed|FAILED|\\berror\\b|exception|panicked|✗)\\b"
+  approve_re: "^(thanks|thank you|perfect|great|awesome|nice|lgtm|looks good|that works|ship it|excellent|amazing|love it|works now|fixed it)\\b"
+  approve_max_chars: 80
+
+quality_tiers:
+  gold: [tests_passed, clean_build]
+  silver: [committed, pr_created, user_approved]
+  inherit_parent_for_subagents: true
+
+# ---- quality funnel: drop ceremony tools, filler, and duplicates ----
+quality_filter:
+  enabled: true
+  drop_tools: [TaskCreate, TaskUpdate, TaskList, TaskGet, TaskOutput, TaskStop,
+               TeamCreate, TeamDelete, SendMessage, ToolSearch, Monitor,
+               EnterPlanMode, ExitPlanMode, PushNotification, CronCreate, CronList,
+               CronDelete, RemoteTrigger]
+  drop_skills: ["PACT:bootstrap", "PACT:teammate-bootstrap", "PACT:orchestration"]
+  min_completion_tokens: 12
+  dedup:
+    enabled: true
+  drop_prompt_markers: []
+  # empty = tag-only (keep all rows, stamped with quality_tier). Set to e.g.
+  # [tests_passed, clean_build] to keep ONLY verified-good sessions.
+  require_outcomes: []

--- a/.agents/skills/transcript-distillation/reference/case-study-claude-codex.md
+++ b/.agents/skills/transcript-distillation/reference/case-study-claude-codex.md
@@ -1,0 +1,75 @@
+# Case Study: Distilling Claude Code + Codex into a Fine-Tuning Dataset
+
+The worked example this skill was built from — turning ~2,700 local Claude Code
+and Codex CLI transcripts into a private SFT/KTO dataset.
+
+## Goal
+Fine-tune a private model on the user's own coding-agent behavior. SFT on a
+clean high-quality pool first, then KTO refinement on a held-out set + mined
+negatives. Reuse the repo's existing training pipeline; the only new work is
+extracting good rows from raw logs.
+
+## Config
+`configs/transcript_import/default.yaml` (repo root). Differs from the template:
+- `scope.include_substrings: ["documents-code-", "/documents/code/"]` — only
+  coding projects.
+- `scope.exclude_substrings: ["qwoted", "plan-your-baby"]` — client/sensitive.
+- Output to `private/transcripts/` (gitignored).
+
+Run:
+```bash
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml --smoke --limit 30 --show 3   # smoke
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml                              # full
+```
+
+## What the data looked like
+- 1,793 Claude files = **53 main sessions + 1,740 subagent traces** (nested under
+  `<project>/<session>/subagents/`). 923 Codex rollouts (filed by date; scoped by cwd).
+- Claude main transcripts use the newer event schema (skip `attachment`,
+  `last-prompt`, `queue-operation`, `system`, ...). Subagent prompts carry heavy
+  PACT framing.
+- Codex encodes exit status as plaintext `Process exited with code N`.
+
+## Full-run result (8192-token budget)
+```
+538,804 raw turns
+  - quality funnel dropped 436,649: duplicate 368,087 · ceremony 55,763 · trivial 12,799
+  = 102,155 rows kept
+tiers:  gold 79,099 · silver 8,748 · bronze 14,308
+labels: accept 98,577 · borderline 3,509 (-> judge) · reject 69
+secrets redacted: 98,165   (0 residual on grep)
+runtime: ~6 min
+```
+
+The headline: **dedup did most of the work** — the repeated session-start ritual
+and boilerplate across 1,740 subagent files collapsed 368k duplicate turns. The
+"insane" 450k raw became ~102k deduped, ~77% gold.
+
+## Lessons (calibration for future runs)
+1. **Per-turn dump is too noisy** — every assistant turn includes acks,
+   thinking-only turns, and orchestration ceremony. The funnel (dedup + ceremony
+   + filler) is essential, not optional.
+2. **Outcome > heuristics.** Judging the whole session by tests-passed/built/
+   committed/PR'd is the strongest quality signal. ~77% of funnel-survivors were
+   from verifiably-good sessions.
+3. **Subagents must inherit the parent outcome** — their own transcript never
+   contains the commit/PR/test. Without inheritance they're ~all bronze; with
+   it, ~98% gold.
+4. **Beware noisy survey heuristics.** An early survey reported "16% Codex error
+   rate" — it was matching the word "error" in tool *output*, not real failures.
+   True failure rate (nonzero exit) was ~3%. Always confirm a detector fires on
+   true positives.
+5. **Distillation ceiling:** completions are frontier-model output, so
+   deterministic negatives are scarce (~3%). KTO negatives come mostly from the
+   judge over the borderline pool, not from rules.
+6. **Token budget is the compute knob**, not a coverage knob — it bounds context
+   depth per row, not row count. 8192 over 32768 (~16× attention cost) with ~0
+   coverage loss.
+
+## Downstream
+- **SFT**: `label==true` gold rows.
+- **KTO**: `label==null` (borderline) rows → LLM-as-judge
+  (`SynthChat validate --rubrics quality_labels`) → confirmed accept/reject,
+  interleaved with held-out gold accepts.

--- a/.agents/skills/transcript-distillation/reference/config-schema.md
+++ b/.agents/skills/transcript-distillation/reference/config-schema.md
@@ -1,0 +1,92 @@
+# Config Schema
+
+Every knob in a distill config. Start from `configs/template.yaml`.
+
+## `sources` (map)
+Each entry is one source of transcripts. The key (e.g. `claude_main`) is the
+`source_kind` stamped on rows and used for `--sources`.
+
+```yaml
+sources:
+  claude_main:
+    format: claude_code     # adapter name (REGISTRY in scripts/adapters/__init__.py)
+    enabled: true
+    root: "~/.claude/projects"   # ~ is expanded
+    glob: "*/*.jsonl"            # glob under root (recursive ** supported)
+```
+
+Multiple sources can share a format (e.g. `claude_main` and `claude_subagent`
+both use `claude_code` with different globs).
+
+## `scope` (map)
+Filter which projects are included.
+- `include_substrings`: a transcript is kept only if its scope-key contains one
+  of these (case-insensitive). **Empty list = include everything.**
+- `exclude_substrings`: ...and none of these.
+
+The scope-key is adapter-defined: `claude_code` uses the project-slug;
+`codex` uses the `cwd` recorded in `session_meta`.
+
+## `output` (map)
+- `dir`: output directory, relative to the current working directory (or absolute).
+- `rows_file`: filename (default `rows.jsonl`).
+- `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
+
+## `sanitize` (map)
+Deterministic secret scrub, applied to every text field at emit time.
+- `enabled`: bool.
+- `replacement`: template, `{name}` = pattern name.
+- `patterns`: name → regex. Each match replaced with the redaction marker.
+- `env_assignment.sensitive_key_re` / `.replacement`: redacts the VALUE in
+  `KEY=value` / `KEY: value` lines when the key matches (keeps the key name).
+
+## `context_budget` (map)
+- `max_context_tokens`: caps each row's context by estimated tokens. This is the
+  **compute knob** — set it to your training sequence length. It bounds context
+  DEPTH per row, not the number of rows.
+- `chars_per_token`: estimate divisor (4.0 ≈ English; ~3.5 for code-heavy).
+- `max_context_messages`: hard ceiling on context messages regardless of tokens.
+
+Context is filled most-recent-first after reserving room for the completion.
+A turn whose completion alone exceeds budget is still emitted, flagged
+`metadata.oversize=true`.
+
+## `labeling` (map)
+Deterministic per-turn label.
+- `correction_markers`: the next human turn is a correction (=> reject) only if
+  it is short (`max_correction_chars`) and STARTS WITH one of these.
+- `max_correction_chars`: length ceiling for a correction.
+- `interrupt_markers`: substrings marking a user interrupt.
+
+Result: `label=true` (clean accept), `label=false` (human-corrected reject),
+`label=null` (errored/interrupted but no human signal → borderline → send to a judge).
+
+## `session_outcome` (map)
+Classifies the WHOLE session by terminal signal, by matching tool commands and
+their output. All regexes are case-insensitive.
+- `test_command_re` / `build_command_re` / `commit_command_re`: which commands count.
+- `pass_re` / `fail_re`: success/failure tokens in command output.
+- `approve_re` / `approve_max_chars`: a short final human turn = approval.
+
+Detected outcomes: `tests_passed`, `clean_build`, `committed`, `pr_created`,
+`user_approved`. (`pr_created` also comes from adapter session signals, e.g.
+Claude's `pr-link` events.)
+
+## `quality_tiers` (map)
+- `gold`: list of outcomes that mean code verifiably worked.
+- `silver`: outcomes that mean saved/shipped.
+- anything else → `bronze`.
+- `inherit_parent_for_subagents`: subagents inherit their parent session's
+  outcome (their own transcript never contains the commit/PR/test).
+
+## `quality_filter` (map)
+- `enabled`: bool.
+- `drop_tools`: a turn whose only tool calls are these (ceremony/orchestration)
+  and which has no substantive text is dropped.
+- `drop_skills`: `Skill()` invocations of these are ceremony.
+- `min_completion_tokens`: text-only turns shorter than this are filler → dropped.
+- `dedup.enabled`: drop near-duplicate completions (normalized hash).
+- `drop_prompt_markers`: drop rows whose prompt starts with a ritual marker
+  (off by default — can over-drop).
+- `require_outcomes`: empty = tag-only (keep all, tiered). Set to e.g.
+  `[tests_passed, clean_build]` to keep ONLY verified-good sessions.

--- a/.agents/skills/transcript-distillation/reference/writing-adapters.md
+++ b/.agents/skills/transcript-distillation/reference/writing-adapters.md
@@ -1,0 +1,85 @@
+# Writing a Transcript Adapter
+
+The engine is format-agnostic. To support a new transcript format (a different
+agent CLI, a ShareGPT export, an OpenAI conversation dump, your own logger),
+write one adapter. Everything downstream — labeling, secret scrub, token budget,
+outcome tiering, dedup — works unchanged.
+
+## The contract
+
+Implement `Adapter` from `scripts/adapters/base.py`:
+
+```python
+from .base import Adapter, blocks_text
+
+class MyFormatAdapter(Adapter):
+    name = "myformat"                     # referenced by `format:` in config
+
+    def scope_key(self, path, root):      # string matched against scope filters
+        ...                               # e.g. a project slug or recorded cwd
+
+    def project(self, path, root):        # human label for the project
+        ...
+
+    def parse(self, path):                # -> (events, signals)
+        ...
+
+    def parent_path(self, path):          # optional: nested/subagent -> parent file
+        return None
+```
+
+Register it in `scripts/adapters/__init__.py`:
+
+```python
+from .myformat import MyFormatAdapter
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter(), MyFormatAdapter()]
+```
+
+## The normalized event model
+
+`parse(path)` returns `(events, signals)`.
+
+`events` — ordered list, one dict per turn:
+
+```python
+{"role": "human",     "text": "..."}
+{"role": "assistant", "text": "...", "tool_calls": [{"name": "Edit", "input": {...}}]}
+{"role": "tool",      "tool_error": False, "command": "pytest -q", "output": "5 passed"}
+```
+
+Rules:
+- One row is emitted per `assistant` event.
+- A `tool` event carries the `command` it answers and the `output` text. This is
+  what makes outcome detection (tests/build/commit) work **generically** — you
+  don't write any outcome logic, you just surface the command + output.
+- `command` should be the shell command string when the tool is a shell/exec
+  tool (used by `session_outcome` regexes); `""` otherwise.
+
+`signals` — session-level booleans the engine folds into outcomes:
+
+```python
+{"pr_created": True}   # e.g. the format logs an explicit "PR opened" event
+```
+
+Return `{}` if your format has no such signals (commits/PRs will still be
+detected from commands).
+
+## Tips
+
+- Skip metadata/noise lines silently; only emit human/assistant/tool turns.
+- If your format batches multiple tool results in one record, emit one `tool`
+  event per result.
+- `blocks_text()` in `base.py` handles the common "content is a string OR a list
+  of typed text blocks" shape.
+- For nested/subagent transcripts, return the parent session's file path from
+  `parent_path()` so the child inherits the parent's outcome tier.
+- Validate by running `--smoke --limit 5 --show 3` and eyeballing that prompts,
+  completions, and tool calls look right before a full run.
+
+## Reference adapters
+
+- `adapters/claude_code.py` — event-stream JSONL, `tool_use`/`tool_result`
+  blocks paired by id, `pr-link` session signal, subagent → parent inheritance.
+- `adapters/codex.py` — `response_item` payloads, `function_call` /
+  `function_call_output` pairs, exit status parsed from plaintext output, cwd
+  scope-key from `session_meta`.

--- a/.agents/skills/transcript-distillation/scripts/adapters/__init__.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Adapter registry. Add a new transcript format here.
+
+To support a new format: implement the Adapter interface in a new module
+(see base.py and writing-adapters.md), import it, and add an instance below.
+"""
+from .claude_code import ClaudeCodeAdapter
+from .codex import CodexAdapter
+
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter()]
+REGISTRY = {a.name: a for a in _ADAPTERS}
+
+
+def get_adapter(fmt: str):
+    if fmt not in REGISTRY:
+        raise KeyError(
+            f"unknown transcript format '{fmt}'. Registered: {sorted(REGISTRY)}. "
+            f"Add an adapter in adapters/ and register it in adapters/__init__.py."
+        )
+    return REGISTRY[fmt]

--- a/.agents/skills/transcript-distillation/scripts/adapters/base.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/base.py
@@ -1,0 +1,65 @@
+"""Transcript-format adapter contract.
+
+The engine (distill.py) is 100% format-agnostic. Everything format-specific
+lives in an adapter. To support a new transcript format, implement this
+interface and register it in adapters/__init__.py.
+
+NORMALIZED EVENT MODEL (the contract every adapter emits)
+---------------------------------------------------------
+parse(path) returns (events, signals).
+
+events: ordered list of dicts, one per logical turn:
+  human turn     -> {"role": "human",     "text": str}
+  assistant turn -> {"role": "assistant", "text": str,
+                     "tool_calls": [{"name": str, "input": any}]}
+  tool result    -> {"role": "tool", "tool_error": bool,
+                     "command": str,   # the command this result is answering
+                     "output": str}    # the result text (for outcome detection)
+
+  Why tool events carry command+output: it lets the engine detect "tests
+  passed / build clean / committed" generically from regexes in config —
+  no format-specific outcome code.
+
+signals: dict of session-level booleans the engine folds into outcomes, e.g.
+  {"pr_created": True}  (Claude logs an explicit pr-link event)
+
+Adapters also answer cheap path questions WITHOUT a full parse where possible:
+  scope_key(path, root) -> the string matched against scope include/exclude
+                           (a project slug, a recorded cwd, ...)
+  project(path, root)   -> a human label for the project
+  parent_path(path)     -> for nested/subagent transcripts, the parent session
+                           file whose outcome should be inherited; else None
+"""
+from __future__ import annotations
+
+
+class Adapter:
+    name = "base"
+
+    def scope_key(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def project(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def parse(self, path: str):
+        """-> (events: list[dict], signals: dict)"""
+        raise NotImplementedError
+
+    def parent_path(self, path: str):
+        """-> str | None. Override for nested/subagent transcripts."""
+        return None
+
+
+def blocks_text(content) -> str:
+    """Join text blocks from a content list (or pass a str through). Shared
+    helper — most chat formats use either a string or a list of typed blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") in ("text", "input_text", "output_text"):
+                out.append(str(b.get("text", "")))
+        return "".join(out)
+    return ""

--- a/.agents/skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -1,0 +1,95 @@
+"""Adapter for Claude Code transcripts (~/.claude/projects/**.jsonl).
+
+Main sessions and subagent runs share one schema. Subagents are nested at
+<project>/<session>/subagents/agent-*.jsonl and inherit their parent session's
+outcome (the commit/PR/test happens in the parent, never in the subagent).
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(tool_use: dict) -> str:
+    inp = tool_use.get("input")
+    if isinstance(inp, dict):
+        return str(inp.get("command", "") or "")
+    return ""
+
+
+class ClaudeCodeAdapter(Adapter):
+    name = "claude_code"
+
+    def scope_key(self, path: str, root: str) -> str:
+        # project slug is the first path component under the projects root
+        return Path(path).resolve().relative_to(Path(root).resolve()).parts[0]
+
+    def project(self, path: str, root: str) -> str:
+        return self.scope_key(path, root)
+
+    def parent_path(self, path: str):
+        # .../project/<session>/subagents/agent.jsonl -> .../project/<session>.jsonl
+        if "/subagents/" not in path.replace("\\", "/"):
+            return None
+        session_dir = Path(path).parents[1]
+        return str(session_dir.with_name(session_dir.name + ".jsonl"))
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        id2cmd: dict[str, str] = {}
+
+        for line in open(path, errors="ignore"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            t = o.get("type")
+
+            if t == "pr-link":
+                signals["pr_created"] = True
+                continue
+
+            msg = o.get("message") or {}
+            content = msg.get("content")
+
+            if t == "assistant":
+                text, tool_calls = "", []
+                if isinstance(content, list):
+                    for b in content:
+                        if not isinstance(b, dict):
+                            continue
+                        bt = b.get("type")
+                        if bt == "text":
+                            text += str(b.get("text", ""))
+                        elif bt == "tool_use":
+                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
+                            if b.get("id"):
+                                id2cmd[b["id"]] = _command_of(b)
+                elif isinstance(content, str):
+                    text = content
+                events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
+
+            elif t == "user":
+                results = []
+                if isinstance(content, list):
+                    results = [b for b in content
+                               if isinstance(b, dict) and b.get("type") == "tool_result"]
+                if results:
+                    for b in results:
+                        out = str(b.get("content", ""))
+                        err = bool(b.get("is_error"))
+                        if not err:  # some errors only show in the text, not the flag
+                            low = out[:200].lower()
+                            err = "error" in low or "traceback" in low
+                        events.append({"role": "tool", "tool_error": err,
+                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "output": out})
+                else:
+                    events.append({"role": "human", "text": blocks_text(content)})
+            # other event types (attachment, system, last-prompt, ...) are skipped
+        return events, signals

--- a/.agents/skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/codex.py
@@ -1,0 +1,89 @@
+"""Adapter for Codex CLI rollouts (~/.codex/sessions/**/*.jsonl).
+
+Sessions are filed by date, not project, so scope is filtered by the `cwd`
+recorded in the session_meta event. Tool actions are function_call /
+function_call_output pairs; exit status is plaintext "Process exited with code N".
+"""
+from __future__ import annotations
+import json
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(arguments) -> str:
+    """Best-effort shell command from a function_call's arguments."""
+    if isinstance(arguments, str):
+        try:
+            d = json.loads(arguments)
+            if isinstance(d, dict):
+                return str(d.get("cmd") or d.get("command") or arguments)
+        except json.JSONDecodeError:
+            return arguments
+        return arguments
+    if isinstance(arguments, dict):
+        return str(arguments.get("cmd") or arguments.get("command") or "")
+    return ""
+
+
+class CodexAdapter(Adapter):
+    name = "codex"
+
+    def _cwd(self, path: str) -> str:
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") == "session_meta":
+                return (o.get("payload") or {}).get("cwd", "") or ""
+        return ""
+
+    def scope_key(self, path: str, root: str) -> str:
+        return self._cwd(path)
+
+    def project(self, path: str, root: str) -> str:
+        from pathlib import Path
+        return Path(self._cwd(path)).name
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        pending_cmd = ""
+
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") != "response_item":
+                continue
+            p = o.get("payload") or {}
+            pt = p.get("type")
+
+            if pt == "message":
+                role = p.get("role")
+                text = blocks_text(p.get("content"))
+                if role == "assistant":
+                    events.append({"role": "assistant", "text": text, "tool_calls": []})
+                elif role == "user":
+                    events.append({"role": "human", "text": text})
+
+            elif pt in ("function_call", "custom_tool_call"):
+                args = p.get("arguments") or p.get("input") or ""
+                cmd = _command_of(args)
+                if "gh pr create" in cmd:
+                    signals["pr_created"] = True
+                events.append({"role": "assistant", "text": "",
+                               "tool_calls": [{"name": p.get("name"), "input": args}]})
+                pending_cmd = cmd
+
+            elif pt in ("function_call_output", "custom_tool_call_output"):
+                out = p.get("output")
+                s = out if isinstance(out, str) else json.dumps(out)
+                low = s.lower()
+                err = ("exited with code" in low and "exited with code 0" not in low) \
+                    or "traceback (most recent call last)" in low
+                events.append({"role": "tool", "tool_error": err,
+                               "command": pending_cmd, "output": s})
+                pending_cmd = ""
+        return events, signals

--- a/.agents/skills/transcript-distillation/scripts/distill.py
+++ b/.agents/skills/transcript-distillation/scripts/distill.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Distill training rows from agent transcripts (Claude Code, Codex, or any
+format with an adapter). Format-agnostic engine — all policy is in config.
+
+Pipeline: parse (adapter) -> per-assistant-turn rows -> secret scrub ->
+token-budget context -> deterministic accept/borderline labels ->
+quality funnel (drop ceremony/filler/dups) -> session-outcome tiering
+(gold/silver/bronze) -> JSONL.
+
+Usage:
+    python distill.py --config config.yaml                  # full run
+    python distill.py --config config.yaml --smoke --limit 20 --show 3
+    python distill.py --config config.yaml --sources codex --max-context-tokens 4096
+
+Paths in --config (and output.dir) are resolved relative to the current
+working directory; source roots support ~ expansion. Only dependency: pyyaml.
+"""
+from __future__ import annotations
+import argparse, glob, json, os, re, sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sanitize import Redactor          # noqa: E402
+from adapters import get_adapter       # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# scope
+# ----------------------------------------------------------------------------
+def scope_ok(key: str, scope: dict) -> bool:
+    low = (key or "").lower()
+    inc = scope.get("include_substrings") or []
+    if inc and not any(s in low for s in inc):
+        return False
+    if any(s in low for s in scope.get("exclude_substrings") or []):
+        return False
+    return True
+
+
+# ----------------------------------------------------------------------------
+# row emission + deterministic labeling  (operates on normalized events)
+# ----------------------------------------------------------------------------
+def render_completion(ev: dict) -> str:
+    parts = []
+    if ev.get("text", "").strip():
+        parts.append(ev["text"].strip())
+    if ev.get("tool_calls"):
+        parts.append("Tool calls: " + json.dumps(ev["tool_calls"], ensure_ascii=False))
+    return "\n".join(parts)
+
+
+def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
+    low = text.strip().lower()
+    if not low or len(low) > max_len:
+        return False
+    return any(low.startswith(m) for m in markers)
+
+
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+    rows = []
+    corr_markers = lab["correction_markers"]
+    intr_markers = lab["interrupt_markers"]
+    max_tokens = ctx_budget.get("max_context_tokens", 8192)
+    cpt = ctx_budget.get("chars_per_token", 4.0)
+    max_msgs = ctx_budget.get("max_context_messages", 60)
+    est = lambda s: int(len(s) / cpt) + 1   # noqa: E731
+
+    def _content(e):
+        if e["role"] == "tool":
+            return "[tool result]"
+        return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    for i, ev in enumerate(events):
+        if ev["role"] != "assistant":
+            continue
+        had_tool = bool(ev.get("tool_calls"))
+
+        tool_error = False
+        if had_tool:
+            for j in range(i + 1, min(i + 3, len(events))):
+                if events[j]["role"] == "tool":
+                    tool_error = bool(events[j].get("tool_error"))
+                    break
+
+        next_human = None
+        for j in range(i + 1, len(events)):
+            if events[j]["role"] == "human":
+                next_human = events[j].get("text", "")
+                break
+
+        interrupted = any(m in ev.get("text", "").lower() for m in intr_markers) or (
+            next_human is not None and any(m in next_human.lower() for m in intr_markers))
+        corrected = next_human is not None and _is_correction(
+            next_human, corr_markers, lab["max_correction_chars"])
+
+        failure_labels = []
+        if corrected:
+            label, tier = False, "bad"
+            failure_labels.append("user_corrected")
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        elif tool_error or interrupted:
+            label, tier = None, "borderline"
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        else:
+            label, tier = True, "good"
+
+        completion_str = render_completion(ev)
+        budget = max_tokens - est(completion_str)
+        oversize = budget < 0
+        conv_rev = [{"role": "assistant", "content": completion_str}]
+        used = 0
+        for e in reversed(events[:i]):
+            if len(conv_rev) >= max_msgs:
+                break
+            c = _content(e)
+            t = est(c)
+            if used + t > budget and len(conv_rev) > 1:
+                break
+            used += t
+            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+            conv_rev.append({"role": role, "content": c})
+        conv = list(reversed(conv_rev))
+
+        prompt = ""
+        for e in reversed(events[:i]):
+            if e["role"] == "human":
+                prompt = e.get("text", "")
+                break
+
+        rows.append({
+            "conversations": conv,
+            "prompt": prompt,
+            "completion": completion_str,
+            "label": label,
+            "score_tier": tier,
+            "failure_labels": failure_labels,
+            "source_example_id": f"{source_kind}:{rel_id}:{i}",
+            "metadata": {
+                "source_kind": source_kind,
+                "project": project,
+                "turn_index": i,
+                "tool_names": [c.get("name") for c in ev.get("tool_calls", [])],
+                "had_tool_error": tool_error,
+                "interrupted": interrupted,
+                "next_correction": corrected,
+                "est_tokens": used + est(completion_str),
+                "oversize": oversize,
+            },
+        })
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# session outcome  (generic: reads command/output off normalized tool events)
+# ----------------------------------------------------------------------------
+def classify_session(events, signals, oc) -> dict:
+    test_re = re.compile(oc["test_command_re"], re.I)
+    build_re = re.compile(oc["build_command_re"], re.I)
+    commit_re = re.compile(oc["commit_command_re"], re.I)
+    pass_re = re.compile(oc["pass_re"], re.I)
+    fail_re = re.compile(oc["fail_re"], re.I)
+    approve_re = re.compile(oc["approve_re"], re.I)
+    amax = oc.get("approve_max_chars", 80)
+
+    res = {"tests_passed": None, "clean_build": None, "committed": False,
+           "pr_created": bool((signals or {}).get("pr_created")), "user_approved": False}
+    last_human = ""
+
+    def category(cmd):
+        if commit_re.search(cmd):
+            return "commit"
+        if test_re.search(cmd):
+            return "tests"
+        if build_re.search(cmd):
+            return "build"
+        return None
+
+    for e in events:
+        if e["role"] == "human" and e.get("text", "").strip():
+            last_human = e["text"].strip()
+        elif e["role"] == "tool":
+            cmd = e.get("command") or ""
+            if "gh pr create" in cmd:
+                res["pr_created"] = True
+            cat = category(cmd)
+            if not cat:
+                continue
+            out = e.get("output") or ""
+            ok = (not e.get("tool_error")) and not fail_re.search(out)
+            if cat == "tests":
+                res["tests_passed"] = bool(ok and (pass_re.search(out) or not out.strip()))
+            elif cat == "build":
+                res["clean_build"] = bool(ok)
+            elif cat == "commit" and ok:
+                res["committed"] = True
+
+    if last_human and len(last_human) <= amax and approve_re.search(last_human):
+        res["user_approved"] = True
+
+    return {"outcomes": [k for k, v in res.items() if v is True], "evidence": res}
+
+
+def derive_tier(outcomes, tiers_cfg) -> str:
+    s = set(outcomes)
+    if s & set(tiers_cfg.get("gold", [])):
+        return "gold"
+    if s & set(tiers_cfg.get("silver", [])):
+        return "silver"
+    return "bronze"
+
+
+# ----------------------------------------------------------------------------
+# quality funnel
+# ----------------------------------------------------------------------------
+def _norm(s: str) -> str:
+    return " ".join(s.split()).lower()
+
+
+def should_keep(row, q, seen, cpt):
+    comp = row["completion"]
+    tools = [t for t in row["metadata"]["tool_names"] if t]
+    drop_tools = set(q.get("drop_tools", []))
+    drop_skills = q.get("drop_skills", [])
+
+    if tools:
+        kept = [t for t in tools if t not in drop_tools]
+        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
+            return False, "ceremony_tool"
+    else:
+        if int(len(comp) / cpt) < q.get("min_completion_tokens", 12):
+            return False, "trivial_text"
+
+    markers = q.get("drop_prompt_markers") or []
+    if markers and any(m in row["prompt"][:300] for m in markers):
+        return False, "ritual_prompt"
+
+    if q.get("dedup", {}).get("enabled"):
+        key = hash(_norm(comp))
+        if key in seen:
+            return False, "duplicate"
+        seen.add(key)
+    return True, "keep"
+
+
+# ----------------------------------------------------------------------------
+def gather_files(sources_cfg, scope, only):
+    """Yield (source_kind, adapter, path, root) for every in-scope transcript."""
+    for kind, sc in sources_cfg.items():
+        if only and kind not in only:
+            continue
+        if not sc.get("enabled", True):
+            continue
+        adapter = get_adapter(sc["format"])
+        root = os.path.expanduser(sc["root"])
+        for path in glob.glob(os.path.join(root, sc["glob"]), recursive=True):
+            try:
+                if not scope_ok(adapter.scope_key(path, root), scope):
+                    continue
+            except Exception:
+                continue
+            yield kind, adapter, path, root
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True, help="path to distill config YAML")
+    ap.add_argument("--smoke", action="store_true", help="write to smoke/ subdir")
+    ap.add_argument("--limit", type=int, default=0, help="cap files per source (0=all)")
+    ap.add_argument("--sources", default="", help="comma list to restrict sources")
+    ap.add_argument("--show", type=int, default=0, help="print N sample rows")
+    ap.add_argument("--max-context-tokens", type=int, default=0,
+                    help="override context_budget.max_context_tokens")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.config))
+    scope = cfg.get("scope", {})
+    lab = cfg["labeling"]
+    if args.max_context_tokens:
+        cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
+    redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
+    redaction_counts: Counter = Counter()
+    qcfg = cfg.get("quality_filter") or {"enabled": False}
+    q_enabled = qcfg.get("enabled", False)
+    oc_cfg = cfg.get("session_outcome") or {"enabled": False}
+    oc_enabled = oc_cfg.get("enabled", False)
+    tiers_cfg = cfg.get("quality_tiers") or {}
+    inherit_parent = tiers_cfg.get("inherit_parent_for_subagents", True)
+    require_outcomes = set(qcfg.get("require_outcomes") or [])
+    cpt = cfg.get("context_budget", {}).get("chars_per_token", 4.0)
+
+    seen: set = set()
+    drop_counts: Counter = Counter()
+    outcome_counts: Counter = Counter()
+    tier_counts: Counter = Counter()
+    parent_cache: dict = {}
+    only = set(s.strip() for s in args.sources.split(",") if s.strip())
+
+    out_dir = Path(os.path.expanduser(cfg["output"]["dir"]))
+    if args.smoke:
+        out_dir = out_dir / cfg["output"].get("smoke_subdir", "smoke")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / cfg["output"].get("rows_file", "rows.jsonl")
+
+    per_source_files: Counter = Counter()
+    stats = {"rows": 0, "accept": 0, "reject": 0, "borderline": 0, "oversize": 0}
+    by_source: dict = {}
+    samples = []
+
+    with open(out_path, "w") as fout:
+        for kind, adapter, path, root in gather_files(cfg["sources"], scope, only):
+            if args.limit and per_source_files[kind] >= args.limit:
+                continue
+            per_source_files[kind] += 1
+            try:
+                events, signals = adapter.parse(path)
+            except Exception as e:
+                print(f"  ! parse failed {path}: {e}", file=sys.stderr)
+                continue
+            project = adapter.project(path, root)
+            rel_id = Path(path).name
+
+            outcomes = []
+            if oc_enabled:
+                clf = path
+                parent = adapter.parent_path(path) if inherit_parent else None
+                if parent and os.path.exists(parent):
+                    clf = parent
+                if clf in parent_cache:
+                    outcomes = parent_cache[clf]
+                else:
+                    try:
+                        ev2, sig2 = (events, signals) if clf == path else adapter.parse(clf)
+                        outcomes = classify_session(ev2, sig2, oc_cfg)["outcomes"]
+                    except Exception as e:
+                        print(f"  ! outcome scan failed {clf}: {e}", file=sys.stderr)
+                        outcomes = []
+                    parent_cache[clf] = outcomes
+            tier = derive_tier(outcomes, tiers_cfg)
+
+            rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+            bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
+            for r in rows:
+                r["metadata"]["session_outcome"] = outcomes
+                r["metadata"]["good_path"] = bool(outcomes)
+                r["metadata"]["quality_tier"] = tier
+                r["prompt"] = redactor.redact(r["prompt"], redaction_counts)
+                r["completion"] = redactor.redact(r["completion"], redaction_counts)
+                if q_enabled:
+                    keep, reason = should_keep(r, qcfg, seen, cpt)
+                    if not keep:
+                        drop_counts[reason] += 1
+                        continue
+                if require_outcomes and not (set(outcomes) & require_outcomes):
+                    drop_counts["no_good_outcome"] += 1
+                    continue
+                for o2 in (outcomes or ["(none)"]):
+                    outcome_counts[o2] += 1
+                tier_counts[tier] += 1
+                for m in r["conversations"]:
+                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                fout.write(json.dumps(r, ensure_ascii=False) + "\n")
+                stats["rows"] += 1
+                bucket = ("accept" if r["label"] is True else
+                          "reject" if r["label"] is False else "borderline")
+                stats[bucket] += 1
+                bs[bucket] += 1
+                if r["metadata"]["oversize"]:
+                    stats["oversize"] += 1
+                if len(samples) < args.show and r["completion"].strip():
+                    samples.append(r)
+
+    print("=" * 64)
+    dropped = sum(drop_counts.values())
+    if dropped:
+        print(f"quality funnel dropped {dropped:,} rows: {dict(drop_counts)}")
+    print(f"wrote {stats['rows']:,} rows -> {out_path}")
+    print(f"  files per source: {dict(per_source_files)}")
+    print(f"  ACCEPT {stats['accept']:,} | REJECT {stats['reject']:,} | "
+          f"BORDERLINE {stats['borderline']:,} (-> judge)")
+    for k, b in by_source.items():
+        print(f"    {k:18s}: {b['accept']:,} / {b['reject']:,} / {b['borderline']:,}")
+    print(f"  oversize rows: {stats['oversize']:,}")
+    print(f"  session outcome (turn counts): {dict(outcome_counts)}")
+    print(f"  QUALITY TIER: {dict(tier_counts)}")
+    total_redacted = sum(redaction_counts.values())
+    print(f"  secrets redacted: {total_redacted:,}", dict(redaction_counts) or "")
+    print("=" * 64)
+    for k, s in enumerate(samples):
+        print(f"\n--- sample {k+1} [{s['metadata']['source_kind']} / {s['score_tier']} / "
+              f"{s['metadata']['quality_tier']}] tools={s['metadata']['tool_names']} ---")
+        print("PROMPT   :", (s["prompt"] or "")[:160].replace("\n", " "))
+        print("COMPLETE :", s["completion"][:240].replace("\n", " "))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/skills/transcript-distillation/scripts/sanitize.py
+++ b/.agents/skills/transcript-distillation/scripts/sanitize.py
@@ -1,0 +1,48 @@
+"""Deterministic secret redaction for transcript rows.
+
+Config-driven (see configs/transcript_import/default.yaml `sanitize:`). Catches
+high-entropy credential formats and sensitive KEY=VALUE assignments. Applied at
+emit time so raw secrets never reach disk.
+
+This is a SECRET scrubber, not a PII scrubber — it targets keys/tokens that a
+model could memorize and regurgitate. For names/emails/paths, run the OPF-backed
+SynthChat sanitize as a separate pass.
+"""
+from __future__ import annotations
+import re
+from collections import Counter
+
+
+class Redactor:
+    def __init__(self, cfg: dict):
+        self.enabled = cfg.get("enabled", True)
+        self.replacement = cfg.get("replacement", "[REDACTED:{name}]")
+        self._patterns = [(name, re.compile(pat))
+                          for name, pat in cfg.get("patterns", {}).items()]
+        env = cfg.get("env_assignment") or {}
+        self._env_re = None
+        if env.get("sensitive_key_re"):
+            key_re = env["sensitive_key_re"].replace("(?i)", "")  # flag -> compile arg
+            # capture a sensitive key followed by = or : then the value to drop
+            self._env_re = re.compile(
+                rf"({key_re}\s*[:=]\s*)"
+                r"(['\"]?)([^\s'\"]{4,})(\2)", re.IGNORECASE)
+            self._env_replacement = env.get("replacement", "[REDACTED:env_secret]")
+
+    def redact(self, text: str, counts: Counter | None = None):
+        """Return redacted text; tally hits into `counts` if given."""
+        if not self.enabled or not text:
+            return text
+        for name, rx in self._patterns:
+            def _sub(m, n=name):
+                if counts is not None:
+                    counts[n] += 1
+                return self.replacement.format(name=n)
+            text = rx.sub(_sub, text)
+        if self._env_re is not None:
+            def _env_sub(m):
+                if counts is not None:
+                    counts["env_secret"] += 1
+                return m.group(1) + self._env_replacement
+            text = self._env_re.sub(_env_sub, text)
+        return text

--- a/.claude/skills/transcript-distillation/SKILL.md
+++ b/.claude/skills/transcript-distillation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: transcript-distillation
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+allowed-tools: Read, Bash, Write, Edit, Grep, Glob
+---
+
+# Transcript Distillation
+
+Mine local agent transcripts into training data. You point it at a directory of
+conversation logs; it emits one row per assistant turn, scrubs secrets, labels
+each turn (accept / borderline / reject), scores each *session* by how it ended
+up (tests passed, clean build, commit, PR, approval), drops ceremony/filler/
+duplicates, and stamps a quality tier (gold/silver/bronze) on every row.
+
+**Format-agnostic.** The engine knows nothing about Claude or Codex — that lives
+in small pluggable *adapters*. Two ship built-in (`claude_code`, `codex`); add
+more in ~40 lines (see `reference/writing-adapters.md`).
+
+## Quickstart
+
+```bash
+SKILL=.skills/transcript-distillation
+
+# 1. copy the template config and (optionally) edit scope/paths
+cp $SKILL/configs/template.yaml my_distill.yaml
+
+# 2. smoke test on a few files first — ALWAYS do this before a full run
+python $SKILL/scripts/distill.py --config my_distill.yaml --smoke --limit 20 --show 3
+
+# 3. full run
+python $SKILL/scripts/distill.py --config my_distill.yaml
+```
+
+Out of the box the template grabs **all** local Claude Code (`~/.claude/projects`)
+and Codex (`~/.codex/sessions`) transcripts and writes to
+`./transcript_distill_out/rows.jsonl`. Only dependency: `pyyaml`.
+
+## CLI
+
+| Flag | Meaning |
+|------|---------|
+| `--config PATH` | distill config YAML (required) |
+| `--smoke` | write to a `smoke/` subdir (keeps full runs separate) |
+| `--limit N` | cap files **per source** (0 = all) — use for smoke tests |
+| `--sources a,b` | restrict to named sources from config |
+| `--show N` | print N sample rows to eyeball quality |
+| `--max-context-tokens N` | override `context_budget.max_context_tokens` for this run |
+
+## Pipeline (all config-driven)
+
+```
+adapter.parse(file)            # format-specific -> normalized events
+  -> one row per assistant turn
+  -> secret scrub at emit time (raw secrets never hit disk)
+  -> context filled most-recent-first under a TOKEN budget
+  -> deterministic label: accept / borderline(->judge) / reject
+  -> quality funnel: drop ceremony tools, trivial filler, duplicates
+  -> session-outcome tiering: gold / silver / bronze
+  -> JSONL
+```
+
+Each knob is documented in `reference/config-schema.md`. Highlights:
+
+- **`scope`** — include/exclude projects by substring (Claude: project slug;
+  Codex: recorded cwd). Empty include = everything.
+- **`context_budget.max_context_tokens`** — set to your training seq length.
+  This caps context DEPTH per row, *not* the number of rows; training cost is
+  ~O(seq²), so keep it real (8192 is a good default; 32768 is ~16× the compute).
+- **`session_outcome`** — regexes that detect tests-passed / clean-build /
+  commit / PR / approval from tool commands + their output. The strongest
+  quality signal: it judges the whole path by where it ended up.
+- **`quality_tiers`** — map outcomes to gold (verified-correct) / silver
+  (saved/shipped) / bronze (no signal). Subagents inherit their parent
+  session's tier.
+- **`quality_filter`** — drop ceremony tools (orchestration), trivial text
+  turns, and duplicate completions. Set `require_outcomes` to keep ONLY
+  verified-good sessions.
+
+## Output row schema
+
+One JSON object per line, shaped for SFT/KTO:
+
+```json
+{
+  "conversations": [{"role": "...", "content": "..."}],
+  "prompt": "...", "completion": "...",
+  "label": true | false | null,        // accept / reject / borderline(->judge)
+  "score_tier": "good|bad|borderline",
+  "failure_labels": ["tool_error", "user_corrected", ...],
+  "source_example_id": "claude_main:<file>:<turn>",
+  "metadata": {
+    "quality_tier": "gold|silver|bronze",
+    "session_outcome": ["clean_build", "committed"],
+    "good_path": true,
+    "tool_names": ["Edit"], "est_tokens": 5948, "oversize": false, ...
+  }
+}
+```
+
+Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
+SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
+LLM-as-judge to mint KTO negatives.
+
+## Privacy
+
+- Secret scrubbing is **on by default** and runs at emit time, so raw API
+  keys/tokens never reach disk. Verify with a residual grep after a run.
+- Transcript-derived output is private. Keep the output dir gitignored.
+- A trained model on frontier-agent transcripts is distillation — keep it
+  private (provider ToS).
+
+## References
+
+| File | When |
+|------|------|
+| `reference/config-schema.md` | Every config knob explained |
+| `reference/writing-adapters.md` | Add support for a new transcript format |
+| `reference/case-study-claude-codex.md` | Worked example: 538k turns → ~102k tiered rows |
+
+## Discipline
+
+- **Always `--smoke --limit` first**, eyeball `--show` samples, then full run.
+- Keep everything in config — never hardcode a tool name, scope, or format
+  assumption in the engine. Format specifics belong in an adapter.

--- a/.claude/skills/transcript-distillation/configs/template.yaml
+++ b/.claude/skills/transcript-distillation/configs/template.yaml
@@ -1,0 +1,101 @@
+# transcript-distillation — portable template config.
+# Copy this, adjust, and run:
+#   python .../scripts/distill.py --config my_config.yaml --smoke --limit 20 --show 3
+#
+# Out of the box this grabs ALL local Claude Code + Codex transcripts (empty
+# scope = match everything) and writes deduped, quality-tiered rows to
+# ./transcript_distill_out/. Tighten `scope` to target specific projects.
+
+sources:
+  claude_main:
+    format: claude_code          # adapter name (see scripts/adapters/)
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*.jsonl"            # main session transcripts
+  claude_subagent:
+    format: claude_code
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*/subagents/*.jsonl"   # Task-tool / subagent runs (inherit parent outcome)
+  codex:
+    format: codex
+    enabled: true
+    root: "~/.codex/sessions"
+    glob: "**/*.jsonl"
+
+# Which projects to include. Claude is matched by project-slug, Codex by the
+# cwd in session_meta. EMPTY include = match everything (good for a first run).
+scope:
+  include_substrings: []         # e.g. ["documents-code-", "/documents/code/"]
+  exclude_substrings: []         # e.g. ["secret-client", "personal"]
+
+output:
+  dir: "transcript_distill_out"  # relative to where you run distill.py
+  rows_file: "rows.jsonl"
+  smoke_subdir: "smoke"
+
+# ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
+sanitize:
+  enabled: true
+  replacement: "[REDACTED:{name}]"
+  patterns:
+    openai_key: "sk-(?:proj-)?[A-Za-z0-9_-]{20,}"
+    openrouter_key: "sk-or-v1-[A-Za-z0-9]{32,}"
+    anthropic_key: "sk-ant-[A-Za-z0-9_-]{20,}"
+    hf_token: "hf_[A-Za-z0-9]{30,}"
+    github_token: "gh[pousr]_[A-Za-z0-9]{36,}"
+    aws_access_key: "AKIA[0-9A-Z]{16}"
+    google_api_key: "AIza[0-9A-Za-z_-]{35}"
+    slack_token: "xox[baprs]-[0-9A-Za-z-]{10,}"
+    bearer_token: "[Bb]earer\\s+[A-Za-z0-9._-]{20,}"
+    jwt: "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}"
+    private_key_block: "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+  env_assignment:
+    sensitive_key_re: "(?i)(?:api[_-]?key|secret|token|password|passwd|private[_-]?key|access[_-]?key|client[_-]?secret)"
+    replacement: "[REDACTED:env_secret]"
+
+# ---- one row per assistant turn; context filled most-recent-first to budget ----
+context_budget:
+  max_context_tokens: 8192       # your training seq length (override: --max-context-tokens)
+  chars_per_token: 4.0
+  max_context_messages: 120
+
+# ---- deterministic labels: accept / borderline(->judge) / reject ----
+labeling:
+  correction_markers: ["no,", "no.", "no ", "nope", "stop", "wrong", "that's wrong",
+                       "thats wrong", "that's not", "thats not", "incorrect", "undo",
+                       "revert", "not what i"]
+  max_correction_chars: 180
+  interrupt_markers: ["[request interrupted by user]", "[request interrupted"]
+
+# ---- session-outcome classifier (the strongest quality signal) ----
+session_outcome:
+  enabled: true
+  test_command_re: "\\b(pytest|jest|vitest|mocha|go test|cargo test|cargo nextest|npm (?:run )?test|yarn test|pnpm test|tox|rspec|phpunit|gradle test|mvn test|unittest|ctest|python -m pytest)\\b"
+  build_command_re: "\\b(tsc|cargo (?:build|check|clippy)|go build|make\\b|cmake|vite build|next build|webpack|gradle build|mvn (?:package|compile)|eslint|ruff|mypy)\\b"
+  commit_command_re: "git commit"
+  pass_re: "\\b(\\d+ passed|all tests passed|tests? passed|build succeeded|0 errors?|passing|PASS)\\b"
+  fail_re: "\\b(\\d+ failed|FAILED|\\berror\\b|exception|panicked|✗)\\b"
+  approve_re: "^(thanks|thank you|perfect|great|awesome|nice|lgtm|looks good|that works|ship it|excellent|amazing|love it|works now|fixed it)\\b"
+  approve_max_chars: 80
+
+quality_tiers:
+  gold: [tests_passed, clean_build]
+  silver: [committed, pr_created, user_approved]
+  inherit_parent_for_subagents: true
+
+# ---- quality funnel: drop ceremony tools, filler, and duplicates ----
+quality_filter:
+  enabled: true
+  drop_tools: [TaskCreate, TaskUpdate, TaskList, TaskGet, TaskOutput, TaskStop,
+               TeamCreate, TeamDelete, SendMessage, ToolSearch, Monitor,
+               EnterPlanMode, ExitPlanMode, PushNotification, CronCreate, CronList,
+               CronDelete, RemoteTrigger]
+  drop_skills: ["PACT:bootstrap", "PACT:teammate-bootstrap", "PACT:orchestration"]
+  min_completion_tokens: 12
+  dedup:
+    enabled: true
+  drop_prompt_markers: []
+  # empty = tag-only (keep all rows, stamped with quality_tier). Set to e.g.
+  # [tests_passed, clean_build] to keep ONLY verified-good sessions.
+  require_outcomes: []

--- a/.claude/skills/transcript-distillation/reference/case-study-claude-codex.md
+++ b/.claude/skills/transcript-distillation/reference/case-study-claude-codex.md
@@ -1,0 +1,75 @@
+# Case Study: Distilling Claude Code + Codex into a Fine-Tuning Dataset
+
+The worked example this skill was built from — turning ~2,700 local Claude Code
+and Codex CLI transcripts into a private SFT/KTO dataset.
+
+## Goal
+Fine-tune a private model on the user's own coding-agent behavior. SFT on a
+clean high-quality pool first, then KTO refinement on a held-out set + mined
+negatives. Reuse the repo's existing training pipeline; the only new work is
+extracting good rows from raw logs.
+
+## Config
+`configs/transcript_import/default.yaml` (repo root). Differs from the template:
+- `scope.include_substrings: ["documents-code-", "/documents/code/"]` — only
+  coding projects.
+- `scope.exclude_substrings: ["qwoted", "plan-your-baby"]` — client/sensitive.
+- Output to `private/transcripts/` (gitignored).
+
+Run:
+```bash
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml --smoke --limit 30 --show 3   # smoke
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml                              # full
+```
+
+## What the data looked like
+- 1,793 Claude files = **53 main sessions + 1,740 subagent traces** (nested under
+  `<project>/<session>/subagents/`). 923 Codex rollouts (filed by date; scoped by cwd).
+- Claude main transcripts use the newer event schema (skip `attachment`,
+  `last-prompt`, `queue-operation`, `system`, ...). Subagent prompts carry heavy
+  PACT framing.
+- Codex encodes exit status as plaintext `Process exited with code N`.
+
+## Full-run result (8192-token budget)
+```
+538,804 raw turns
+  - quality funnel dropped 436,649: duplicate 368,087 · ceremony 55,763 · trivial 12,799
+  = 102,155 rows kept
+tiers:  gold 79,099 · silver 8,748 · bronze 14,308
+labels: accept 98,577 · borderline 3,509 (-> judge) · reject 69
+secrets redacted: 98,165   (0 residual on grep)
+runtime: ~6 min
+```
+
+The headline: **dedup did most of the work** — the repeated session-start ritual
+and boilerplate across 1,740 subagent files collapsed 368k duplicate turns. The
+"insane" 450k raw became ~102k deduped, ~77% gold.
+
+## Lessons (calibration for future runs)
+1. **Per-turn dump is too noisy** — every assistant turn includes acks,
+   thinking-only turns, and orchestration ceremony. The funnel (dedup + ceremony
+   + filler) is essential, not optional.
+2. **Outcome > heuristics.** Judging the whole session by tests-passed/built/
+   committed/PR'd is the strongest quality signal. ~77% of funnel-survivors were
+   from verifiably-good sessions.
+3. **Subagents must inherit the parent outcome** — their own transcript never
+   contains the commit/PR/test. Without inheritance they're ~all bronze; with
+   it, ~98% gold.
+4. **Beware noisy survey heuristics.** An early survey reported "16% Codex error
+   rate" — it was matching the word "error" in tool *output*, not real failures.
+   True failure rate (nonzero exit) was ~3%. Always confirm a detector fires on
+   true positives.
+5. **Distillation ceiling:** completions are frontier-model output, so
+   deterministic negatives are scarce (~3%). KTO negatives come mostly from the
+   judge over the borderline pool, not from rules.
+6. **Token budget is the compute knob**, not a coverage knob — it bounds context
+   depth per row, not row count. 8192 over 32768 (~16× attention cost) with ~0
+   coverage loss.
+
+## Downstream
+- **SFT**: `label==true` gold rows.
+- **KTO**: `label==null` (borderline) rows → LLM-as-judge
+  (`SynthChat validate --rubrics quality_labels`) → confirmed accept/reject,
+  interleaved with held-out gold accepts.

--- a/.claude/skills/transcript-distillation/reference/config-schema.md
+++ b/.claude/skills/transcript-distillation/reference/config-schema.md
@@ -1,0 +1,92 @@
+# Config Schema
+
+Every knob in a distill config. Start from `configs/template.yaml`.
+
+## `sources` (map)
+Each entry is one source of transcripts. The key (e.g. `claude_main`) is the
+`source_kind` stamped on rows and used for `--sources`.
+
+```yaml
+sources:
+  claude_main:
+    format: claude_code     # adapter name (REGISTRY in scripts/adapters/__init__.py)
+    enabled: true
+    root: "~/.claude/projects"   # ~ is expanded
+    glob: "*/*.jsonl"            # glob under root (recursive ** supported)
+```
+
+Multiple sources can share a format (e.g. `claude_main` and `claude_subagent`
+both use `claude_code` with different globs).
+
+## `scope` (map)
+Filter which projects are included.
+- `include_substrings`: a transcript is kept only if its scope-key contains one
+  of these (case-insensitive). **Empty list = include everything.**
+- `exclude_substrings`: ...and none of these.
+
+The scope-key is adapter-defined: `claude_code` uses the project-slug;
+`codex` uses the `cwd` recorded in `session_meta`.
+
+## `output` (map)
+- `dir`: output directory, relative to the current working directory (or absolute).
+- `rows_file`: filename (default `rows.jsonl`).
+- `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
+
+## `sanitize` (map)
+Deterministic secret scrub, applied to every text field at emit time.
+- `enabled`: bool.
+- `replacement`: template, `{name}` = pattern name.
+- `patterns`: name → regex. Each match replaced with the redaction marker.
+- `env_assignment.sensitive_key_re` / `.replacement`: redacts the VALUE in
+  `KEY=value` / `KEY: value` lines when the key matches (keeps the key name).
+
+## `context_budget` (map)
+- `max_context_tokens`: caps each row's context by estimated tokens. This is the
+  **compute knob** — set it to your training sequence length. It bounds context
+  DEPTH per row, not the number of rows.
+- `chars_per_token`: estimate divisor (4.0 ≈ English; ~3.5 for code-heavy).
+- `max_context_messages`: hard ceiling on context messages regardless of tokens.
+
+Context is filled most-recent-first after reserving room for the completion.
+A turn whose completion alone exceeds budget is still emitted, flagged
+`metadata.oversize=true`.
+
+## `labeling` (map)
+Deterministic per-turn label.
+- `correction_markers`: the next human turn is a correction (=> reject) only if
+  it is short (`max_correction_chars`) and STARTS WITH one of these.
+- `max_correction_chars`: length ceiling for a correction.
+- `interrupt_markers`: substrings marking a user interrupt.
+
+Result: `label=true` (clean accept), `label=false` (human-corrected reject),
+`label=null` (errored/interrupted but no human signal → borderline → send to a judge).
+
+## `session_outcome` (map)
+Classifies the WHOLE session by terminal signal, by matching tool commands and
+their output. All regexes are case-insensitive.
+- `test_command_re` / `build_command_re` / `commit_command_re`: which commands count.
+- `pass_re` / `fail_re`: success/failure tokens in command output.
+- `approve_re` / `approve_max_chars`: a short final human turn = approval.
+
+Detected outcomes: `tests_passed`, `clean_build`, `committed`, `pr_created`,
+`user_approved`. (`pr_created` also comes from adapter session signals, e.g.
+Claude's `pr-link` events.)
+
+## `quality_tiers` (map)
+- `gold`: list of outcomes that mean code verifiably worked.
+- `silver`: outcomes that mean saved/shipped.
+- anything else → `bronze`.
+- `inherit_parent_for_subagents`: subagents inherit their parent session's
+  outcome (their own transcript never contains the commit/PR/test).
+
+## `quality_filter` (map)
+- `enabled`: bool.
+- `drop_tools`: a turn whose only tool calls are these (ceremony/orchestration)
+  and which has no substantive text is dropped.
+- `drop_skills`: `Skill()` invocations of these are ceremony.
+- `min_completion_tokens`: text-only turns shorter than this are filler → dropped.
+- `dedup.enabled`: drop near-duplicate completions (normalized hash).
+- `drop_prompt_markers`: drop rows whose prompt starts with a ritual marker
+  (off by default — can over-drop).
+- `require_outcomes`: empty = tag-only (keep all, tiered). Set to e.g.
+  `[tests_passed, clean_build]` to keep ONLY verified-good sessions.

--- a/.claude/skills/transcript-distillation/reference/writing-adapters.md
+++ b/.claude/skills/transcript-distillation/reference/writing-adapters.md
@@ -1,0 +1,85 @@
+# Writing a Transcript Adapter
+
+The engine is format-agnostic. To support a new transcript format (a different
+agent CLI, a ShareGPT export, an OpenAI conversation dump, your own logger),
+write one adapter. Everything downstream — labeling, secret scrub, token budget,
+outcome tiering, dedup — works unchanged.
+
+## The contract
+
+Implement `Adapter` from `scripts/adapters/base.py`:
+
+```python
+from .base import Adapter, blocks_text
+
+class MyFormatAdapter(Adapter):
+    name = "myformat"                     # referenced by `format:` in config
+
+    def scope_key(self, path, root):      # string matched against scope filters
+        ...                               # e.g. a project slug or recorded cwd
+
+    def project(self, path, root):        # human label for the project
+        ...
+
+    def parse(self, path):                # -> (events, signals)
+        ...
+
+    def parent_path(self, path):          # optional: nested/subagent -> parent file
+        return None
+```
+
+Register it in `scripts/adapters/__init__.py`:
+
+```python
+from .myformat import MyFormatAdapter
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter(), MyFormatAdapter()]
+```
+
+## The normalized event model
+
+`parse(path)` returns `(events, signals)`.
+
+`events` — ordered list, one dict per turn:
+
+```python
+{"role": "human",     "text": "..."}
+{"role": "assistant", "text": "...", "tool_calls": [{"name": "Edit", "input": {...}}]}
+{"role": "tool",      "tool_error": False, "command": "pytest -q", "output": "5 passed"}
+```
+
+Rules:
+- One row is emitted per `assistant` event.
+- A `tool` event carries the `command` it answers and the `output` text. This is
+  what makes outcome detection (tests/build/commit) work **generically** — you
+  don't write any outcome logic, you just surface the command + output.
+- `command` should be the shell command string when the tool is a shell/exec
+  tool (used by `session_outcome` regexes); `""` otherwise.
+
+`signals` — session-level booleans the engine folds into outcomes:
+
+```python
+{"pr_created": True}   # e.g. the format logs an explicit "PR opened" event
+```
+
+Return `{}` if your format has no such signals (commits/PRs will still be
+detected from commands).
+
+## Tips
+
+- Skip metadata/noise lines silently; only emit human/assistant/tool turns.
+- If your format batches multiple tool results in one record, emit one `tool`
+  event per result.
+- `blocks_text()` in `base.py` handles the common "content is a string OR a list
+  of typed text blocks" shape.
+- For nested/subagent transcripts, return the parent session's file path from
+  `parent_path()` so the child inherits the parent's outcome tier.
+- Validate by running `--smoke --limit 5 --show 3` and eyeballing that prompts,
+  completions, and tool calls look right before a full run.
+
+## Reference adapters
+
+- `adapters/claude_code.py` — event-stream JSONL, `tool_use`/`tool_result`
+  blocks paired by id, `pr-link` session signal, subagent → parent inheritance.
+- `adapters/codex.py` — `response_item` payloads, `function_call` /
+  `function_call_output` pairs, exit status parsed from plaintext output, cwd
+  scope-key from `session_meta`.

--- a/.claude/skills/transcript-distillation/scripts/adapters/__init__.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Adapter registry. Add a new transcript format here.
+
+To support a new format: implement the Adapter interface in a new module
+(see base.py and writing-adapters.md), import it, and add an instance below.
+"""
+from .claude_code import ClaudeCodeAdapter
+from .codex import CodexAdapter
+
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter()]
+REGISTRY = {a.name: a for a in _ADAPTERS}
+
+
+def get_adapter(fmt: str):
+    if fmt not in REGISTRY:
+        raise KeyError(
+            f"unknown transcript format '{fmt}'. Registered: {sorted(REGISTRY)}. "
+            f"Add an adapter in adapters/ and register it in adapters/__init__.py."
+        )
+    return REGISTRY[fmt]

--- a/.claude/skills/transcript-distillation/scripts/adapters/base.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/base.py
@@ -1,0 +1,65 @@
+"""Transcript-format adapter contract.
+
+The engine (distill.py) is 100% format-agnostic. Everything format-specific
+lives in an adapter. To support a new transcript format, implement this
+interface and register it in adapters/__init__.py.
+
+NORMALIZED EVENT MODEL (the contract every adapter emits)
+---------------------------------------------------------
+parse(path) returns (events, signals).
+
+events: ordered list of dicts, one per logical turn:
+  human turn     -> {"role": "human",     "text": str}
+  assistant turn -> {"role": "assistant", "text": str,
+                     "tool_calls": [{"name": str, "input": any}]}
+  tool result    -> {"role": "tool", "tool_error": bool,
+                     "command": str,   # the command this result is answering
+                     "output": str}    # the result text (for outcome detection)
+
+  Why tool events carry command+output: it lets the engine detect "tests
+  passed / build clean / committed" generically from regexes in config —
+  no format-specific outcome code.
+
+signals: dict of session-level booleans the engine folds into outcomes, e.g.
+  {"pr_created": True}  (Claude logs an explicit pr-link event)
+
+Adapters also answer cheap path questions WITHOUT a full parse where possible:
+  scope_key(path, root) -> the string matched against scope include/exclude
+                           (a project slug, a recorded cwd, ...)
+  project(path, root)   -> a human label for the project
+  parent_path(path)     -> for nested/subagent transcripts, the parent session
+                           file whose outcome should be inherited; else None
+"""
+from __future__ import annotations
+
+
+class Adapter:
+    name = "base"
+
+    def scope_key(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def project(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def parse(self, path: str):
+        """-> (events: list[dict], signals: dict)"""
+        raise NotImplementedError
+
+    def parent_path(self, path: str):
+        """-> str | None. Override for nested/subagent transcripts."""
+        return None
+
+
+def blocks_text(content) -> str:
+    """Join text blocks from a content list (or pass a str through). Shared
+    helper — most chat formats use either a string or a list of typed blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") in ("text", "input_text", "output_text"):
+                out.append(str(b.get("text", "")))
+        return "".join(out)
+    return ""

--- a/.claude/skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -1,0 +1,95 @@
+"""Adapter for Claude Code transcripts (~/.claude/projects/**.jsonl).
+
+Main sessions and subagent runs share one schema. Subagents are nested at
+<project>/<session>/subagents/agent-*.jsonl and inherit their parent session's
+outcome (the commit/PR/test happens in the parent, never in the subagent).
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(tool_use: dict) -> str:
+    inp = tool_use.get("input")
+    if isinstance(inp, dict):
+        return str(inp.get("command", "") or "")
+    return ""
+
+
+class ClaudeCodeAdapter(Adapter):
+    name = "claude_code"
+
+    def scope_key(self, path: str, root: str) -> str:
+        # project slug is the first path component under the projects root
+        return Path(path).resolve().relative_to(Path(root).resolve()).parts[0]
+
+    def project(self, path: str, root: str) -> str:
+        return self.scope_key(path, root)
+
+    def parent_path(self, path: str):
+        # .../project/<session>/subagents/agent.jsonl -> .../project/<session>.jsonl
+        if "/subagents/" not in path.replace("\\", "/"):
+            return None
+        session_dir = Path(path).parents[1]
+        return str(session_dir.with_name(session_dir.name + ".jsonl"))
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        id2cmd: dict[str, str] = {}
+
+        for line in open(path, errors="ignore"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            t = o.get("type")
+
+            if t == "pr-link":
+                signals["pr_created"] = True
+                continue
+
+            msg = o.get("message") or {}
+            content = msg.get("content")
+
+            if t == "assistant":
+                text, tool_calls = "", []
+                if isinstance(content, list):
+                    for b in content:
+                        if not isinstance(b, dict):
+                            continue
+                        bt = b.get("type")
+                        if bt == "text":
+                            text += str(b.get("text", ""))
+                        elif bt == "tool_use":
+                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
+                            if b.get("id"):
+                                id2cmd[b["id"]] = _command_of(b)
+                elif isinstance(content, str):
+                    text = content
+                events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
+
+            elif t == "user":
+                results = []
+                if isinstance(content, list):
+                    results = [b for b in content
+                               if isinstance(b, dict) and b.get("type") == "tool_result"]
+                if results:
+                    for b in results:
+                        out = str(b.get("content", ""))
+                        err = bool(b.get("is_error"))
+                        if not err:  # some errors only show in the text, not the flag
+                            low = out[:200].lower()
+                            err = "error" in low or "traceback" in low
+                        events.append({"role": "tool", "tool_error": err,
+                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "output": out})
+                else:
+                    events.append({"role": "human", "text": blocks_text(content)})
+            # other event types (attachment, system, last-prompt, ...) are skipped
+        return events, signals

--- a/.claude/skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/codex.py
@@ -1,0 +1,89 @@
+"""Adapter for Codex CLI rollouts (~/.codex/sessions/**/*.jsonl).
+
+Sessions are filed by date, not project, so scope is filtered by the `cwd`
+recorded in the session_meta event. Tool actions are function_call /
+function_call_output pairs; exit status is plaintext "Process exited with code N".
+"""
+from __future__ import annotations
+import json
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(arguments) -> str:
+    """Best-effort shell command from a function_call's arguments."""
+    if isinstance(arguments, str):
+        try:
+            d = json.loads(arguments)
+            if isinstance(d, dict):
+                return str(d.get("cmd") or d.get("command") or arguments)
+        except json.JSONDecodeError:
+            return arguments
+        return arguments
+    if isinstance(arguments, dict):
+        return str(arguments.get("cmd") or arguments.get("command") or "")
+    return ""
+
+
+class CodexAdapter(Adapter):
+    name = "codex"
+
+    def _cwd(self, path: str) -> str:
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") == "session_meta":
+                return (o.get("payload") or {}).get("cwd", "") or ""
+        return ""
+
+    def scope_key(self, path: str, root: str) -> str:
+        return self._cwd(path)
+
+    def project(self, path: str, root: str) -> str:
+        from pathlib import Path
+        return Path(self._cwd(path)).name
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        pending_cmd = ""
+
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") != "response_item":
+                continue
+            p = o.get("payload") or {}
+            pt = p.get("type")
+
+            if pt == "message":
+                role = p.get("role")
+                text = blocks_text(p.get("content"))
+                if role == "assistant":
+                    events.append({"role": "assistant", "text": text, "tool_calls": []})
+                elif role == "user":
+                    events.append({"role": "human", "text": text})
+
+            elif pt in ("function_call", "custom_tool_call"):
+                args = p.get("arguments") or p.get("input") or ""
+                cmd = _command_of(args)
+                if "gh pr create" in cmd:
+                    signals["pr_created"] = True
+                events.append({"role": "assistant", "text": "",
+                               "tool_calls": [{"name": p.get("name"), "input": args}]})
+                pending_cmd = cmd
+
+            elif pt in ("function_call_output", "custom_tool_call_output"):
+                out = p.get("output")
+                s = out if isinstance(out, str) else json.dumps(out)
+                low = s.lower()
+                err = ("exited with code" in low and "exited with code 0" not in low) \
+                    or "traceback (most recent call last)" in low
+                events.append({"role": "tool", "tool_error": err,
+                               "command": pending_cmd, "output": s})
+                pending_cmd = ""
+        return events, signals

--- a/.claude/skills/transcript-distillation/scripts/distill.py
+++ b/.claude/skills/transcript-distillation/scripts/distill.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Distill training rows from agent transcripts (Claude Code, Codex, or any
+format with an adapter). Format-agnostic engine — all policy is in config.
+
+Pipeline: parse (adapter) -> per-assistant-turn rows -> secret scrub ->
+token-budget context -> deterministic accept/borderline labels ->
+quality funnel (drop ceremony/filler/dups) -> session-outcome tiering
+(gold/silver/bronze) -> JSONL.
+
+Usage:
+    python distill.py --config config.yaml                  # full run
+    python distill.py --config config.yaml --smoke --limit 20 --show 3
+    python distill.py --config config.yaml --sources codex --max-context-tokens 4096
+
+Paths in --config (and output.dir) are resolved relative to the current
+working directory; source roots support ~ expansion. Only dependency: pyyaml.
+"""
+from __future__ import annotations
+import argparse, glob, json, os, re, sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sanitize import Redactor          # noqa: E402
+from adapters import get_adapter       # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# scope
+# ----------------------------------------------------------------------------
+def scope_ok(key: str, scope: dict) -> bool:
+    low = (key or "").lower()
+    inc = scope.get("include_substrings") or []
+    if inc and not any(s in low for s in inc):
+        return False
+    if any(s in low for s in scope.get("exclude_substrings") or []):
+        return False
+    return True
+
+
+# ----------------------------------------------------------------------------
+# row emission + deterministic labeling  (operates on normalized events)
+# ----------------------------------------------------------------------------
+def render_completion(ev: dict) -> str:
+    parts = []
+    if ev.get("text", "").strip():
+        parts.append(ev["text"].strip())
+    if ev.get("tool_calls"):
+        parts.append("Tool calls: " + json.dumps(ev["tool_calls"], ensure_ascii=False))
+    return "\n".join(parts)
+
+
+def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
+    low = text.strip().lower()
+    if not low or len(low) > max_len:
+        return False
+    return any(low.startswith(m) for m in markers)
+
+
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+    rows = []
+    corr_markers = lab["correction_markers"]
+    intr_markers = lab["interrupt_markers"]
+    max_tokens = ctx_budget.get("max_context_tokens", 8192)
+    cpt = ctx_budget.get("chars_per_token", 4.0)
+    max_msgs = ctx_budget.get("max_context_messages", 60)
+    est = lambda s: int(len(s) / cpt) + 1   # noqa: E731
+
+    def _content(e):
+        if e["role"] == "tool":
+            return "[tool result]"
+        return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    for i, ev in enumerate(events):
+        if ev["role"] != "assistant":
+            continue
+        had_tool = bool(ev.get("tool_calls"))
+
+        tool_error = False
+        if had_tool:
+            for j in range(i + 1, min(i + 3, len(events))):
+                if events[j]["role"] == "tool":
+                    tool_error = bool(events[j].get("tool_error"))
+                    break
+
+        next_human = None
+        for j in range(i + 1, len(events)):
+            if events[j]["role"] == "human":
+                next_human = events[j].get("text", "")
+                break
+
+        interrupted = any(m in ev.get("text", "").lower() for m in intr_markers) or (
+            next_human is not None and any(m in next_human.lower() for m in intr_markers))
+        corrected = next_human is not None and _is_correction(
+            next_human, corr_markers, lab["max_correction_chars"])
+
+        failure_labels = []
+        if corrected:
+            label, tier = False, "bad"
+            failure_labels.append("user_corrected")
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        elif tool_error or interrupted:
+            label, tier = None, "borderline"
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        else:
+            label, tier = True, "good"
+
+        completion_str = render_completion(ev)
+        budget = max_tokens - est(completion_str)
+        oversize = budget < 0
+        conv_rev = [{"role": "assistant", "content": completion_str}]
+        used = 0
+        for e in reversed(events[:i]):
+            if len(conv_rev) >= max_msgs:
+                break
+            c = _content(e)
+            t = est(c)
+            if used + t > budget and len(conv_rev) > 1:
+                break
+            used += t
+            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+            conv_rev.append({"role": role, "content": c})
+        conv = list(reversed(conv_rev))
+
+        prompt = ""
+        for e in reversed(events[:i]):
+            if e["role"] == "human":
+                prompt = e.get("text", "")
+                break
+
+        rows.append({
+            "conversations": conv,
+            "prompt": prompt,
+            "completion": completion_str,
+            "label": label,
+            "score_tier": tier,
+            "failure_labels": failure_labels,
+            "source_example_id": f"{source_kind}:{rel_id}:{i}",
+            "metadata": {
+                "source_kind": source_kind,
+                "project": project,
+                "turn_index": i,
+                "tool_names": [c.get("name") for c in ev.get("tool_calls", [])],
+                "had_tool_error": tool_error,
+                "interrupted": interrupted,
+                "next_correction": corrected,
+                "est_tokens": used + est(completion_str),
+                "oversize": oversize,
+            },
+        })
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# session outcome  (generic: reads command/output off normalized tool events)
+# ----------------------------------------------------------------------------
+def classify_session(events, signals, oc) -> dict:
+    test_re = re.compile(oc["test_command_re"], re.I)
+    build_re = re.compile(oc["build_command_re"], re.I)
+    commit_re = re.compile(oc["commit_command_re"], re.I)
+    pass_re = re.compile(oc["pass_re"], re.I)
+    fail_re = re.compile(oc["fail_re"], re.I)
+    approve_re = re.compile(oc["approve_re"], re.I)
+    amax = oc.get("approve_max_chars", 80)
+
+    res = {"tests_passed": None, "clean_build": None, "committed": False,
+           "pr_created": bool((signals or {}).get("pr_created")), "user_approved": False}
+    last_human = ""
+
+    def category(cmd):
+        if commit_re.search(cmd):
+            return "commit"
+        if test_re.search(cmd):
+            return "tests"
+        if build_re.search(cmd):
+            return "build"
+        return None
+
+    for e in events:
+        if e["role"] == "human" and e.get("text", "").strip():
+            last_human = e["text"].strip()
+        elif e["role"] == "tool":
+            cmd = e.get("command") or ""
+            if "gh pr create" in cmd:
+                res["pr_created"] = True
+            cat = category(cmd)
+            if not cat:
+                continue
+            out = e.get("output") or ""
+            ok = (not e.get("tool_error")) and not fail_re.search(out)
+            if cat == "tests":
+                res["tests_passed"] = bool(ok and (pass_re.search(out) or not out.strip()))
+            elif cat == "build":
+                res["clean_build"] = bool(ok)
+            elif cat == "commit" and ok:
+                res["committed"] = True
+
+    if last_human and len(last_human) <= amax and approve_re.search(last_human):
+        res["user_approved"] = True
+
+    return {"outcomes": [k for k, v in res.items() if v is True], "evidence": res}
+
+
+def derive_tier(outcomes, tiers_cfg) -> str:
+    s = set(outcomes)
+    if s & set(tiers_cfg.get("gold", [])):
+        return "gold"
+    if s & set(tiers_cfg.get("silver", [])):
+        return "silver"
+    return "bronze"
+
+
+# ----------------------------------------------------------------------------
+# quality funnel
+# ----------------------------------------------------------------------------
+def _norm(s: str) -> str:
+    return " ".join(s.split()).lower()
+
+
+def should_keep(row, q, seen, cpt):
+    comp = row["completion"]
+    tools = [t for t in row["metadata"]["tool_names"] if t]
+    drop_tools = set(q.get("drop_tools", []))
+    drop_skills = q.get("drop_skills", [])
+
+    if tools:
+        kept = [t for t in tools if t not in drop_tools]
+        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
+            return False, "ceremony_tool"
+    else:
+        if int(len(comp) / cpt) < q.get("min_completion_tokens", 12):
+            return False, "trivial_text"
+
+    markers = q.get("drop_prompt_markers") or []
+    if markers and any(m in row["prompt"][:300] for m in markers):
+        return False, "ritual_prompt"
+
+    if q.get("dedup", {}).get("enabled"):
+        key = hash(_norm(comp))
+        if key in seen:
+            return False, "duplicate"
+        seen.add(key)
+    return True, "keep"
+
+
+# ----------------------------------------------------------------------------
+def gather_files(sources_cfg, scope, only):
+    """Yield (source_kind, adapter, path, root) for every in-scope transcript."""
+    for kind, sc in sources_cfg.items():
+        if only and kind not in only:
+            continue
+        if not sc.get("enabled", True):
+            continue
+        adapter = get_adapter(sc["format"])
+        root = os.path.expanduser(sc["root"])
+        for path in glob.glob(os.path.join(root, sc["glob"]), recursive=True):
+            try:
+                if not scope_ok(adapter.scope_key(path, root), scope):
+                    continue
+            except Exception:
+                continue
+            yield kind, adapter, path, root
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True, help="path to distill config YAML")
+    ap.add_argument("--smoke", action="store_true", help="write to smoke/ subdir")
+    ap.add_argument("--limit", type=int, default=0, help="cap files per source (0=all)")
+    ap.add_argument("--sources", default="", help="comma list to restrict sources")
+    ap.add_argument("--show", type=int, default=0, help="print N sample rows")
+    ap.add_argument("--max-context-tokens", type=int, default=0,
+                    help="override context_budget.max_context_tokens")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.config))
+    scope = cfg.get("scope", {})
+    lab = cfg["labeling"]
+    if args.max_context_tokens:
+        cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
+    redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
+    redaction_counts: Counter = Counter()
+    qcfg = cfg.get("quality_filter") or {"enabled": False}
+    q_enabled = qcfg.get("enabled", False)
+    oc_cfg = cfg.get("session_outcome") or {"enabled": False}
+    oc_enabled = oc_cfg.get("enabled", False)
+    tiers_cfg = cfg.get("quality_tiers") or {}
+    inherit_parent = tiers_cfg.get("inherit_parent_for_subagents", True)
+    require_outcomes = set(qcfg.get("require_outcomes") or [])
+    cpt = cfg.get("context_budget", {}).get("chars_per_token", 4.0)
+
+    seen: set = set()
+    drop_counts: Counter = Counter()
+    outcome_counts: Counter = Counter()
+    tier_counts: Counter = Counter()
+    parent_cache: dict = {}
+    only = set(s.strip() for s in args.sources.split(",") if s.strip())
+
+    out_dir = Path(os.path.expanduser(cfg["output"]["dir"]))
+    if args.smoke:
+        out_dir = out_dir / cfg["output"].get("smoke_subdir", "smoke")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / cfg["output"].get("rows_file", "rows.jsonl")
+
+    per_source_files: Counter = Counter()
+    stats = {"rows": 0, "accept": 0, "reject": 0, "borderline": 0, "oversize": 0}
+    by_source: dict = {}
+    samples = []
+
+    with open(out_path, "w") as fout:
+        for kind, adapter, path, root in gather_files(cfg["sources"], scope, only):
+            if args.limit and per_source_files[kind] >= args.limit:
+                continue
+            per_source_files[kind] += 1
+            try:
+                events, signals = adapter.parse(path)
+            except Exception as e:
+                print(f"  ! parse failed {path}: {e}", file=sys.stderr)
+                continue
+            project = adapter.project(path, root)
+            rel_id = Path(path).name
+
+            outcomes = []
+            if oc_enabled:
+                clf = path
+                parent = adapter.parent_path(path) if inherit_parent else None
+                if parent and os.path.exists(parent):
+                    clf = parent
+                if clf in parent_cache:
+                    outcomes = parent_cache[clf]
+                else:
+                    try:
+                        ev2, sig2 = (events, signals) if clf == path else adapter.parse(clf)
+                        outcomes = classify_session(ev2, sig2, oc_cfg)["outcomes"]
+                    except Exception as e:
+                        print(f"  ! outcome scan failed {clf}: {e}", file=sys.stderr)
+                        outcomes = []
+                    parent_cache[clf] = outcomes
+            tier = derive_tier(outcomes, tiers_cfg)
+
+            rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+            bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
+            for r in rows:
+                r["metadata"]["session_outcome"] = outcomes
+                r["metadata"]["good_path"] = bool(outcomes)
+                r["metadata"]["quality_tier"] = tier
+                r["prompt"] = redactor.redact(r["prompt"], redaction_counts)
+                r["completion"] = redactor.redact(r["completion"], redaction_counts)
+                if q_enabled:
+                    keep, reason = should_keep(r, qcfg, seen, cpt)
+                    if not keep:
+                        drop_counts[reason] += 1
+                        continue
+                if require_outcomes and not (set(outcomes) & require_outcomes):
+                    drop_counts["no_good_outcome"] += 1
+                    continue
+                for o2 in (outcomes or ["(none)"]):
+                    outcome_counts[o2] += 1
+                tier_counts[tier] += 1
+                for m in r["conversations"]:
+                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                fout.write(json.dumps(r, ensure_ascii=False) + "\n")
+                stats["rows"] += 1
+                bucket = ("accept" if r["label"] is True else
+                          "reject" if r["label"] is False else "borderline")
+                stats[bucket] += 1
+                bs[bucket] += 1
+                if r["metadata"]["oversize"]:
+                    stats["oversize"] += 1
+                if len(samples) < args.show and r["completion"].strip():
+                    samples.append(r)
+
+    print("=" * 64)
+    dropped = sum(drop_counts.values())
+    if dropped:
+        print(f"quality funnel dropped {dropped:,} rows: {dict(drop_counts)}")
+    print(f"wrote {stats['rows']:,} rows -> {out_path}")
+    print(f"  files per source: {dict(per_source_files)}")
+    print(f"  ACCEPT {stats['accept']:,} | REJECT {stats['reject']:,} | "
+          f"BORDERLINE {stats['borderline']:,} (-> judge)")
+    for k, b in by_source.items():
+        print(f"    {k:18s}: {b['accept']:,} / {b['reject']:,} / {b['borderline']:,}")
+    print(f"  oversize rows: {stats['oversize']:,}")
+    print(f"  session outcome (turn counts): {dict(outcome_counts)}")
+    print(f"  QUALITY TIER: {dict(tier_counts)}")
+    total_redacted = sum(redaction_counts.values())
+    print(f"  secrets redacted: {total_redacted:,}", dict(redaction_counts) or "")
+    print("=" * 64)
+    for k, s in enumerate(samples):
+        print(f"\n--- sample {k+1} [{s['metadata']['source_kind']} / {s['score_tier']} / "
+              f"{s['metadata']['quality_tier']}] tools={s['metadata']['tool_names']} ---")
+        print("PROMPT   :", (s["prompt"] or "")[:160].replace("\n", " "))
+        print("COMPLETE :", s["completion"][:240].replace("\n", " "))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/transcript-distillation/scripts/sanitize.py
+++ b/.claude/skills/transcript-distillation/scripts/sanitize.py
@@ -1,0 +1,48 @@
+"""Deterministic secret redaction for transcript rows.
+
+Config-driven (see configs/transcript_import/default.yaml `sanitize:`). Catches
+high-entropy credential formats and sensitive KEY=VALUE assignments. Applied at
+emit time so raw secrets never reach disk.
+
+This is a SECRET scrubber, not a PII scrubber — it targets keys/tokens that a
+model could memorize and regurgitate. For names/emails/paths, run the OPF-backed
+SynthChat sanitize as a separate pass.
+"""
+from __future__ import annotations
+import re
+from collections import Counter
+
+
+class Redactor:
+    def __init__(self, cfg: dict):
+        self.enabled = cfg.get("enabled", True)
+        self.replacement = cfg.get("replacement", "[REDACTED:{name}]")
+        self._patterns = [(name, re.compile(pat))
+                          for name, pat in cfg.get("patterns", {}).items()]
+        env = cfg.get("env_assignment") or {}
+        self._env_re = None
+        if env.get("sensitive_key_re"):
+            key_re = env["sensitive_key_re"].replace("(?i)", "")  # flag -> compile arg
+            # capture a sensitive key followed by = or : then the value to drop
+            self._env_re = re.compile(
+                rf"({key_re}\s*[:=]\s*)"
+                r"(['\"]?)([^\s'\"]{4,})(\2)", re.IGNORECASE)
+            self._env_replacement = env.get("replacement", "[REDACTED:env_secret]")
+
+    def redact(self, text: str, counts: Counter | None = None):
+        """Return redacted text; tally hits into `counts` if given."""
+        if not self.enabled or not text:
+            return text
+        for name, rx in self._patterns:
+            def _sub(m, n=name):
+                if counts is not None:
+                    counts[n] += 1
+                return self.replacement.format(name=n)
+            text = rx.sub(_sub, text)
+        if self._env_re is not None:
+            def _env_sub(m):
+                if counts is not None:
+                    counts["env_secret"] += 1
+                return m.group(1) + self._env_replacement
+            text = self._env_re.sub(_env_sub, text)
+        return text

--- a/.gitignore
+++ b/.gitignore
@@ -126,6 +126,9 @@ grpo_output_rtx3090/.worktrees/
 # Local scratch workspace
 scratch/
 
+# Private transcript-derived training data (local Claude/Codex logs) — NEVER commit
+private/
+
 # Runtime/test scratch output
 /.runtime_tmp/
 /.tmp/

--- a/.skills/transcript-distillation/SKILL.md
+++ b/.skills/transcript-distillation/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: transcript-distillation
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+allowed-tools: Read, Bash, Write, Edit, Grep, Glob
+---
+
+# Transcript Distillation
+
+Mine local agent transcripts into training data. You point it at a directory of
+conversation logs; it emits one row per assistant turn, scrubs secrets, labels
+each turn (accept / borderline / reject), scores each *session* by how it ended
+up (tests passed, clean build, commit, PR, approval), drops ceremony/filler/
+duplicates, and stamps a quality tier (gold/silver/bronze) on every row.
+
+**Format-agnostic.** The engine knows nothing about Claude or Codex — that lives
+in small pluggable *adapters*. Two ship built-in (`claude_code`, `codex`); add
+more in ~40 lines (see `reference/writing-adapters.md`).
+
+## Quickstart
+
+```bash
+SKILL=.skills/transcript-distillation
+
+# 1. copy the template config and (optionally) edit scope/paths
+cp $SKILL/configs/template.yaml my_distill.yaml
+
+# 2. smoke test on a few files first — ALWAYS do this before a full run
+python $SKILL/scripts/distill.py --config my_distill.yaml --smoke --limit 20 --show 3
+
+# 3. full run
+python $SKILL/scripts/distill.py --config my_distill.yaml
+```
+
+Out of the box the template grabs **all** local Claude Code (`~/.claude/projects`)
+and Codex (`~/.codex/sessions`) transcripts and writes to
+`./transcript_distill_out/rows.jsonl`. Only dependency: `pyyaml`.
+
+## CLI
+
+| Flag | Meaning |
+|------|---------|
+| `--config PATH` | distill config YAML (required) |
+| `--smoke` | write to a `smoke/` subdir (keeps full runs separate) |
+| `--limit N` | cap files **per source** (0 = all) — use for smoke tests |
+| `--sources a,b` | restrict to named sources from config |
+| `--show N` | print N sample rows to eyeball quality |
+| `--max-context-tokens N` | override `context_budget.max_context_tokens` for this run |
+
+## Pipeline (all config-driven)
+
+```
+adapter.parse(file)            # format-specific -> normalized events
+  -> one row per assistant turn
+  -> secret scrub at emit time (raw secrets never hit disk)
+  -> context filled most-recent-first under a TOKEN budget
+  -> deterministic label: accept / borderline(->judge) / reject
+  -> quality funnel: drop ceremony tools, trivial filler, duplicates
+  -> session-outcome tiering: gold / silver / bronze
+  -> JSONL
+```
+
+Each knob is documented in `reference/config-schema.md`. Highlights:
+
+- **`scope`** — include/exclude projects by substring (Claude: project slug;
+  Codex: recorded cwd). Empty include = everything.
+- **`context_budget.max_context_tokens`** — set to your training seq length.
+  This caps context DEPTH per row, *not* the number of rows; training cost is
+  ~O(seq²), so keep it real (8192 is a good default; 32768 is ~16× the compute).
+- **`session_outcome`** — regexes that detect tests-passed / clean-build /
+  commit / PR / approval from tool commands + their output. The strongest
+  quality signal: it judges the whole path by where it ended up.
+- **`quality_tiers`** — map outcomes to gold (verified-correct) / silver
+  (saved/shipped) / bronze (no signal). Subagents inherit their parent
+  session's tier.
+- **`quality_filter`** — drop ceremony tools (orchestration), trivial text
+  turns, and duplicate completions. Set `require_outcomes` to keep ONLY
+  verified-good sessions.
+
+## Output row schema
+
+One JSON object per line, shaped for SFT/KTO:
+
+```json
+{
+  "conversations": [{"role": "...", "content": "..."}],
+  "prompt": "...", "completion": "...",
+  "label": true | false | null,        // accept / reject / borderline(->judge)
+  "score_tier": "good|bad|borderline",
+  "failure_labels": ["tool_error", "user_corrected", ...],
+  "source_example_id": "claude_main:<file>:<turn>",
+  "metadata": {
+    "quality_tier": "gold|silver|bronze",
+    "session_outcome": ["clean_build", "committed"],
+    "good_path": true,
+    "tool_names": ["Edit"], "est_tokens": 5948, "oversize": false, ...
+  }
+}
+```
+
+Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
+SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
+LLM-as-judge to mint KTO negatives.
+
+## Privacy
+
+- Secret scrubbing is **on by default** and runs at emit time, so raw API
+  keys/tokens never reach disk. Verify with a residual grep after a run.
+- Transcript-derived output is private. Keep the output dir gitignored.
+- A trained model on frontier-agent transcripts is distillation — keep it
+  private (provider ToS).
+
+## References
+
+| File | When |
+|------|------|
+| `reference/config-schema.md` | Every config knob explained |
+| `reference/writing-adapters.md` | Add support for a new transcript format |
+| `reference/case-study-claude-codex.md` | Worked example: 538k turns → ~102k tiered rows |
+
+## Discipline
+
+- **Always `--smoke --limit` first**, eyeball `--show` samples, then full run.
+- Keep everything in config — never hardcode a tool name, scope, or format
+  assumption in the engine. Format specifics belong in an adapter.

--- a/.skills/transcript-distillation/configs/template.yaml
+++ b/.skills/transcript-distillation/configs/template.yaml
@@ -1,0 +1,101 @@
+# transcript-distillation — portable template config.
+# Copy this, adjust, and run:
+#   python .../scripts/distill.py --config my_config.yaml --smoke --limit 20 --show 3
+#
+# Out of the box this grabs ALL local Claude Code + Codex transcripts (empty
+# scope = match everything) and writes deduped, quality-tiered rows to
+# ./transcript_distill_out/. Tighten `scope` to target specific projects.
+
+sources:
+  claude_main:
+    format: claude_code          # adapter name (see scripts/adapters/)
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*.jsonl"            # main session transcripts
+  claude_subagent:
+    format: claude_code
+    enabled: true
+    root: "~/.claude/projects"
+    glob: "*/*/subagents/*.jsonl"   # Task-tool / subagent runs (inherit parent outcome)
+  codex:
+    format: codex
+    enabled: true
+    root: "~/.codex/sessions"
+    glob: "**/*.jsonl"
+
+# Which projects to include. Claude is matched by project-slug, Codex by the
+# cwd in session_meta. EMPTY include = match everything (good for a first run).
+scope:
+  include_substrings: []         # e.g. ["documents-code-", "/documents/code/"]
+  exclude_substrings: []         # e.g. ["secret-client", "personal"]
+
+output:
+  dir: "transcript_distill_out"  # relative to where you run distill.py
+  rows_file: "rows.jsonl"
+  smoke_subdir: "smoke"
+
+# ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
+sanitize:
+  enabled: true
+  replacement: "[REDACTED:{name}]"
+  patterns:
+    openai_key: "sk-(?:proj-)?[A-Za-z0-9_-]{20,}"
+    openrouter_key: "sk-or-v1-[A-Za-z0-9]{32,}"
+    anthropic_key: "sk-ant-[A-Za-z0-9_-]{20,}"
+    hf_token: "hf_[A-Za-z0-9]{30,}"
+    github_token: "gh[pousr]_[A-Za-z0-9]{36,}"
+    aws_access_key: "AKIA[0-9A-Z]{16}"
+    google_api_key: "AIza[0-9A-Za-z_-]{35}"
+    slack_token: "xox[baprs]-[0-9A-Za-z-]{10,}"
+    bearer_token: "[Bb]earer\\s+[A-Za-z0-9._-]{20,}"
+    jwt: "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}"
+    private_key_block: "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+  env_assignment:
+    sensitive_key_re: "(?i)(?:api[_-]?key|secret|token|password|passwd|private[_-]?key|access[_-]?key|client[_-]?secret)"
+    replacement: "[REDACTED:env_secret]"
+
+# ---- one row per assistant turn; context filled most-recent-first to budget ----
+context_budget:
+  max_context_tokens: 8192       # your training seq length (override: --max-context-tokens)
+  chars_per_token: 4.0
+  max_context_messages: 120
+
+# ---- deterministic labels: accept / borderline(->judge) / reject ----
+labeling:
+  correction_markers: ["no,", "no.", "no ", "nope", "stop", "wrong", "that's wrong",
+                       "thats wrong", "that's not", "thats not", "incorrect", "undo",
+                       "revert", "not what i"]
+  max_correction_chars: 180
+  interrupt_markers: ["[request interrupted by user]", "[request interrupted"]
+
+# ---- session-outcome classifier (the strongest quality signal) ----
+session_outcome:
+  enabled: true
+  test_command_re: "\\b(pytest|jest|vitest|mocha|go test|cargo test|cargo nextest|npm (?:run )?test|yarn test|pnpm test|tox|rspec|phpunit|gradle test|mvn test|unittest|ctest|python -m pytest)\\b"
+  build_command_re: "\\b(tsc|cargo (?:build|check|clippy)|go build|make\\b|cmake|vite build|next build|webpack|gradle build|mvn (?:package|compile)|eslint|ruff|mypy)\\b"
+  commit_command_re: "git commit"
+  pass_re: "\\b(\\d+ passed|all tests passed|tests? passed|build succeeded|0 errors?|passing|PASS)\\b"
+  fail_re: "\\b(\\d+ failed|FAILED|\\berror\\b|exception|panicked|✗)\\b"
+  approve_re: "^(thanks|thank you|perfect|great|awesome|nice|lgtm|looks good|that works|ship it|excellent|amazing|love it|works now|fixed it)\\b"
+  approve_max_chars: 80
+
+quality_tiers:
+  gold: [tests_passed, clean_build]
+  silver: [committed, pr_created, user_approved]
+  inherit_parent_for_subagents: true
+
+# ---- quality funnel: drop ceremony tools, filler, and duplicates ----
+quality_filter:
+  enabled: true
+  drop_tools: [TaskCreate, TaskUpdate, TaskList, TaskGet, TaskOutput, TaskStop,
+               TeamCreate, TeamDelete, SendMessage, ToolSearch, Monitor,
+               EnterPlanMode, ExitPlanMode, PushNotification, CronCreate, CronList,
+               CronDelete, RemoteTrigger]
+  drop_skills: ["PACT:bootstrap", "PACT:teammate-bootstrap", "PACT:orchestration"]
+  min_completion_tokens: 12
+  dedup:
+    enabled: true
+  drop_prompt_markers: []
+  # empty = tag-only (keep all rows, stamped with quality_tier). Set to e.g.
+  # [tests_passed, clean_build] to keep ONLY verified-good sessions.
+  require_outcomes: []

--- a/.skills/transcript-distillation/reference/case-study-claude-codex.md
+++ b/.skills/transcript-distillation/reference/case-study-claude-codex.md
@@ -1,0 +1,75 @@
+# Case Study: Distilling Claude Code + Codex into a Fine-Tuning Dataset
+
+The worked example this skill was built from — turning ~2,700 local Claude Code
+and Codex CLI transcripts into a private SFT/KTO dataset.
+
+## Goal
+Fine-tune a private model on the user's own coding-agent behavior. SFT on a
+clean high-quality pool first, then KTO refinement on a held-out set + mined
+negatives. Reuse the repo's existing training pipeline; the only new work is
+extracting good rows from raw logs.
+
+## Config
+`configs/transcript_import/default.yaml` (repo root). Differs from the template:
+- `scope.include_substrings: ["documents-code-", "/documents/code/"]` — only
+  coding projects.
+- `scope.exclude_substrings: ["qwoted", "plan-your-baby"]` — client/sensitive.
+- Output to `private/transcripts/` (gitignored).
+
+Run:
+```bash
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml --smoke --limit 30 --show 3   # smoke
+python .skills/transcript-distillation/scripts/distill.py \
+  --config configs/transcript_import/default.yaml                              # full
+```
+
+## What the data looked like
+- 1,793 Claude files = **53 main sessions + 1,740 subagent traces** (nested under
+  `<project>/<session>/subagents/`). 923 Codex rollouts (filed by date; scoped by cwd).
+- Claude main transcripts use the newer event schema (skip `attachment`,
+  `last-prompt`, `queue-operation`, `system`, ...). Subagent prompts carry heavy
+  PACT framing.
+- Codex encodes exit status as plaintext `Process exited with code N`.
+
+## Full-run result (8192-token budget)
+```
+538,804 raw turns
+  - quality funnel dropped 436,649: duplicate 368,087 · ceremony 55,763 · trivial 12,799
+  = 102,155 rows kept
+tiers:  gold 79,099 · silver 8,748 · bronze 14,308
+labels: accept 98,577 · borderline 3,509 (-> judge) · reject 69
+secrets redacted: 98,165   (0 residual on grep)
+runtime: ~6 min
+```
+
+The headline: **dedup did most of the work** — the repeated session-start ritual
+and boilerplate across 1,740 subagent files collapsed 368k duplicate turns. The
+"insane" 450k raw became ~102k deduped, ~77% gold.
+
+## Lessons (calibration for future runs)
+1. **Per-turn dump is too noisy** — every assistant turn includes acks,
+   thinking-only turns, and orchestration ceremony. The funnel (dedup + ceremony
+   + filler) is essential, not optional.
+2. **Outcome > heuristics.** Judging the whole session by tests-passed/built/
+   committed/PR'd is the strongest quality signal. ~77% of funnel-survivors were
+   from verifiably-good sessions.
+3. **Subagents must inherit the parent outcome** — their own transcript never
+   contains the commit/PR/test. Without inheritance they're ~all bronze; with
+   it, ~98% gold.
+4. **Beware noisy survey heuristics.** An early survey reported "16% Codex error
+   rate" — it was matching the word "error" in tool *output*, not real failures.
+   True failure rate (nonzero exit) was ~3%. Always confirm a detector fires on
+   true positives.
+5. **Distillation ceiling:** completions are frontier-model output, so
+   deterministic negatives are scarce (~3%). KTO negatives come mostly from the
+   judge over the borderline pool, not from rules.
+6. **Token budget is the compute knob**, not a coverage knob — it bounds context
+   depth per row, not row count. 8192 over 32768 (~16× attention cost) with ~0
+   coverage loss.
+
+## Downstream
+- **SFT**: `label==true` gold rows.
+- **KTO**: `label==null` (borderline) rows → LLM-as-judge
+  (`SynthChat validate --rubrics quality_labels`) → confirmed accept/reject,
+  interleaved with held-out gold accepts.

--- a/.skills/transcript-distillation/reference/config-schema.md
+++ b/.skills/transcript-distillation/reference/config-schema.md
@@ -1,0 +1,92 @@
+# Config Schema
+
+Every knob in a distill config. Start from `configs/template.yaml`.
+
+## `sources` (map)
+Each entry is one source of transcripts. The key (e.g. `claude_main`) is the
+`source_kind` stamped on rows and used for `--sources`.
+
+```yaml
+sources:
+  claude_main:
+    format: claude_code     # adapter name (REGISTRY in scripts/adapters/__init__.py)
+    enabled: true
+    root: "~/.claude/projects"   # ~ is expanded
+    glob: "*/*.jsonl"            # glob under root (recursive ** supported)
+```
+
+Multiple sources can share a format (e.g. `claude_main` and `claude_subagent`
+both use `claude_code` with different globs).
+
+## `scope` (map)
+Filter which projects are included.
+- `include_substrings`: a transcript is kept only if its scope-key contains one
+  of these (case-insensitive). **Empty list = include everything.**
+- `exclude_substrings`: ...and none of these.
+
+The scope-key is adapter-defined: `claude_code` uses the project-slug;
+`codex` uses the `cwd` recorded in `session_meta`.
+
+## `output` (map)
+- `dir`: output directory, relative to the current working directory (or absolute).
+- `rows_file`: filename (default `rows.jsonl`).
+- `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
+
+## `sanitize` (map)
+Deterministic secret scrub, applied to every text field at emit time.
+- `enabled`: bool.
+- `replacement`: template, `{name}` = pattern name.
+- `patterns`: name → regex. Each match replaced with the redaction marker.
+- `env_assignment.sensitive_key_re` / `.replacement`: redacts the VALUE in
+  `KEY=value` / `KEY: value` lines when the key matches (keeps the key name).
+
+## `context_budget` (map)
+- `max_context_tokens`: caps each row's context by estimated tokens. This is the
+  **compute knob** — set it to your training sequence length. It bounds context
+  DEPTH per row, not the number of rows.
+- `chars_per_token`: estimate divisor (4.0 ≈ English; ~3.5 for code-heavy).
+- `max_context_messages`: hard ceiling on context messages regardless of tokens.
+
+Context is filled most-recent-first after reserving room for the completion.
+A turn whose completion alone exceeds budget is still emitted, flagged
+`metadata.oversize=true`.
+
+## `labeling` (map)
+Deterministic per-turn label.
+- `correction_markers`: the next human turn is a correction (=> reject) only if
+  it is short (`max_correction_chars`) and STARTS WITH one of these.
+- `max_correction_chars`: length ceiling for a correction.
+- `interrupt_markers`: substrings marking a user interrupt.
+
+Result: `label=true` (clean accept), `label=false` (human-corrected reject),
+`label=null` (errored/interrupted but no human signal → borderline → send to a judge).
+
+## `session_outcome` (map)
+Classifies the WHOLE session by terminal signal, by matching tool commands and
+their output. All regexes are case-insensitive.
+- `test_command_re` / `build_command_re` / `commit_command_re`: which commands count.
+- `pass_re` / `fail_re`: success/failure tokens in command output.
+- `approve_re` / `approve_max_chars`: a short final human turn = approval.
+
+Detected outcomes: `tests_passed`, `clean_build`, `committed`, `pr_created`,
+`user_approved`. (`pr_created` also comes from adapter session signals, e.g.
+Claude's `pr-link` events.)
+
+## `quality_tiers` (map)
+- `gold`: list of outcomes that mean code verifiably worked.
+- `silver`: outcomes that mean saved/shipped.
+- anything else → `bronze`.
+- `inherit_parent_for_subagents`: subagents inherit their parent session's
+  outcome (their own transcript never contains the commit/PR/test).
+
+## `quality_filter` (map)
+- `enabled`: bool.
+- `drop_tools`: a turn whose only tool calls are these (ceremony/orchestration)
+  and which has no substantive text is dropped.
+- `drop_skills`: `Skill()` invocations of these are ceremony.
+- `min_completion_tokens`: text-only turns shorter than this are filler → dropped.
+- `dedup.enabled`: drop near-duplicate completions (normalized hash).
+- `drop_prompt_markers`: drop rows whose prompt starts with a ritual marker
+  (off by default — can over-drop).
+- `require_outcomes`: empty = tag-only (keep all, tiered). Set to e.g.
+  `[tests_passed, clean_build]` to keep ONLY verified-good sessions.

--- a/.skills/transcript-distillation/reference/writing-adapters.md
+++ b/.skills/transcript-distillation/reference/writing-adapters.md
@@ -1,0 +1,85 @@
+# Writing a Transcript Adapter
+
+The engine is format-agnostic. To support a new transcript format (a different
+agent CLI, a ShareGPT export, an OpenAI conversation dump, your own logger),
+write one adapter. Everything downstream — labeling, secret scrub, token budget,
+outcome tiering, dedup — works unchanged.
+
+## The contract
+
+Implement `Adapter` from `scripts/adapters/base.py`:
+
+```python
+from .base import Adapter, blocks_text
+
+class MyFormatAdapter(Adapter):
+    name = "myformat"                     # referenced by `format:` in config
+
+    def scope_key(self, path, root):      # string matched against scope filters
+        ...                               # e.g. a project slug or recorded cwd
+
+    def project(self, path, root):        # human label for the project
+        ...
+
+    def parse(self, path):                # -> (events, signals)
+        ...
+
+    def parent_path(self, path):          # optional: nested/subagent -> parent file
+        return None
+```
+
+Register it in `scripts/adapters/__init__.py`:
+
+```python
+from .myformat import MyFormatAdapter
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter(), MyFormatAdapter()]
+```
+
+## The normalized event model
+
+`parse(path)` returns `(events, signals)`.
+
+`events` — ordered list, one dict per turn:
+
+```python
+{"role": "human",     "text": "..."}
+{"role": "assistant", "text": "...", "tool_calls": [{"name": "Edit", "input": {...}}]}
+{"role": "tool",      "tool_error": False, "command": "pytest -q", "output": "5 passed"}
+```
+
+Rules:
+- One row is emitted per `assistant` event.
+- A `tool` event carries the `command` it answers and the `output` text. This is
+  what makes outcome detection (tests/build/commit) work **generically** — you
+  don't write any outcome logic, you just surface the command + output.
+- `command` should be the shell command string when the tool is a shell/exec
+  tool (used by `session_outcome` regexes); `""` otherwise.
+
+`signals` — session-level booleans the engine folds into outcomes:
+
+```python
+{"pr_created": True}   # e.g. the format logs an explicit "PR opened" event
+```
+
+Return `{}` if your format has no such signals (commits/PRs will still be
+detected from commands).
+
+## Tips
+
+- Skip metadata/noise lines silently; only emit human/assistant/tool turns.
+- If your format batches multiple tool results in one record, emit one `tool`
+  event per result.
+- `blocks_text()` in `base.py` handles the common "content is a string OR a list
+  of typed text blocks" shape.
+- For nested/subagent transcripts, return the parent session's file path from
+  `parent_path()` so the child inherits the parent's outcome tier.
+- Validate by running `--smoke --limit 5 --show 3` and eyeballing that prompts,
+  completions, and tool calls look right before a full run.
+
+## Reference adapters
+
+- `adapters/claude_code.py` — event-stream JSONL, `tool_use`/`tool_result`
+  blocks paired by id, `pr-link` session signal, subagent → parent inheritance.
+- `adapters/codex.py` — `response_item` payloads, `function_call` /
+  `function_call_output` pairs, exit status parsed from plaintext output, cwd
+  scope-key from `session_meta`.

--- a/.skills/transcript-distillation/scripts/adapters/__init__.py
+++ b/.skills/transcript-distillation/scripts/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Adapter registry. Add a new transcript format here.
+
+To support a new format: implement the Adapter interface in a new module
+(see base.py and writing-adapters.md), import it, and add an instance below.
+"""
+from .claude_code import ClaudeCodeAdapter
+from .codex import CodexAdapter
+
+_ADAPTERS = [ClaudeCodeAdapter(), CodexAdapter()]
+REGISTRY = {a.name: a for a in _ADAPTERS}
+
+
+def get_adapter(fmt: str):
+    if fmt not in REGISTRY:
+        raise KeyError(
+            f"unknown transcript format '{fmt}'. Registered: {sorted(REGISTRY)}. "
+            f"Add an adapter in adapters/ and register it in adapters/__init__.py."
+        )
+    return REGISTRY[fmt]

--- a/.skills/transcript-distillation/scripts/adapters/base.py
+++ b/.skills/transcript-distillation/scripts/adapters/base.py
@@ -1,0 +1,65 @@
+"""Transcript-format adapter contract.
+
+The engine (distill.py) is 100% format-agnostic. Everything format-specific
+lives in an adapter. To support a new transcript format, implement this
+interface and register it in adapters/__init__.py.
+
+NORMALIZED EVENT MODEL (the contract every adapter emits)
+---------------------------------------------------------
+parse(path) returns (events, signals).
+
+events: ordered list of dicts, one per logical turn:
+  human turn     -> {"role": "human",     "text": str}
+  assistant turn -> {"role": "assistant", "text": str,
+                     "tool_calls": [{"name": str, "input": any}]}
+  tool result    -> {"role": "tool", "tool_error": bool,
+                     "command": str,   # the command this result is answering
+                     "output": str}    # the result text (for outcome detection)
+
+  Why tool events carry command+output: it lets the engine detect "tests
+  passed / build clean / committed" generically from regexes in config —
+  no format-specific outcome code.
+
+signals: dict of session-level booleans the engine folds into outcomes, e.g.
+  {"pr_created": True}  (Claude logs an explicit pr-link event)
+
+Adapters also answer cheap path questions WITHOUT a full parse where possible:
+  scope_key(path, root) -> the string matched against scope include/exclude
+                           (a project slug, a recorded cwd, ...)
+  project(path, root)   -> a human label for the project
+  parent_path(path)     -> for nested/subagent transcripts, the parent session
+                           file whose outcome should be inherited; else None
+"""
+from __future__ import annotations
+
+
+class Adapter:
+    name = "base"
+
+    def scope_key(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def project(self, path: str, root: str) -> str:
+        raise NotImplementedError
+
+    def parse(self, path: str):
+        """-> (events: list[dict], signals: dict)"""
+        raise NotImplementedError
+
+    def parent_path(self, path: str):
+        """-> str | None. Override for nested/subagent transcripts."""
+        return None
+
+
+def blocks_text(content) -> str:
+    """Join text blocks from a content list (or pass a str through). Shared
+    helper — most chat formats use either a string or a list of typed blocks."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        out = []
+        for b in content:
+            if isinstance(b, dict) and b.get("type") in ("text", "input_text", "output_text"):
+                out.append(str(b.get("text", "")))
+        return "".join(out)
+    return ""

--- a/.skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -1,0 +1,95 @@
+"""Adapter for Claude Code transcripts (~/.claude/projects/**.jsonl).
+
+Main sessions and subagent runs share one schema. Subagents are nested at
+<project>/<session>/subagents/agent-*.jsonl and inherit their parent session's
+outcome (the commit/PR/test happens in the parent, never in the subagent).
+"""
+from __future__ import annotations
+import json
+from pathlib import Path
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(tool_use: dict) -> str:
+    inp = tool_use.get("input")
+    if isinstance(inp, dict):
+        return str(inp.get("command", "") or "")
+    return ""
+
+
+class ClaudeCodeAdapter(Adapter):
+    name = "claude_code"
+
+    def scope_key(self, path: str, root: str) -> str:
+        # project slug is the first path component under the projects root
+        return Path(path).resolve().relative_to(Path(root).resolve()).parts[0]
+
+    def project(self, path: str, root: str) -> str:
+        return self.scope_key(path, root)
+
+    def parent_path(self, path: str):
+        # .../project/<session>/subagents/agent.jsonl -> .../project/<session>.jsonl
+        if "/subagents/" not in path.replace("\\", "/"):
+            return None
+        session_dir = Path(path).parents[1]
+        return str(session_dir.with_name(session_dir.name + ".jsonl"))
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        id2cmd: dict[str, str] = {}
+
+        for line in open(path, errors="ignore"):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            t = o.get("type")
+
+            if t == "pr-link":
+                signals["pr_created"] = True
+                continue
+
+            msg = o.get("message") or {}
+            content = msg.get("content")
+
+            if t == "assistant":
+                text, tool_calls = "", []
+                if isinstance(content, list):
+                    for b in content:
+                        if not isinstance(b, dict):
+                            continue
+                        bt = b.get("type")
+                        if bt == "text":
+                            text += str(b.get("text", ""))
+                        elif bt == "tool_use":
+                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
+                            if b.get("id"):
+                                id2cmd[b["id"]] = _command_of(b)
+                elif isinstance(content, str):
+                    text = content
+                events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
+
+            elif t == "user":
+                results = []
+                if isinstance(content, list):
+                    results = [b for b in content
+                               if isinstance(b, dict) and b.get("type") == "tool_result"]
+                if results:
+                    for b in results:
+                        out = str(b.get("content", ""))
+                        err = bool(b.get("is_error"))
+                        if not err:  # some errors only show in the text, not the flag
+                            low = out[:200].lower()
+                            err = "error" in low or "traceback" in low
+                        events.append({"role": "tool", "tool_error": err,
+                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "output": out})
+                else:
+                    events.append({"role": "human", "text": blocks_text(content)})
+            # other event types (attachment, system, last-prompt, ...) are skipped
+        return events, signals

--- a/.skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.skills/transcript-distillation/scripts/adapters/codex.py
@@ -1,0 +1,89 @@
+"""Adapter for Codex CLI rollouts (~/.codex/sessions/**/*.jsonl).
+
+Sessions are filed by date, not project, so scope is filtered by the `cwd`
+recorded in the session_meta event. Tool actions are function_call /
+function_call_output pairs; exit status is plaintext "Process exited with code N".
+"""
+from __future__ import annotations
+import json
+
+from .base import Adapter, blocks_text
+
+
+def _command_of(arguments) -> str:
+    """Best-effort shell command from a function_call's arguments."""
+    if isinstance(arguments, str):
+        try:
+            d = json.loads(arguments)
+            if isinstance(d, dict):
+                return str(d.get("cmd") or d.get("command") or arguments)
+        except json.JSONDecodeError:
+            return arguments
+        return arguments
+    if isinstance(arguments, dict):
+        return str(arguments.get("cmd") or arguments.get("command") or "")
+    return ""
+
+
+class CodexAdapter(Adapter):
+    name = "codex"
+
+    def _cwd(self, path: str) -> str:
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") == "session_meta":
+                return (o.get("payload") or {}).get("cwd", "") or ""
+        return ""
+
+    def scope_key(self, path: str, root: str) -> str:
+        return self._cwd(path)
+
+    def project(self, path: str, root: str) -> str:
+        from pathlib import Path
+        return Path(self._cwd(path)).name
+
+    def parse(self, path: str):
+        events: list[dict] = []
+        signals = {"pr_created": False}
+        pending_cmd = ""
+
+        for line in open(path, errors="ignore"):
+            try:
+                o = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if o.get("type") != "response_item":
+                continue
+            p = o.get("payload") or {}
+            pt = p.get("type")
+
+            if pt == "message":
+                role = p.get("role")
+                text = blocks_text(p.get("content"))
+                if role == "assistant":
+                    events.append({"role": "assistant", "text": text, "tool_calls": []})
+                elif role == "user":
+                    events.append({"role": "human", "text": text})
+
+            elif pt in ("function_call", "custom_tool_call"):
+                args = p.get("arguments") or p.get("input") or ""
+                cmd = _command_of(args)
+                if "gh pr create" in cmd:
+                    signals["pr_created"] = True
+                events.append({"role": "assistant", "text": "",
+                               "tool_calls": [{"name": p.get("name"), "input": args}]})
+                pending_cmd = cmd
+
+            elif pt in ("function_call_output", "custom_tool_call_output"):
+                out = p.get("output")
+                s = out if isinstance(out, str) else json.dumps(out)
+                low = s.lower()
+                err = ("exited with code" in low and "exited with code 0" not in low) \
+                    or "traceback (most recent call last)" in low
+                events.append({"role": "tool", "tool_error": err,
+                               "command": pending_cmd, "output": s})
+                pending_cmd = ""
+        return events, signals

--- a/.skills/transcript-distillation/scripts/distill.py
+++ b/.skills/transcript-distillation/scripts/distill.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""Distill training rows from agent transcripts (Claude Code, Codex, or any
+format with an adapter). Format-agnostic engine — all policy is in config.
+
+Pipeline: parse (adapter) -> per-assistant-turn rows -> secret scrub ->
+token-budget context -> deterministic accept/borderline labels ->
+quality funnel (drop ceremony/filler/dups) -> session-outcome tiering
+(gold/silver/bronze) -> JSONL.
+
+Usage:
+    python distill.py --config config.yaml                  # full run
+    python distill.py --config config.yaml --smoke --limit 20 --show 3
+    python distill.py --config config.yaml --sources codex --max-context-tokens 4096
+
+Paths in --config (and output.dir) are resolved relative to the current
+working directory; source roots support ~ expansion. Only dependency: pyyaml.
+"""
+from __future__ import annotations
+import argparse, glob, json, os, re, sys
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from sanitize import Redactor          # noqa: E402
+from adapters import get_adapter       # noqa: E402
+
+
+# ----------------------------------------------------------------------------
+# scope
+# ----------------------------------------------------------------------------
+def scope_ok(key: str, scope: dict) -> bool:
+    low = (key or "").lower()
+    inc = scope.get("include_substrings") or []
+    if inc and not any(s in low for s in inc):
+        return False
+    if any(s in low for s in scope.get("exclude_substrings") or []):
+        return False
+    return True
+
+
+# ----------------------------------------------------------------------------
+# row emission + deterministic labeling  (operates on normalized events)
+# ----------------------------------------------------------------------------
+def render_completion(ev: dict) -> str:
+    parts = []
+    if ev.get("text", "").strip():
+        parts.append(ev["text"].strip())
+    if ev.get("tool_calls"):
+        parts.append("Tool calls: " + json.dumps(ev["tool_calls"], ensure_ascii=False))
+    return "\n".join(parts)
+
+
+def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
+    low = text.strip().lower()
+    if not low or len(low) > max_len:
+        return False
+    return any(low.startswith(m) for m in markers)
+
+
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+    rows = []
+    corr_markers = lab["correction_markers"]
+    intr_markers = lab["interrupt_markers"]
+    max_tokens = ctx_budget.get("max_context_tokens", 8192)
+    cpt = ctx_budget.get("chars_per_token", 4.0)
+    max_msgs = ctx_budget.get("max_context_messages", 60)
+    est = lambda s: int(len(s) / cpt) + 1   # noqa: E731
+
+    def _content(e):
+        if e["role"] == "tool":
+            return "[tool result]"
+        return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    for i, ev in enumerate(events):
+        if ev["role"] != "assistant":
+            continue
+        had_tool = bool(ev.get("tool_calls"))
+
+        tool_error = False
+        if had_tool:
+            for j in range(i + 1, min(i + 3, len(events))):
+                if events[j]["role"] == "tool":
+                    tool_error = bool(events[j].get("tool_error"))
+                    break
+
+        next_human = None
+        for j in range(i + 1, len(events)):
+            if events[j]["role"] == "human":
+                next_human = events[j].get("text", "")
+                break
+
+        interrupted = any(m in ev.get("text", "").lower() for m in intr_markers) or (
+            next_human is not None and any(m in next_human.lower() for m in intr_markers))
+        corrected = next_human is not None and _is_correction(
+            next_human, corr_markers, lab["max_correction_chars"])
+
+        failure_labels = []
+        if corrected:
+            label, tier = False, "bad"
+            failure_labels.append("user_corrected")
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        elif tool_error or interrupted:
+            label, tier = None, "borderline"
+            if tool_error:
+                failure_labels.append("tool_error")
+            if interrupted:
+                failure_labels.append("interrupted")
+        else:
+            label, tier = True, "good"
+
+        completion_str = render_completion(ev)
+        budget = max_tokens - est(completion_str)
+        oversize = budget < 0
+        conv_rev = [{"role": "assistant", "content": completion_str}]
+        used = 0
+        for e in reversed(events[:i]):
+            if len(conv_rev) >= max_msgs:
+                break
+            c = _content(e)
+            t = est(c)
+            if used + t > budget and len(conv_rev) > 1:
+                break
+            used += t
+            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+            conv_rev.append({"role": role, "content": c})
+        conv = list(reversed(conv_rev))
+
+        prompt = ""
+        for e in reversed(events[:i]):
+            if e["role"] == "human":
+                prompt = e.get("text", "")
+                break
+
+        rows.append({
+            "conversations": conv,
+            "prompt": prompt,
+            "completion": completion_str,
+            "label": label,
+            "score_tier": tier,
+            "failure_labels": failure_labels,
+            "source_example_id": f"{source_kind}:{rel_id}:{i}",
+            "metadata": {
+                "source_kind": source_kind,
+                "project": project,
+                "turn_index": i,
+                "tool_names": [c.get("name") for c in ev.get("tool_calls", [])],
+                "had_tool_error": tool_error,
+                "interrupted": interrupted,
+                "next_correction": corrected,
+                "est_tokens": used + est(completion_str),
+                "oversize": oversize,
+            },
+        })
+    return rows
+
+
+# ----------------------------------------------------------------------------
+# session outcome  (generic: reads command/output off normalized tool events)
+# ----------------------------------------------------------------------------
+def classify_session(events, signals, oc) -> dict:
+    test_re = re.compile(oc["test_command_re"], re.I)
+    build_re = re.compile(oc["build_command_re"], re.I)
+    commit_re = re.compile(oc["commit_command_re"], re.I)
+    pass_re = re.compile(oc["pass_re"], re.I)
+    fail_re = re.compile(oc["fail_re"], re.I)
+    approve_re = re.compile(oc["approve_re"], re.I)
+    amax = oc.get("approve_max_chars", 80)
+
+    res = {"tests_passed": None, "clean_build": None, "committed": False,
+           "pr_created": bool((signals or {}).get("pr_created")), "user_approved": False}
+    last_human = ""
+
+    def category(cmd):
+        if commit_re.search(cmd):
+            return "commit"
+        if test_re.search(cmd):
+            return "tests"
+        if build_re.search(cmd):
+            return "build"
+        return None
+
+    for e in events:
+        if e["role"] == "human" and e.get("text", "").strip():
+            last_human = e["text"].strip()
+        elif e["role"] == "tool":
+            cmd = e.get("command") or ""
+            if "gh pr create" in cmd:
+                res["pr_created"] = True
+            cat = category(cmd)
+            if not cat:
+                continue
+            out = e.get("output") or ""
+            ok = (not e.get("tool_error")) and not fail_re.search(out)
+            if cat == "tests":
+                res["tests_passed"] = bool(ok and (pass_re.search(out) or not out.strip()))
+            elif cat == "build":
+                res["clean_build"] = bool(ok)
+            elif cat == "commit" and ok:
+                res["committed"] = True
+
+    if last_human and len(last_human) <= amax and approve_re.search(last_human):
+        res["user_approved"] = True
+
+    return {"outcomes": [k for k, v in res.items() if v is True], "evidence": res}
+
+
+def derive_tier(outcomes, tiers_cfg) -> str:
+    s = set(outcomes)
+    if s & set(tiers_cfg.get("gold", [])):
+        return "gold"
+    if s & set(tiers_cfg.get("silver", [])):
+        return "silver"
+    return "bronze"
+
+
+# ----------------------------------------------------------------------------
+# quality funnel
+# ----------------------------------------------------------------------------
+def _norm(s: str) -> str:
+    return " ".join(s.split()).lower()
+
+
+def should_keep(row, q, seen, cpt):
+    comp = row["completion"]
+    tools = [t for t in row["metadata"]["tool_names"] if t]
+    drop_tools = set(q.get("drop_tools", []))
+    drop_skills = q.get("drop_skills", [])
+
+    if tools:
+        kept = [t for t in tools if t not in drop_tools]
+        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
+            return False, "ceremony_tool"
+    else:
+        if int(len(comp) / cpt) < q.get("min_completion_tokens", 12):
+            return False, "trivial_text"
+
+    markers = q.get("drop_prompt_markers") or []
+    if markers and any(m in row["prompt"][:300] for m in markers):
+        return False, "ritual_prompt"
+
+    if q.get("dedup", {}).get("enabled"):
+        key = hash(_norm(comp))
+        if key in seen:
+            return False, "duplicate"
+        seen.add(key)
+    return True, "keep"
+
+
+# ----------------------------------------------------------------------------
+def gather_files(sources_cfg, scope, only):
+    """Yield (source_kind, adapter, path, root) for every in-scope transcript."""
+    for kind, sc in sources_cfg.items():
+        if only and kind not in only:
+            continue
+        if not sc.get("enabled", True):
+            continue
+        adapter = get_adapter(sc["format"])
+        root = os.path.expanduser(sc["root"])
+        for path in glob.glob(os.path.join(root, sc["glob"]), recursive=True):
+            try:
+                if not scope_ok(adapter.scope_key(path, root), scope):
+                    continue
+            except Exception:
+                continue
+            yield kind, adapter, path, root
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True, help="path to distill config YAML")
+    ap.add_argument("--smoke", action="store_true", help="write to smoke/ subdir")
+    ap.add_argument("--limit", type=int, default=0, help="cap files per source (0=all)")
+    ap.add_argument("--sources", default="", help="comma list to restrict sources")
+    ap.add_argument("--show", type=int, default=0, help="print N sample rows")
+    ap.add_argument("--max-context-tokens", type=int, default=0,
+                    help="override context_budget.max_context_tokens")
+    args = ap.parse_args()
+
+    cfg = yaml.safe_load(open(args.config))
+    scope = cfg.get("scope", {})
+    lab = cfg["labeling"]
+    if args.max_context_tokens:
+        cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
+    redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
+    redaction_counts: Counter = Counter()
+    qcfg = cfg.get("quality_filter") or {"enabled": False}
+    q_enabled = qcfg.get("enabled", False)
+    oc_cfg = cfg.get("session_outcome") or {"enabled": False}
+    oc_enabled = oc_cfg.get("enabled", False)
+    tiers_cfg = cfg.get("quality_tiers") or {}
+    inherit_parent = tiers_cfg.get("inherit_parent_for_subagents", True)
+    require_outcomes = set(qcfg.get("require_outcomes") or [])
+    cpt = cfg.get("context_budget", {}).get("chars_per_token", 4.0)
+
+    seen: set = set()
+    drop_counts: Counter = Counter()
+    outcome_counts: Counter = Counter()
+    tier_counts: Counter = Counter()
+    parent_cache: dict = {}
+    only = set(s.strip() for s in args.sources.split(",") if s.strip())
+
+    out_dir = Path(os.path.expanduser(cfg["output"]["dir"]))
+    if args.smoke:
+        out_dir = out_dir / cfg["output"].get("smoke_subdir", "smoke")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / cfg["output"].get("rows_file", "rows.jsonl")
+
+    per_source_files: Counter = Counter()
+    stats = {"rows": 0, "accept": 0, "reject": 0, "borderline": 0, "oversize": 0}
+    by_source: dict = {}
+    samples = []
+
+    with open(out_path, "w") as fout:
+        for kind, adapter, path, root in gather_files(cfg["sources"], scope, only):
+            if args.limit and per_source_files[kind] >= args.limit:
+                continue
+            per_source_files[kind] += 1
+            try:
+                events, signals = adapter.parse(path)
+            except Exception as e:
+                print(f"  ! parse failed {path}: {e}", file=sys.stderr)
+                continue
+            project = adapter.project(path, root)
+            rel_id = Path(path).name
+
+            outcomes = []
+            if oc_enabled:
+                clf = path
+                parent = adapter.parent_path(path) if inherit_parent else None
+                if parent and os.path.exists(parent):
+                    clf = parent
+                if clf in parent_cache:
+                    outcomes = parent_cache[clf]
+                else:
+                    try:
+                        ev2, sig2 = (events, signals) if clf == path else adapter.parse(clf)
+                        outcomes = classify_session(ev2, sig2, oc_cfg)["outcomes"]
+                    except Exception as e:
+                        print(f"  ! outcome scan failed {clf}: {e}", file=sys.stderr)
+                        outcomes = []
+                    parent_cache[clf] = outcomes
+            tier = derive_tier(outcomes, tiers_cfg)
+
+            rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+            bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
+            for r in rows:
+                r["metadata"]["session_outcome"] = outcomes
+                r["metadata"]["good_path"] = bool(outcomes)
+                r["metadata"]["quality_tier"] = tier
+                r["prompt"] = redactor.redact(r["prompt"], redaction_counts)
+                r["completion"] = redactor.redact(r["completion"], redaction_counts)
+                if q_enabled:
+                    keep, reason = should_keep(r, qcfg, seen, cpt)
+                    if not keep:
+                        drop_counts[reason] += 1
+                        continue
+                if require_outcomes and not (set(outcomes) & require_outcomes):
+                    drop_counts["no_good_outcome"] += 1
+                    continue
+                for o2 in (outcomes or ["(none)"]):
+                    outcome_counts[o2] += 1
+                tier_counts[tier] += 1
+                for m in r["conversations"]:
+                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                fout.write(json.dumps(r, ensure_ascii=False) + "\n")
+                stats["rows"] += 1
+                bucket = ("accept" if r["label"] is True else
+                          "reject" if r["label"] is False else "borderline")
+                stats[bucket] += 1
+                bs[bucket] += 1
+                if r["metadata"]["oversize"]:
+                    stats["oversize"] += 1
+                if len(samples) < args.show and r["completion"].strip():
+                    samples.append(r)
+
+    print("=" * 64)
+    dropped = sum(drop_counts.values())
+    if dropped:
+        print(f"quality funnel dropped {dropped:,} rows: {dict(drop_counts)}")
+    print(f"wrote {stats['rows']:,} rows -> {out_path}")
+    print(f"  files per source: {dict(per_source_files)}")
+    print(f"  ACCEPT {stats['accept']:,} | REJECT {stats['reject']:,} | "
+          f"BORDERLINE {stats['borderline']:,} (-> judge)")
+    for k, b in by_source.items():
+        print(f"    {k:18s}: {b['accept']:,} / {b['reject']:,} / {b['borderline']:,}")
+    print(f"  oversize rows: {stats['oversize']:,}")
+    print(f"  session outcome (turn counts): {dict(outcome_counts)}")
+    print(f"  QUALITY TIER: {dict(tier_counts)}")
+    total_redacted = sum(redaction_counts.values())
+    print(f"  secrets redacted: {total_redacted:,}", dict(redaction_counts) or "")
+    print("=" * 64)
+    for k, s in enumerate(samples):
+        print(f"\n--- sample {k+1} [{s['metadata']['source_kind']} / {s['score_tier']} / "
+              f"{s['metadata']['quality_tier']}] tools={s['metadata']['tool_names']} ---")
+        print("PROMPT   :", (s["prompt"] or "")[:160].replace("\n", " "))
+        print("COMPLETE :", s["completion"][:240].replace("\n", " "))
+
+
+if __name__ == "__main__":
+    main()

--- a/.skills/transcript-distillation/scripts/sanitize.py
+++ b/.skills/transcript-distillation/scripts/sanitize.py
@@ -1,0 +1,48 @@
+"""Deterministic secret redaction for transcript rows.
+
+Config-driven (see configs/transcript_import/default.yaml `sanitize:`). Catches
+high-entropy credential formats and sensitive KEY=VALUE assignments. Applied at
+emit time so raw secrets never reach disk.
+
+This is a SECRET scrubber, not a PII scrubber — it targets keys/tokens that a
+model could memorize and regurgitate. For names/emails/paths, run the OPF-backed
+SynthChat sanitize as a separate pass.
+"""
+from __future__ import annotations
+import re
+from collections import Counter
+
+
+class Redactor:
+    def __init__(self, cfg: dict):
+        self.enabled = cfg.get("enabled", True)
+        self.replacement = cfg.get("replacement", "[REDACTED:{name}]")
+        self._patterns = [(name, re.compile(pat))
+                          for name, pat in cfg.get("patterns", {}).items()]
+        env = cfg.get("env_assignment") or {}
+        self._env_re = None
+        if env.get("sensitive_key_re"):
+            key_re = env["sensitive_key_re"].replace("(?i)", "")  # flag -> compile arg
+            # capture a sensitive key followed by = or : then the value to drop
+            self._env_re = re.compile(
+                rf"({key_re}\s*[:=]\s*)"
+                r"(['\"]?)([^\s'\"]{4,})(\2)", re.IGNORECASE)
+            self._env_replacement = env.get("replacement", "[REDACTED:env_secret]")
+
+    def redact(self, text: str, counts: Counter | None = None):
+        """Return redacted text; tally hits into `counts` if given."""
+        if not self.enabled or not text:
+            return text
+        for name, rx in self._patterns:
+            def _sub(m, n=name):
+                if counts is not None:
+                    counts[n] += 1
+                return self.replacement.format(name=n)
+            text = rx.sub(_sub, text)
+        if self._env_re is not None:
+            def _env_sub(m):
+                if counts is not None:
+                    counts["env_secret"] += 1
+                return m.group(1) + self._env_replacement
+            text = self._env_re.sub(_env_sub, text)
+        return text

--- a/configs/transcript_import/default.yaml
+++ b/configs/transcript_import/default.yaml
@@ -1,0 +1,192 @@
+# CASE-STUDY config for the `transcript-distillation` skill (see
+# .skills/transcript-distillation/). Our own run: scope to coding projects,
+# exclude client/sensitive ones, output to gitignored private/.
+#
+# Run with the skill engine:
+#   python .skills/transcript-distillation/scripts/distill.py \
+#     --config configs/transcript_import/default.yaml --smoke --limit 30 --show 3
+#
+# OUTPUT IS PRIVATE: rows land under private/ which is gitignored. Never commit.
+
+sources:
+  claude_main:
+    format: claude_code
+    enabled: true
+    root: "~/.claude/projects"
+    # session transcripts sit directly in each <project-slug>/ dir
+    glob: "*/*.jsonl"
+  claude_subagent:
+    format: claude_code
+    enabled: true
+    root: "~/.claude/projects"
+    # subagent (Task-tool / PACT teammate) runs nested under <project>/<session>/subagents/
+    glob: "*/*/subagents/*.jsonl"
+  codex:
+    format: codex
+    enabled: true
+    root: "~/.codex/sessions"
+    glob: "**/*.jsonl"
+
+# Scope filter. Claude projects are filtered by their dir-slug; Codex sessions
+# are filtered by the cwd recorded in their session_meta event.
+scope:
+  # a project is in-scope only if its path/cwd matches one of these (case-insensitive)
+  include_substrings:
+    - "documents-code-"   # claude slug form
+    - "/documents/code/"  # codex cwd form
+  # ...and matches NONE of these
+  exclude_substrings:
+    - "qwoted"
+    - "plan-your-baby"
+
+# Deterministic secret redaction, applied at emit time so raw secrets never
+# hit disk. High-entropy credential formats (keys/tokens) + sensitive env
+# assignments. This is the PRIMARY scrub (your priority: keep live secrets out
+# of training data). For deeper PII (names/emails/paths) run the OPF-backed
+# SynthChat sanitize as an optional second pass once OPF_CHECKPOINT is set up.
+sanitize:
+  enabled: true
+  replacement: "[REDACTED:{name}]"
+  # named regexes; value secrets in env-assignments keep the key, drop the value
+  patterns:
+    openai_key: "sk-(?:proj-)?[A-Za-z0-9_-]{20,}"
+    openrouter_key: "sk-or-v1-[A-Za-z0-9]{32,}"
+    anthropic_key: "sk-ant-[A-Za-z0-9_-]{20,}"
+    hf_token: "hf_[A-Za-z0-9]{30,}"
+    github_token: "gh[pousr]_[A-Za-z0-9]{36,}"
+    aws_access_key: "AKIA[0-9A-Z]{16}"
+    google_api_key: "AIza[0-9A-Za-z_-]{35}"
+    slack_token: "xox[baprs]-[0-9A-Za-z-]{10,}"
+    bearer_token: "[Bb]earer\\s+[A-Za-z0-9._-]{20,}"
+    jwt: "eyJ[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}"
+    private_key_block: "-----BEGIN [A-Z ]*PRIVATE KEY-----[\\s\\S]*?-----END [A-Z ]*PRIVATE KEY-----"
+  # for KEY=VALUE / KEY: VALUE lines, redact the VALUE but keep the key name
+  env_assignment:
+    sensitive_key_re: "(?i)(?:api[_-]?key|secret|token|password|passwd|private[_-]?key|access[_-]?key|client[_-]?secret)"
+    replacement: "[REDACTED:env_secret]"
+
+# Session-outcome classifier — judges the whole trajectory by where it ended up,
+# then tags every row from that session. This is the strongest quality signal:
+# a turn from a session that ultimately passed tests / built clean / got committed
+# / opened a PR / earned user approval was on a good path. Tag-only by default
+# (see quality_filter.require_outcomes to actually filter on it).
+session_outcome:
+  enabled: true
+  test_command_re: "\\b(pytest|jest|vitest|mocha|go test|cargo test|cargo nextest|npm (?:run )?test|yarn test|pnpm test|tox|rspec|phpunit|gradle test|mvn test|unittest|ctest|python -m pytest)\\b"
+  build_command_re: "\\b(tsc|cargo (?:build|check|clippy)|go build|make\\b|cmake|vite build|next build|webpack|gradle build|mvn (?:package|compile)|eslint|ruff|mypy)\\b"
+  commit_command_re: "git commit"
+  # result text signals (used alongside the tool-result error flag / exit code)
+  pass_re: "\\b(\\d+ passed|all tests passed|tests? passed|build succeeded|0 errors?|passing|PASS)\\b"
+  fail_re: "\\b(\\d+ failed|FAILED|\\berror\\b|exception|panicked|✗)\\b"
+  approve_re: "^(thanks|thank you|perfect|great|awesome|nice|lgtm|looks good|that works|ship it|excellent|amazing|love it|works now|fixed it)\\b"
+  approve_max_chars: 80
+
+# Quality tiers stamped on every row (metadata.quality_tier) from the session
+# outcome. Train staged (gold first) or weight by tier. gold = code verifiably
+# worked; silver = saved/shipped; bronze = no terminal signal.
+quality_tiers:
+  gold: [tests_passed, clean_build]
+  silver: [committed, pr_created, user_approved]
+  # everything else -> bronze
+  # subagents inherit their PARENT session's outcome (their own transcript never
+  # contains the commit/PR/test), so a coder subagent under a gold session is gold.
+  inherit_parent_for_subagents: true
+
+# Quality funnel — runs at emit time, BEFORE the judge. Cuts the ~450k raw
+# per-turn rows down to substantive coding-agent turns. Everything here is tunable:
+# flip drop_tools to keep orchestration behavior, raise/lower the text floor, etc.
+quality_filter:
+  enabled: true
+  # tool calls that are harness/PACT ceremony, not transferable coding skill.
+  # a turn whose ONLY tool calls are these (and no substantive text) is dropped.
+  drop_tools:
+    - TaskCreate
+    - TaskUpdate
+    - TaskList
+    - TaskGet
+    - TaskOutput
+    - TaskStop
+    - TeamCreate
+    - TeamDelete
+    - SendMessage
+    - ToolSearch
+    - Monitor
+    - EnterPlanMode
+    - ExitPlanMode
+    - PushNotification
+    - CronCreate
+    - CronList
+    - CronDelete
+    - RemoteTrigger
+  # Skill() calls invoking these are bootstrap/ritual; non-listed skills are kept
+  drop_skills:
+    - "PACT:bootstrap"
+    - "PACT:teammate-bootstrap"
+    - "PACT:orchestration"
+  # text-only turns shorter than this (est. tokens) are filler -> dropped
+  min_completion_tokens: 12
+  # drop rows whose completion is a near-duplicate of one already kept
+  dedup:
+    enabled: true
+  # OFF by default (can over-drop): drop rows whose prompt is a hook/ritual
+  drop_prompt_markers: []
+  # Outcome filter. Empty list = tag only (keep all, record session_outcome in
+  # metadata). Set e.g. [tests_passed, clean_build, committed, pr_created,
+  # user_approved] to keep ONLY rows from verified-good sessions.
+  require_outcomes: []
+
+output:
+  dir: "private/transcripts"
+  rows_file: "rows.jsonl"
+  # written to <dir>/smoke/ when --smoke is passed
+  smoke_subdir: "smoke"
+
+# Each emitted row = one assistant turn with its preceding context.
+granularity: "assistant_turn"
+# Bound row size by ESTIMATED TOKENS so rows fit the training context window
+# (local training is context-limited). Context is filled most-recent-first up to
+# the budget, after reserving room for the completion. message count is only a
+# secondary safety ceiling. Rows whose completion alone exceeds the budget are
+# still emitted but flagged metadata.oversize=true so they can be filtered.
+context_budget:
+  # NOTE: this caps CONTEXT DEPTH per row, not the number of examples (every
+  # assistant turn is one row regardless). Training cost scales ~O(seq^2), so
+  # keep this at your real local seq length. 8192 fits ~all completions + recent
+  # context cheaply; 4096 is the budget option; 32768 is ~16x the attention cost.
+  max_context_tokens: 8192      # local training seq length; override with --max-context-tokens
+  chars_per_token: 4.0         # rough estimate; code skews ~3.5
+  max_context_messages: 120    # hard ceiling regardless of token budget
+
+# Deterministic labeling. Anything not confidently accept/reject is left
+# label=null (borderline) for the downstream SynthChat judge pass.
+labeling:
+  # High-precision correction signal: the NEXT human turn is treated as a
+  # correction only when it is SHORT (<= max_correction_chars) and STARTS WITH
+  # one of these markers. Corrections are terse and directed; loose substring
+  # matching ("don't worry", "actually, also...") produced massive false rejects.
+  correction_markers:
+    - "no,"
+    - "no."
+    - "no "
+    - "nope"
+    - "stop"
+    - "wrong"
+    - "that's wrong"
+    - "thats wrong"
+    - "that's not"
+    - "thats not"
+    - "incorrect"
+    - "undo"
+    - "revert"
+    - "not what i"
+  # a human turn longer than this is a new instruction, not a correction
+  max_correction_chars: 180
+  interrupt_markers:
+    - "[request interrupted by user]"
+    - "[request interrupted"
+  # an assistant turn is a clean ACCEPT only when: no tool error in the turn,
+  # not interrupted, and the next human turn (if any) is not a correction.
+  # a clean REJECT requires an UNRECOVERED failure: a tool error or interrupt
+  # that is followed by a human correction (not by the model fixing it itself).
+  # everything else -> borderline (null) -> judge.
+  require_human_signal_for_reject: true


### PR DESCRIPTION
## What

A new `transcript-distillation` skill that mines local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows.

The engine is **format-agnostic** — format specifics live in pluggable adapters that emit a normalized event model. Two ship built-in (`claude_code`, `codex`); a new format is a ~40-line adapter + one registry line.

## Pipeline (all config-driven)

```
adapter.parse(file) -> per-assistant-turn rows
  -> secret scrub at emit (raw secrets never hit disk)
  -> token-budget context (compute knob = training seq length)
  -> deterministic label: accept / borderline(->judge) / reject
  -> quality funnel: drop ceremony tools, trivial filler, duplicates
  -> session-outcome tiering: gold / silver / bronze
       (tests passed / clean build / commit / PR / approval;
        subagents inherit parent session's outcome)
  -> JSONL
```

## Contents

- `scripts/distill.py` — engine; `scripts/adapters/` — `claude_code` + `codex` + registry
- `scripts/sanitize.py` — deterministic secret scrubber
- `configs/template.yaml` — portable config (empty scope = grab all local transcripts; CWD-relative output; only dep `pyyaml`)
- `reference/` — config-schema, writing-adapters, case-study-claude-codex
- `configs/transcript_import/default.yaml` — case-study config
- `.gitignore` — ignore `private/` (transcript-derived data is never committed)

Mirrors synced to `.agents/skills` and `.claude/skills`.

## Validation

- Runs from a clean working dir with the template config → discovers `~/.claude/projects` + `~/.codex/sessions`, no repo assumptions.
- Case study: 538,804 raw turns → 102,155 deduped rows (gold 79k / silver 9k / bronze 14k) in ~6 min; 0 residual secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)