### PR TITLE
Add Option-A HF-cloud hidden-state extraction verb (cloud-extract)

### DIFF
--- a/tests/cloud/test_cloud_extract_handler.py
+++ b/tests/cloud/test_cloud_extract_handler.py
@@ -26,7 +26,11 @@ import pytest
 
 from tuner.cloud import RepoCheckoutSpec
 from tuner.core.exceptions import CloudProviderError
-from tuner.handlers.cloud_extract_handler import CloudExtractHandler, ExtractionLaunchPlan
+from tuner.handlers.cloud_extract_handler import (
+    CloudExtractHandler,
+    ExtractionLaunchPlan,
+    _redact_url_userinfo,
+)
 
 
 # --------------------------------------------------------------------------- #
@@ -91,6 +95,22 @@ def test_build_launch_plan_trims_and_populates():
     assert plan.base_model_revision == "a" * 40
     assert plan.adapter_repo_id == "prof/sft-contrast-adapter"
     assert plan.repo.commit == "c" * 40
+
+
+def test_handle_surfaces_config_error_through_handle_path():
+    """LOW-1: handle() wraps a config-validation failure as CONFIG_ERROR (rc=1).
+
+    The validation raises are also covered at build_launch_plan() level, but this
+    drives the full handle() try/except wrapper so the CONFIG_ERROR surface is
+    not green-by-omission.
+    """
+    handler = _make_handler(_full_args(slice_dataset_name="", json=True))
+    with patch("tuner.handlers.cloud_extract_handler.load_env_file"), \
+         patch.object(handler, "output_error") as output_error:
+        rc = handler.handle()
+    assert rc == 1
+    # The uniform error surface tagged the failure with the CONFIG_ERROR code.
+    assert output_error.call_args.kwargs.get("code") == "CLOUD_EXTRACT_CONFIG_ERROR"
 
 
 # --------------------------------------------------------------------------- #
@@ -159,6 +179,19 @@ def test_repo_source_falls_back_to_git_when_overrides_absent():
 def test_repo_source_unresolvable_raises():
     handler = _make_handler(_full_args(repo_url=None, repo_branch=None, repo_commit=None))
     with patch.object(handler, "_git", return_value=""):
+        with pytest.raises(CloudProviderError, match="repo source"):
+            handler._resolve_repo_source()
+
+
+def test_explicit_empty_repo_url_fails_closed_not_silent_git_fallback():
+    """LOW-4: an explicit --repo-url '' is honored (fails closed), not silently
+    routed to the git fallback. `is not None` distinguishes passed-but-empty
+    from absent; the empty value then trips the fail-closed guard.
+    """
+    handler = _make_handler(_full_args(repo_url=""))
+    # If the empty override were ignored, _git would be consulted; assert it is
+    # NOT, and that the empty url fails closed.
+    with patch.object(handler, "_git", side_effect=AssertionError("git fallback must not run for an explicit empty override")):
         with pytest.raises(CloudProviderError, match="repo source"):
             handler._resolve_repo_source()
 
@@ -243,6 +276,53 @@ def test_dry_run_json_mode_emits_plan(capsys, monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# SEC-L1: dry-run must not leak credentials embedded in the clone URL
+# --------------------------------------------------------------------------- #
+def test_redact_url_userinfo_strips_credentials():
+    """Unit: _redact_url_userinfo removes user:pass@, leaves clean URLs intact."""
+    assert (
+        _redact_url_userinfo("https://user:ghp_secrettoken@github.com/prof/tuner.git")
+        == "https://github.com/prof/tuner.git"
+    )
+    # No userinfo -> unchanged; empty -> unchanged.
+    assert _redact_url_userinfo("https://github.com/prof/tuner.git") == "https://github.com/prof/tuner.git"
+    assert _redact_url_userinfo("") == ""
+
+
+def test_dry_run_redacts_url_credentials_in_text(capsys, monkeypatch):
+    """SEC-L1: a PAT embedded in --repo-url must NOT reach stdout."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    secret = "ghp_supersecrettoken"
+    handler = _make_handler(_full_args(
+        dry_run=True,
+        repo_url=f"https://user:{secret}@github.com/prof/tuner.git",
+    ))
+    with patch("tuner.handlers.cloud_extract_handler.load_env_file"):
+        rc = handler.handle()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert secret not in out
+    # The redacted host still appears so the operator sees the real target.
+    assert "github.com/prof/tuner.git" in out
+
+
+def test_dry_run_json_redacts_url_credentials_in_command(capsys, monkeypatch):
+    """SEC-L1: the JSON-mode 'command' field must NOT carry the embedded PAT."""
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    secret = "ghp_supersecrettoken"
+    handler = _make_handler(_full_args(
+        dry_run=True,
+        json=True,
+        repo_url=f"https://user:{secret}@github.com/prof/tuner.git",
+    ))
+    with patch("tuner.handlers.cloud_extract_handler.load_env_file"):
+        rc = handler.handle()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert secret not in out
+
+
+# --------------------------------------------------------------------------- #
 # Submit path
 # --------------------------------------------------------------------------- #
 def _patch_submit_env(token: Optional[str], hub: Any):
@@ -276,6 +356,41 @@ def test_submit_with_yes_calls_executor():
     spec = executor_cls.return_value.submit.call_args.args[0]
     assert spec.secrets.get("HF_TOKEN") == "hf_tok"
     assert spec.flavor  # populated
+
+
+def test_submit_hub_load_failure_is_env_error():
+    """LOW-2: load_huggingface_hub raising surfaces as ENV_ERROR (rc=1)."""
+    handler = _make_handler(_full_args(auto_confirm=True, json=True))
+    with patch("tuner.handlers.cloud_extract_handler.load_env_file"), \
+         patch("tuner.handlers.cloud_extract_handler.get_hf_token", return_value="hf_tok"), \
+         patch(
+             "tuner.handlers.cloud_extract_handler.load_huggingface_hub",
+             side_effect=CloudProviderError("huggingface_hub missing run_job"),
+         ), \
+         patch.object(handler, "output_error") as output_error, \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        rc = handler.handle()
+    assert rc == 1
+    executor_cls.return_value.submit.assert_not_called()
+    assert output_error.call_args.kwargs.get("code") == "CLOUD_EXTRACT_ENV_ERROR"
+
+
+def test_submit_executor_failure_is_submit_error():
+    """LOW-3: executor.submit raising (e.g. network/quota) -> SUBMIT_ERROR (rc=1).
+
+    This is the operationally most-likely failure once a real job is launched.
+    """
+    handler = _make_handler(_full_args(auto_confirm=True, json=True))
+    hub = MagicMock()
+    p_env, p_token, p_hub = _patch_submit_env(token="hf_tok", hub=hub)
+    with p_env, p_token, p_hub, \
+         patch.object(handler, "output_error") as output_error, \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        executor_cls.return_value.submit.side_effect = CloudProviderError("HF Jobs quota exceeded")
+        rc = handler.handle()
+    assert rc == 1
+    executor_cls.return_value.submit.assert_called_once()
+    assert output_error.call_args.kwargs.get("code") == "CLOUD_EXTRACT_SUBMIT_ERROR"
 
 
 def test_submit_without_yes_prompts_and_cancel_does_not_submit():

--- a/tests/cloud/test_cloud_extract_handler.py
+++ b/tests/cloud/test_cloud_extract_handler.py
@@ -1,0 +1,337 @@
+"""GPU-free unit tests for the ``cloud-extract`` verb (Option A).
+
+Location: tests/cloud/test_cloud_extract_handler.py
+Purpose: Verify the cloud-extract handler's GPU-free surface -- arg validation,
+         launch-plan resolution, in-job command assembly (every input by hub id),
+         job-spec assembly (HF_TOKEN as a secret, never echoed), the dry-run path
+         (no token / no submit), the submit path (--yes gating, executor call),
+         JSON-mode contracts, and the SACROSANCT off-the-signed-path guarantee
+         (the module imports nothing under tuner.backends.training.*).
+Used by: pytest (tests/ testpaths). No GPU, no network, no real HF_TOKEN.
+
+Design contract: docs/architecture/experiment-runner-probe-dataprep.md section 6.
+The actual cloud extraction RUN is deferred + cost-incurring; these tests mock
+the hub + executor and never submit a real job.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tuner.cloud import RepoCheckoutSpec
+from tuner.core.exceptions import CloudProviderError
+from tuner.handlers.cloud_extract_handler import CloudExtractHandler, ExtractionLaunchPlan
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+def _full_args(**overrides: Any) -> SimpleNamespace:
+    """A complete, valid set of cloud-extract args; override individual fields."""
+    base: Dict[str, Any] = {
+        "extraction_config": "experiment/probe/extraction.yaml",
+        "slice_dataset_name": "prof/probe-slice",
+        "base_model_name": "Qwen/Qwen3-4B-Instruct",
+        "base_model_revision": "a" * 40,
+        "adapter_repo_id": "prof/sft-contrast-adapter",
+        "adapter_revision": "b" * 40,
+        "output_dataset_name": "prof/probe-hidden-states",
+        "gpu": None,
+        "timeout_hours": None,
+        "cloud_image": None,
+        "repo_url": "https://github.com/prof/tuner.git",
+        "repo_branch": "main",
+        "repo_commit": "c" * 40,
+        "dry_run": False,
+        "auto_confirm": False,
+        "json": False,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_handler(args: SimpleNamespace) -> CloudExtractHandler:
+    handler = CloudExtractHandler(args=args)
+    # Pin repo_root so the (unused on the override path) git helper has a cwd.
+    handler._repo_root = Path(".").resolve()
+    return handler
+
+
+# --------------------------------------------------------------------------- #
+# Arg validation
+# --------------------------------------------------------------------------- #
+def test_missing_required_args_reports_all_at_once():
+    handler = _make_handler(_full_args(slice_dataset_name="", adapter_repo_id=None))
+    with pytest.raises(CloudProviderError) as exc:
+        handler.build_launch_plan()
+    message = str(exc.value)
+    assert "--slice-dataset-name" in message
+    assert "--adapter-repo-id" in message
+    # The two present-but-empty fields are both surfaced in a single error.
+    assert message.count("--") >= 2
+
+
+def test_blank_whitespace_arg_treated_as_missing():
+    handler = _make_handler(_full_args(output_dataset_name="   "))
+    with pytest.raises(CloudProviderError, match="--output-dataset-name"):
+        handler.build_launch_plan()
+
+
+def test_build_launch_plan_trims_and_populates():
+    handler = _make_handler(_full_args(extraction_config="  cfg.yaml  "))
+    plan = handler.build_launch_plan()
+    assert isinstance(plan, ExtractionLaunchPlan)
+    assert plan.extraction_config == "cfg.yaml"
+    assert plan.base_model_revision == "a" * 40
+    assert plan.adapter_repo_id == "prof/sft-contrast-adapter"
+    assert plan.repo.commit == "c" * 40
+
+
+# --------------------------------------------------------------------------- #
+# Defaults + numeric validation
+# --------------------------------------------------------------------------- #
+def test_flavor_and_timeout_defaults_apply():
+    plan = _make_handler(_full_args()).build_launch_plan()
+    assert plan.flavor  # a non-empty default
+    assert plan.timeout_hours > 0
+
+
+def test_flavor_and_timeout_overrides_apply():
+    plan = _make_handler(_full_args(gpu="h100-large", timeout_hours=5)).build_launch_plan()
+    assert plan.flavor == "h100-large"
+    assert plan.timeout_hours == 5.0
+
+
+def test_invalid_timeout_raises():
+    with pytest.raises(CloudProviderError, match="timeout-hours"):
+        _make_handler(_full_args(timeout_hours="not-a-number")).build_launch_plan()
+
+
+def test_nonpositive_timeout_raises():
+    with pytest.raises(CloudProviderError, match="positive"):
+        _make_handler(_full_args(timeout_hours=0)).build_launch_plan()
+
+
+def test_cloud_image_override_applies():
+    plan = _make_handler(_full_args(cloud_image="my/custom:image")).build_launch_plan()
+    assert plan.image == "my/custom:image"
+
+
+# --------------------------------------------------------------------------- #
+# Repo source resolution (git helper)
+# --------------------------------------------------------------------------- #
+def test_repo_source_uses_explicit_overrides_without_git():
+    handler = _make_handler(_full_args())
+    # With all three overrides present, the git helper must never be invoked.
+    with patch.object(handler, "_git", side_effect=AssertionError("git should not be called")):
+        spec = handler._resolve_repo_source()
+    assert spec == RepoCheckoutSpec(
+        url="https://github.com/prof/tuner.git",
+        branch="main",
+        commit="c" * 40,
+        clone_dir="/workspace/repo",
+    )
+
+
+def test_repo_source_falls_back_to_git_when_overrides_absent():
+    handler = _make_handler(_full_args(repo_url=None, repo_branch=None, repo_commit=None))
+    with patch.object(
+        handler,
+        "_git",
+        side_effect=lambda *a: {
+            ("config", "--get", "remote.origin.url"): "https://example/repo.git",
+            ("rev-parse", "--abbrev-ref", "HEAD"): "feature/x",
+            ("rev-parse", "HEAD"): "d" * 40,
+        }[a],
+    ):
+        spec = handler._resolve_repo_source()
+    assert spec.url == "https://example/repo.git"
+    assert spec.branch == "feature/x"
+    assert spec.commit == "d" * 40
+
+
+def test_repo_source_unresolvable_raises():
+    handler = _make_handler(_full_args(repo_url=None, repo_branch=None, repo_commit=None))
+    with patch.object(handler, "_git", return_value=""):
+        with pytest.raises(CloudProviderError, match="repo source"):
+            handler._resolve_repo_source()
+
+
+# --------------------------------------------------------------------------- #
+# In-job command assembly
+# --------------------------------------------------------------------------- #
+def test_extraction_command_passes_every_input_by_id():
+    handler = _make_handler(_full_args())
+    plan = handler.build_launch_plan()
+    steps = handler.build_extraction_command(plan)
+    joined = " && ".join(steps)
+    # Repo checkout pins the exact commit.
+    assert ("c" * 40) in joined
+    # Every artifact is referenced by id/revision; no local path leaks in.
+    assert "--slice-dataset-name prof/probe-slice" in joined
+    assert "--base-model-name Qwen/Qwen3-4B-Instruct" in joined
+    assert f"--base-model-revision {'a' * 40}" in joined
+    assert "--adapter-repo-id prof/sft-contrast-adapter" in joined
+    assert f"--adapter-revision {'b' * 40}" in joined
+    assert "--output-dataset-name prof/probe-hidden-states" in joined
+    assert "extraction_runner" in joined
+
+
+# --------------------------------------------------------------------------- #
+# Job-spec assembly + secret handling
+# --------------------------------------------------------------------------- #
+def test_job_spec_injects_token_as_secret_only():
+    handler = _make_handler(_full_args())
+    plan = handler.build_launch_plan()
+    spec = handler.build_job_spec(plan, token="hf_secret_value")
+    assert spec.secrets.get("HF_TOKEN") == "hf_secret_value"
+    # The token NEVER appears in the command or labels.
+    command_text = spec.command[-1]
+    assert "hf_secret_value" not in command_text
+    assert "hf_secret_value" not in str(spec.labels)
+
+
+def test_job_spec_dry_run_has_no_secret():
+    handler = _make_handler(_full_args())
+    plan = handler.build_launch_plan()
+    spec = handler.build_job_spec(plan, token=None)
+    assert spec.secrets == {}
+
+
+def test_job_spec_labels_are_descriptive_and_id_only():
+    handler = _make_handler(_full_args())
+    plan = handler.build_launch_plan()
+    spec = handler.build_job_spec(plan, token="t")
+    assert spec.labels["task"] == "extract"
+    assert spec.labels["output_dataset"] == "prof/probe-hidden-states"
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run path (GPU-free, token-free, submit-free)
+# --------------------------------------------------------------------------- #
+def test_dry_run_does_not_submit_and_needs_no_token(capsys, monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("HF_API_KEY", raising=False)
+    handler = _make_handler(_full_args(dry_run=True))
+    with patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls, \
+         patch("tuner.handlers.cloud_extract_handler.load_env_file"):
+        rc = handler.handle()
+    assert rc == 0
+    executor_cls.assert_not_called()
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "prof/probe-hidden-states" in out
+
+
+def test_dry_run_json_mode_emits_plan(capsys, monkeypatch):
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    handler = _make_handler(_full_args(dry_run=True, json=True))
+    with patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls, \
+         patch("tuner.handlers.cloud_extract_handler.load_env_file"):
+        rc = handler.handle()
+    assert rc == 0
+    executor_cls.assert_not_called()
+    out = capsys.readouterr().out
+    assert '"dry_run": true' in out
+    assert "extraction_runner" in out
+
+
+# --------------------------------------------------------------------------- #
+# Submit path
+# --------------------------------------------------------------------------- #
+def _patch_submit_env(token: Optional[str], hub: Any):
+    """Context managers patching token + hub loader + env for the submit path."""
+    return (
+        patch("tuner.handlers.cloud_extract_handler.load_env_file"),
+        patch("tuner.handlers.cloud_extract_handler.get_hf_token", return_value=token),
+        patch("tuner.handlers.cloud_extract_handler.load_huggingface_hub", return_value=hub),
+    )
+
+
+def test_submit_requires_token():
+    handler = _make_handler(_full_args(auto_confirm=True))
+    p_env, p_token, p_hub = _patch_submit_env(token=None, hub=MagicMock())
+    with p_env, p_token, p_hub:
+        rc = handler.handle()
+    assert rc == 1
+
+
+def test_submit_with_yes_calls_executor():
+    handler = _make_handler(_full_args(auto_confirm=True))
+    hub = MagicMock()
+    submission = SimpleNamespace(job_id="job-xyz", job_url="https://hf.co/jobs/job-xyz")
+    p_env, p_token, p_hub = _patch_submit_env(token="hf_tok", hub=hub)
+    with p_env, p_token, p_hub, \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        executor_cls.return_value.submit.return_value = submission
+        rc = handler.handle()
+    assert rc == 0
+    executor_cls.return_value.submit.assert_called_once()
+    spec = executor_cls.return_value.submit.call_args.args[0]
+    assert spec.secrets.get("HF_TOKEN") == "hf_tok"
+    assert spec.flavor  # populated
+
+
+def test_submit_without_yes_prompts_and_cancel_does_not_submit():
+    handler = _make_handler(_full_args(auto_confirm=False))
+    hub = MagicMock()
+    p_env, p_token, p_hub = _patch_submit_env(token="hf_tok", hub=hub)
+    with p_env, p_token, p_hub, \
+         patch("tuner.handlers.cloud_extract_handler.confirm", return_value=False), \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        rc = handler.handle()
+    assert rc == 0
+    executor_cls.return_value.submit.assert_not_called()
+
+
+def test_submit_json_mode_requires_yes():
+    handler = _make_handler(_full_args(json=True, auto_confirm=False))
+    hub = MagicMock()
+    p_env, p_token, p_hub = _patch_submit_env(token="hf_tok", hub=hub)
+    with p_env, p_token, p_hub, \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        rc = handler.handle()
+    assert rc == 1
+    executor_cls.return_value.submit.assert_not_called()
+
+
+def test_submit_json_mode_with_yes_emits_job_id(capsys):
+    handler = _make_handler(_full_args(json=True, auto_confirm=True))
+    hub = MagicMock()
+    submission = SimpleNamespace(job_id="job-json", job_url=None)
+    p_env, p_token, p_hub = _patch_submit_env(token="hf_tok", hub=hub)
+    with p_env, p_token, p_hub, \
+         patch("tuner.handlers.cloud_extract_handler.HFJobExecutor") as executor_cls:
+        executor_cls.return_value.submit.return_value = submission
+        rc = handler.handle()
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "job-json" in out
+
+
+# --------------------------------------------------------------------------- #
+# SACROSANCT: off-the-signed-path guarantee (section 6.6)
+# --------------------------------------------------------------------------- #
+def test_handler_module_imports_no_training_path():
+    """Static check: the handler source imports nothing under tuner.backends.training.*.
+
+    This guards the no-pollution boundary by inspecting the module's own import
+    statements (AST), so it fails loudly if a future edit reaches across the
+    signed-training boundary.
+    """
+    module_path = Path(__file__).resolve().parents[2] / "tuner" / "handlers" / "cloud_extract_handler.py"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+        elif isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+    offenders = [name for name in imported if "backends.training" in name]
+    assert offenders == [], f"cloud-extract must not import training paths: {offenders}"

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -75,6 +75,7 @@ Commands:
   cloud-eval  Cloud evaluation on HF Jobs
   cloud-gym   Run the vault gym against a trained cloud run on HF Jobs
   cloud-inspect Inspect saved HF cloud evaluation results
+  cloud-extract Forward-only hidden-state extraction on HF Jobs (publish-by-id)
   local-run   Config-driven local Docker training/eval job
   bucket      Read, list, pull, push, or analyze local / HF bucket artifacts
   run-experiment  Run train -> eval -> loss from one experiment config
@@ -141,7 +142,7 @@ Examples:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["train", "cloud", "cloud-run", "local-run", "cloud-jobs", "plan-hardware", "cloud-pipeline", "cloud-eval", "cloud-gym", "cloud-inspect", "bucket", "run-experiment", "analyze-experiment", "eval", "synthchat", "modelops", "ml", "flywheel", "experiment-loop", "prompt-optimize", "surgery", "status", "doctor", "list", "list-runs", "compute-losses", "compare-runs", "judge-sample", "create-experiment", "cloud-compare", "download-experiment"],
+        choices=["train", "cloud", "cloud-run", "local-run", "cloud-jobs", "plan-hardware", "cloud-pipeline", "cloud-eval", "cloud-gym", "cloud-inspect", "cloud-extract", "bucket", "run-experiment", "analyze-experiment", "eval", "synthchat", "modelops", "ml", "flywheel", "experiment-loop", "prompt-optimize", "surgery", "status", "doctor", "list", "list-runs", "compute-losses", "compare-runs", "judge-sample", "create-experiment", "cloud-compare", "download-experiment"],
         help="Command to run (optional, defaults to interactive menu)"
     )
 
@@ -215,6 +216,50 @@ Examples:
         "--surgery-config",
         dest="surgery_config",
         help="Path to LoRA surgery config YAML (surgery command only)"
+    )
+
+    # Cloud-extract-specific flags (forward-only hidden-state extraction on HF
+    # Jobs, publish-by-id). Reuses the shared --base-model-name, --gpu,
+    # --timeout-hours, and --dry-run flags defined elsewhere in this parser.
+    parser.add_argument(
+        "--extraction-config",
+        help="Extraction config (hub id or repo-relative path) for cloud-extract."
+    )
+    parser.add_argument(
+        "--slice-dataset-name",
+        help="Hub dataset id for the matched extraction slice (cloud-extract)."
+    )
+    parser.add_argument(
+        "--base-model-revision",
+        help="Base model commit SHA to pin for cloud-extract (required for cloud)."
+    )
+    parser.add_argument(
+        "--adapter-repo-id",
+        help="Hub model repo id for the contrast adapter (cloud-extract)."
+    )
+    parser.add_argument(
+        "--adapter-revision",
+        help="Contrast adapter commit SHA to pin (cloud-extract)."
+    )
+    parser.add_argument(
+        "--output-dataset-name",
+        help="Hub dataset id to receive the extraction outputs (cloud-extract)."
+    )
+    parser.add_argument(
+        "--cloud-image",
+        help="Override the Docker image for the cloud-extract HF Job."
+    )
+    parser.add_argument(
+        "--repo-url",
+        help="Override the tuner repo clone URL for cloud-extract (default: git origin)."
+    )
+    parser.add_argument(
+        "--repo-branch",
+        help="Override the tuner repo branch for cloud-extract (default: current branch)."
+    )
+    parser.add_argument(
+        "--repo-commit",
+        help="Override the tuner repo commit SHA for cloud-extract (default: HEAD)."
     )
 
     # Cloud-specific flags

--- a/tuner/cli/router.py
+++ b/tuner/cli/router.py
@@ -97,6 +97,7 @@ def route_command(args: Namespace) -> int:
         from tuner.handlers.hardware_plan_handler import HardwarePlanHandler
         from tuner.handlers.cloud_eval_handler import CloudEvalHandler
         from tuner.handlers.cloud_inspect_handler import CloudInspectHandler
+        from tuner.handlers.cloud_extract_handler import CloudExtractHandler
         from tuner.handlers.cloud_jobs_handler import CloudJobsHandler
         from tuner.handlers.cloud_gym_handler import CloudGymHandler
         from tuner.handlers.cloud_run_handler import CloudRunHandler
@@ -236,6 +237,7 @@ def route_command(args: Namespace) -> int:
         'cloud-eval': CloudEvalHandler,
         'cloud-gym': CloudGymHandler,
         'cloud-inspect': CloudInspectHandler,
+        'cloud-extract': CloudExtractHandler,
         'bucket': BucketHandler,
         'run-experiment': ExperimentHandler,
         'analyze-experiment': ExperimentAnalysisHandler,

--- a/tuner/handlers/cloud_extract_handler.py
+++ b/tuner/handlers/cloud_extract_handler.py
@@ -38,6 +38,11 @@ cost-incurring -- gated behind explicit ``--yes`` confirmation and, upstream,
 the runner's capability + submodule-pushed + HF_TOKEN + artifact-resolution
 push-gate (section 6.5). ``--dry-run`` assembles and prints the job spec
 without submitting (and without requiring a token).
+
+RUNBOOK / SECURITY: the tuner repo's git origin (or any ``--repo-url``) MUST NOT
+embed credentials (e.g. a PAT in ``https://user:token@host/...``). The dry-run
+redacts URL userinfo before printing, but credential-free origins are the
+contract; use an HF/GitHub token via the environment, never in the URL.
 """
 
 from __future__ import annotations
@@ -47,6 +52,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from shared.utilities.env import get_hf_token, load_env_file
 from tuner.cloud import (
@@ -81,6 +87,29 @@ _CLONE_DIR = "/workspace/repo"
 # analog of the local probe harness); it is invoked by hub id, never by a local
 # path, because HF Jobs has no research-repo mount.
 _EXTRACTION_ENTRYPOINT = "python -m tuner.cloud.extraction_runner"
+
+
+def _redact_url_userinfo(url: str) -> str:
+    """Strip any ``user:pass@`` userinfo from a URL for safe display.
+
+    Operators MUST NOT embed credentials in the tuner repo's git origin (a PAT
+    in ``https://user:token@host/...`` would otherwise be echoed to stdout/JSON
+    by the dry-run). This redacts the userinfo component so the printed clone
+    URL never carries a secret; the value is display-only and does not alter the
+    URL actually used to clone inside the job. Returns the input unchanged when
+    there is no userinfo (or when the URL cannot be parsed).
+    """
+    if not url:
+        return url
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return url
+    if "@" not in parts.netloc:
+        return url
+    # netloc is "userinfo@host[:port]"; keep only the host[:port] tail.
+    host = parts.netloc.rsplit("@", 1)[1]
+    return urlunsplit((parts.scheme, host, parts.path, parts.query, parts.fragment))
 
 
 @dataclass(frozen=True)
@@ -207,13 +236,26 @@ class CloudExtractHandler(BaseHandler):
         override_branch = getattr(self.args, "repo_branch", None)
         override_commit = getattr(self.args, "repo_commit", None)
 
-        url = str(override_url).strip() if override_url else self._git("config", "--get", "remote.origin.url")
+        # An EXPLICIT override (including an empty string) is honored as a
+        # deliberate choice: `is not None` distinguishes "flag passed" from "flag
+        # absent". An explicit empty value therefore yields '' and is caught by
+        # the fail-closed guard below, rather than silently falling through to
+        # the git fallback (which would mask an operator mistake).
+        url = (
+            str(override_url).strip()
+            if override_url is not None
+            else self._git("config", "--get", "remote.origin.url")
+        )
         branch = (
             str(override_branch).strip()
-            if override_branch
+            if override_branch is not None
             else self._git("rev-parse", "--abbrev-ref", "HEAD")
         )
-        commit = str(override_commit).strip() if override_commit else self._git("rev-parse", "HEAD")
+        commit = (
+            str(override_commit).strip()
+            if override_commit is not None
+            else self._git("rev-parse", "HEAD")
+        )
 
         if not url or not branch or not commit:
             raise CloudProviderError(
@@ -342,9 +384,22 @@ class CloudExtractHandler(BaseHandler):
         return self._handle_submit(plan)
 
     def _handle_dry_run(self, plan: ExtractionLaunchPlan) -> int:
-        """Assemble + print the job spec WITHOUT submitting (no token needed)."""
+        """Assemble + print the job spec WITHOUT submitting (no token needed).
+
+        SECURITY: the printed command embeds the clone URL. If an operator's git
+        origin embeds credentials (``https://user:token@host/...``) those must
+        not leak to stdout/JSON, so the displayed command has any URL userinfo
+        redacted via :func:`_redact_url_userinfo`. Origins should never embed
+        credentials in the first place; the runbook note above the verb
+        documents this.
+        """
         spec = self.build_job_spec(plan, token=None)
         command_text = spec.command[-1] if spec.command else ""
+        # Redact any embedded credentials in the clone URL before display. Only
+        # the printed text is altered; the submitted command is unaffected.
+        safe_url = _redact_url_userinfo(plan.repo.url)
+        if safe_url != plan.repo.url:
+            command_text = command_text.replace(plan.repo.url, safe_url)
         if self.json_mode:
             self.output(
                 {

--- a/tuner/handlers/cloud_extract_handler.py
+++ b/tuner/handlers/cloud_extract_handler.py
@@ -1,0 +1,427 @@
+"""Cloud hidden-state extraction verb for HF Jobs (publish-by-id, Option A).
+
+Location: tuner/handlers/cloud_extract_handler.py
+Purpose: Implement the ``cloud-extract`` CLI verb -- a GENERAL tuner capability
+         that launches a forward-only hidden-state extraction on Hugging Face
+         Jobs against published (hub-resident) inputs: a matched slice dataset,
+         a contrast adapter model repo (by id + revision), and a base model
+         (by id + revision). Outputs are written to a hub output dataset.
+Used by: tuner/cli/router.py (routes the ``cloud-extract`` command here);
+         tuner/cli/parser.py (registers the verb + its flags).
+
+Design contract: docs/architecture/experiment-runner-probe-dataprep.md section 6
+(Component 3, Option A). This verb resolves the three PREPARE blockers:
+  (a) no extraction verb in cloud-pipeline  -> this NEW verb;
+  (b) probe_results.jsonl is large/gitignored -> the runner publishes only the
+      small matched SLICE; this verb consumes it by hub id (never the 123MB file);
+  (c) the contrast adapter is a local artifact -> consumed as a private hub
+      model repo by id + revision.
+
+SACROSANCT off-the-signed-path guarantee (section 6.6): this module shares NO
+code path with cloud-pipeline's training execution or the signed v0.3 /
+Amendment A training recipes. It imports ONLY:
+  - tuner.cloud           (provider-agnostic HF Jobs primitives -- training-clean)
+  - tuner.handlers.base   (the I/O base handler -- training-clean)
+  - tuner.core.exceptions (shared error types)
+  - tuner.ui              (presentation helpers)
+  - huggingface_hub       (the lane-native publish/resolve mechanism)
+It deliberately does NOT import anything under ``tuner.backends.training.*``;
+repo source metadata is resolved via a local ``git`` subprocess helper rather
+than the training-namespace ``resolve_repo_source`` so the verb stays provably
+off the training tree.
+
+GPU boundary (section 10): every step this module performs locally
+(arg parsing, artifact resolution, publish, dry-run command assembly, job
+submission) is GPU-free. The forward-only extraction that the submitted job
+runs on the cloud GPU is the only GPU-required step, and launching it is
+cost-incurring -- gated behind explicit ``--yes`` confirmation and, upstream,
+the runner's capability + submodule-pushed + HF_TOKEN + artifact-resolution
+push-gate (section 6.5). ``--dry-run`` assembles and prints the job spec
+without submitting (and without requiring a token).
+"""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from shared.utilities.env import get_hf_token, load_env_file
+from tuner.cloud import (
+    CloudJobSpec,
+    HFJobExecutor,
+    RepoCheckoutSpec,
+    build_bash_command,
+    build_hf_job_secrets,
+    build_repo_checkout_steps,
+    load_huggingface_hub,
+)
+from tuner.core.exceptions import CloudProviderError
+from tuner.handlers.base import BaseHandler
+from tuner.ui import confirm, print_config, print_error, print_header, print_info, print_success
+
+# Default HF Jobs hardware flavor for a forward-only extraction pass. Extraction
+# is far lighter than training (no optimizer state, no backward), but still needs
+# enough VRAM to hold base + adapter; a10g-large is a safe, modest default and is
+# overridable via --gpu.
+_DEFAULT_FLAVOR = "a10g-large"
+
+# Default wall-clock cap for an extraction job. Forward-only over a few-hundred-row
+# slice is quick; the cap is a guard-rail, overridable via --timeout-hours.
+_DEFAULT_TIMEOUT_HOURS = 2.0
+
+# Where the tuner repo is cloned inside the HF Job, and where the extraction
+# config is read from relative to that clone.
+_CLONE_DIR = "/workspace/repo"
+
+# The in-job entrypoint that runs the forward-only extraction against the
+# published artifacts. This is the tuner repo's own extraction runner (cloud
+# analog of the local probe harness); it is invoked by hub id, never by a local
+# path, because HF Jobs has no research-repo mount.
+_EXTRACTION_ENTRYPOINT = "python -m tuner.cloud.extraction_runner"
+
+
+@dataclass(frozen=True)
+class ExtractionLaunchPlan:
+    """Fully-resolved, provider-agnostic description of a cloud-extract launch.
+
+    Every field is GPU-free to compute and is what the dry-run prints and the
+    submit path hands to :class:`HFJobExecutor`. Keeping this as a pure value
+    object makes the whole resolution path unit-testable without a GPU, a
+    network, or a token.
+    """
+
+    extraction_config: str
+    slice_dataset_name: str
+    base_model_name: str
+    base_model_revision: str
+    adapter_repo_id: str
+    adapter_revision: str
+    output_dataset_name: str
+    flavor: str
+    timeout_hours: float
+    image: str
+    repo: RepoCheckoutSpec
+
+    def as_display(self) -> Dict[str, str]:
+        """Human-readable summary for ``print_config`` / JSON output."""
+        return {
+            "Extraction Config": self.extraction_config,
+            "Slice Dataset": self.slice_dataset_name,
+            "Base Model": f"{self.base_model_name}@{self.base_model_revision}",
+            "Adapter Repo": f"{self.adapter_repo_id}@{self.adapter_revision}",
+            "Output Dataset": self.output_dataset_name,
+            "Image": self.image,
+            "GPU Flavor": self.flavor,
+            "Timeout": f"{self.timeout_hours:.1f}h",
+            "Repo Commit": self.repo.commit,
+        }
+
+
+# Each entry: (cli_attr, flag_name, human_label). Every one is required for a
+# cloud launch because the data-locality contract (section 6.3/6.4) demands that
+# every input -- slice, adapter, base, output -- be a hub id, and every model
+# input be revision-pinned for reproducibility (section 8).
+_REQUIRED_ARGS = (
+    ("extraction_config", "--extraction-config", "extraction config"),
+    ("slice_dataset_name", "--slice-dataset-name", "matched slice dataset id"),
+    ("base_model_name", "--base-model-name", "base model id"),
+    ("base_model_revision", "--base-model-revision", "base model revision SHA"),
+    ("adapter_repo_id", "--adapter-repo-id", "contrast adapter repo id"),
+    ("adapter_revision", "--adapter-revision", "contrast adapter revision SHA"),
+    ("output_dataset_name", "--output-dataset-name", "output dataset id"),
+)
+
+
+class CloudExtractHandler(BaseHandler):
+    """Launch a forward-only hidden-state extraction on HF Jobs (publish-by-id).
+
+    This is a sibling of ``cloud-pipeline`` in placement only; it is a GENERAL
+    tuner capability and is wholly off the signed training path (see module
+    docstring). Inputs are referenced by hub id + revision; outputs land in a
+    hub dataset.
+    """
+
+    @property
+    def name(self) -> str:
+        return "cloud-extract"
+
+    def can_handle_direct_mode(self) -> bool:
+        return True
+
+    # ------------------------------------------------------------------ #
+    # Argument resolution (GPU-free, network-free, token-free)
+    # ------------------------------------------------------------------ #
+    def _collect_required_args(self) -> Dict[str, str]:
+        """Read + validate every required CLI arg, failing fast on any gap.
+
+        Returns a dict of the trimmed string values. Raises
+        :class:`CloudProviderError` listing every missing flag at once so the
+        caller fixes them in a single pass rather than one round-trip per flag.
+        """
+        values: Dict[str, str] = {}
+        missing: List[str] = []
+        for attr, flag, label in _REQUIRED_ARGS:
+            raw = getattr(self.args, attr, None)
+            value = str(raw).strip() if raw is not None else ""
+            if not value:
+                missing.append(f"{flag} ({label})")
+            else:
+                values[attr] = value
+        if missing:
+            raise CloudProviderError(
+                "cloud-extract requires (all are hub ids / pinned SHAs, per the "
+                "data-locality contract): " + ", ".join(missing)
+            )
+        return values
+
+    def _resolve_flavor(self) -> str:
+        return str(getattr(self.args, "gpu", None) or _DEFAULT_FLAVOR).strip() or _DEFAULT_FLAVOR
+
+    def _resolve_timeout_hours(self) -> float:
+        raw = getattr(self.args, "timeout_hours", None)
+        if raw is None:
+            return _DEFAULT_TIMEOUT_HOURS
+        try:
+            timeout = float(raw)
+        except (TypeError, ValueError) as exc:
+            raise CloudProviderError(f"Invalid --timeout-hours value: {raw!r}") from exc
+        if timeout <= 0:
+            raise CloudProviderError("--timeout-hours must be positive.")
+        return timeout
+
+    def _resolve_repo_source(self) -> RepoCheckoutSpec:
+        """Resolve the exact tuner-repo source to clone inside the job.
+
+        Deliberately uses a local ``git`` subprocess (not the training-namespace
+        ``resolve_repo_source``) to keep this module off ``tuner.backends.training.*``
+        (SACROSANCT, section 6.6). The remote URL / branch / commit can be
+        overridden via CLI flags for environments where git metadata is absent
+        or a specific pinned commit is desired (HF Jobs checks out the pinned
+        SHA -- it must be reachable on the remote, which the runner's
+        ``submodule_pushed`` gate enforces upstream).
+        """
+        override_url = getattr(self.args, "repo_url", None)
+        override_branch = getattr(self.args, "repo_branch", None)
+        override_commit = getattr(self.args, "repo_commit", None)
+
+        url = str(override_url).strip() if override_url else self._git("config", "--get", "remote.origin.url")
+        branch = (
+            str(override_branch).strip()
+            if override_branch
+            else self._git("rev-parse", "--abbrev-ref", "HEAD")
+        )
+        commit = str(override_commit).strip() if override_commit else self._git("rev-parse", "HEAD")
+
+        if not url or not branch or not commit:
+            raise CloudProviderError(
+                "Could not resolve tuner repo source (url/branch/commit). Pass "
+                "--repo-url/--repo-branch/--repo-commit explicitly, or run inside "
+                "a git checkout with an 'origin' remote."
+            )
+        return RepoCheckoutSpec(url=url, branch=branch, commit=commit, clone_dir=_CLONE_DIR)
+
+    def _git(self, *args: str) -> str:
+        """Run a read-only ``git`` command in the repo root; '' on any failure."""
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=str(self.repo_root),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
+
+    def _resolve_image(self) -> str:
+        """Resolve the job's Docker image. Overridable via --cloud-image.
+
+        Kept as a simple, explicit knob rather than reaching into the training
+        cloud-config loader (which lives on the training namespace). A default
+        is provided so the common path needs no flag.
+        """
+        override = getattr(self.args, "cloud_image", None)
+        if override and str(override).strip():
+            return str(override).strip()
+        # A CUDA + PyTorch base sufficient for forward-only inference with PEFT.
+        return "huggingface/transformers-pytorch-gpu:latest"
+
+    def build_launch_plan(self) -> ExtractionLaunchPlan:
+        """Assemble the fully-resolved launch plan from CLI args (GPU-free).
+
+        This is the single source of truth for what both the dry-run and the
+        submit path act on, which keeps the two paths from drifting.
+        """
+        values = self._collect_required_args()
+        return ExtractionLaunchPlan(
+            extraction_config=values["extraction_config"],
+            slice_dataset_name=values["slice_dataset_name"],
+            base_model_name=values["base_model_name"],
+            base_model_revision=values["base_model_revision"],
+            adapter_repo_id=values["adapter_repo_id"],
+            adapter_revision=values["adapter_revision"],
+            output_dataset_name=values["output_dataset_name"],
+            flavor=self._resolve_flavor(),
+            timeout_hours=self._resolve_timeout_hours(),
+            image=self._resolve_image(),
+            repo=self._resolve_repo_source(),
+        )
+
+    # ------------------------------------------------------------------ #
+    # Job-spec assembly (GPU-free)
+    # ------------------------------------------------------------------ #
+    def build_extraction_command(self, plan: ExtractionLaunchPlan) -> List[str]:
+        """Build the in-job extraction command (every input passed by hub id).
+
+        Each value is shell-quoted; no local paths cross into the job because HF
+        Jobs has no research-repo mount. The base/adapter revisions are pinned
+        for reproducibility.
+        """
+        invocation = [
+            _EXTRACTION_ENTRYPOINT,
+            f"--extraction-config {shlex.quote(plan.extraction_config)}",
+            f"--slice-dataset-name {shlex.quote(plan.slice_dataset_name)}",
+            f"--base-model-name {shlex.quote(plan.base_model_name)}",
+            f"--base-model-revision {shlex.quote(plan.base_model_revision)}",
+            f"--adapter-repo-id {shlex.quote(plan.adapter_repo_id)}",
+            f"--adapter-revision {shlex.quote(plan.adapter_revision)}",
+            f"--output-dataset-name {shlex.quote(plan.output_dataset_name)}",
+        ]
+        return [
+            *build_repo_checkout_steps(plan.repo),
+            f"cd {shlex.quote(plan.repo.clone_dir)}",
+            " ".join(invocation),
+        ]
+
+    def build_job_spec(self, plan: ExtractionLaunchPlan, *, token: Optional[str]) -> CloudJobSpec:
+        """Assemble the provider-agnostic :class:`CloudJobSpec` (GPU-free).
+
+        HF_TOKEN is injected as a job SECRET (never echoed into the command or
+        labels). ``token`` may be None for dry-run, in which case no secret is
+        attached.
+        """
+        secrets = build_hf_job_secrets(token) if token else {}
+        labels = {
+            "task": "extract",
+            "base_model": plan.base_model_name,
+            "adapter_repo": plan.adapter_repo_id,
+            "output_dataset": plan.output_dataset_name,
+        }
+        return CloudJobSpec(
+            provider="hf_jobs",
+            image=plan.image,
+            command=build_bash_command(self.build_extraction_command(plan)),
+            flavor=plan.flavor,
+            timeout_hours=plan.timeout_hours,
+            secrets=secrets,
+            labels=labels,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Entry point
+    # ------------------------------------------------------------------ #
+    def handle(self) -> int:
+        # Load .env so HF_TOKEN is available for a real (non-dry-run) submit.
+        load_env_file()
+        dry_run = bool(getattr(self.args, "dry_run", False))
+
+        try:
+            plan = self.build_launch_plan()
+        except Exception as exc:
+            return self._fail(exc, code="CLOUD_EXTRACT_CONFIG_ERROR")
+
+        if dry_run:
+            return self._handle_dry_run(plan)
+
+        return self._handle_submit(plan)
+
+    def _handle_dry_run(self, plan: ExtractionLaunchPlan) -> int:
+        """Assemble + print the job spec WITHOUT submitting (no token needed)."""
+        spec = self.build_job_spec(plan, token=None)
+        command_text = spec.command[-1] if spec.command else ""
+        if self.json_mode:
+            self.output(
+                {
+                    "dry_run": True,
+                    "plan": plan.as_display(),
+                    "image": spec.image,
+                    "flavor": spec.flavor,
+                    "timeout_hours": spec.timeout_hours,
+                    "labels": spec.labels,
+                    "command": command_text,
+                }
+            )
+            return 0
+        print_header("CLOUD EXTRACT (DRY RUN)", "Forward-only hidden-state extraction on HF Jobs")
+        print_config(plan.as_display(), "Cloud Extract Plan")
+        print_info("Job command (not submitted):")
+        print(command_text)
+        return 0
+
+    def _handle_submit(self, plan: ExtractionLaunchPlan) -> int:
+        """Resolve the token + hub, confirm, and submit the extraction job."""
+        try:
+            token = get_hf_token()
+            if not token:
+                raise CloudProviderError(
+                    "HF_TOKEN not set. Required to submit cloud-extract. Set "
+                    "HF_TOKEN (or HF_API_KEY) in your .env file or environment."
+                )
+            huggingface_hub = load_huggingface_hub(require_apis=("run_job",))
+            spec = self.build_job_spec(plan, token=token)
+        except Exception as exc:
+            return self._fail(exc, code="CLOUD_EXTRACT_ENV_ERROR")
+
+        if self.json_mode:
+            # JSON mode is non-interactive: require explicit confirmation.
+            if not getattr(self.args, "auto_confirm", False):
+                self.output_error(
+                    "cloud-extract in --json mode requires --yes to submit "
+                    "(this is a cost-incurring GPU job).",
+                    code="CLOUD_EXTRACT_CONFIRM_REQUIRED",
+                )
+                return 1
+        else:
+            print_header("CLOUD EXTRACT", "Forward-only hidden-state extraction on HF Jobs")
+            print_config(plan.as_display(), "Cloud Extract Plan")
+            if not getattr(self.args, "auto_confirm", False) and not confirm(
+                "Submit this cost-incurring GPU extraction job to HF Jobs?"
+            ):
+                print_info("Cloud extract cancelled.")
+                return 0
+
+        try:
+            submission = HFJobExecutor(huggingface_hub).submit(spec)
+        except Exception as exc:
+            return self._fail(exc, code="CLOUD_EXTRACT_SUBMIT_ERROR")
+
+        if self.json_mode:
+            self.output(
+                {
+                    "submitted": True,
+                    "job_id": submission.job_id,
+                    "job_url": submission.job_url,
+                    "output_dataset": plan.output_dataset_name,
+                }
+            )
+            return 0
+        print_success(f"Cloud extraction job submitted: {submission.job_id}")
+        if submission.job_url:
+            print_info(f"Monitor at: {submission.job_url}")
+        print_info(f"Outputs will be written to hub dataset: {plan.output_dataset_name}")
+        return 0
+
+    def _fail(self, exc: Exception, *, code: str) -> int:
+        """Uniform error surface honoring --json mode."""
+        message = str(exc)
+        if self.json_mode:
+            self.output_error(message, code=code)
+        else:
+            print_error(message)
+        return 1


### PR DESCRIPTION
## Summary

Adds an Option-A HF-cloud `cloud-extract` verb for hidden-state extraction via HF Jobs. Consumed by the `experiment-runner` skill in ProfSynapse/Epistemic-Humility-Research (umbrella PR #36 there bumps the gitlink to this branch's HEAD).

- New `tuner/handlers/cloud_extract_handler.py`: registration triad (parser/router) + handler.
- **HF_TOKEN secret-only**: env → `get_hf_token` → `build_hf_job_secrets` → `CloudJobSpec.secrets` → `run_job(secrets=...)` as a kwarg separate from command/labels. Never in argv (not process-listing-visible), never on disk; dry-run uses `token=None`.
- **§6.6 no-pollution boundary HOLDS**: imports nothing under `tuner.backends.training.*` (proven by grep + AST test + counter-test).
- `tests/cloud/test_cloud_extract_handler.py`: 30 tests pass (incl. negative no-leak + error-branch coverage).

## Commits
- `f948c21` — Add cloud-extract verb for HF Jobs hidden-state extraction (Option A)
- `fa0bda2` — Harden: dry-run clone-URL userinfo redaction + SECURITY runbook note (SEC-L1), LOW-1..4 error-branch coverage (CONFIG_ERROR/ENV_ERROR/SUBMIT_ERROR), is-not-None override semantics.

## Peer review
Reviewed as part of Epistemic-Humility-Research #40 (5 parallel reviewers, APPROVE, zero blocking). SEC-L1 dry-run redaction + LOW-1..4 remediated in fa0bda2. Submit-path hardening + in-job `tuner.cloud.extraction_runner` deferred (tracked downstream, post-KTO, approval-gated).

## Not in scope
Pre-existing baseline test failure `test_cloud_jobs_handler.py::test_resolve_stage_artifact_root_decodes_encoded_labels` at 040054021c (not a regression from this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)