### PR TITLE
[codex] Fix GRPO custom reward dataclass loading

### DIFF
--- a/Trainers/grpo/src/rewards.py
+++ b/Trainers/grpo/src/rewards.py
@@ -16,6 +16,7 @@ import importlib
 import importlib.util
 import json
 import re
+import sys
 from pathlib import Path
 from types import ModuleType
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -588,6 +589,7 @@ def build_combined_reward_function(
                 spec = importlib.util.spec_from_file_location("custom_rewards", str(path))
                 if spec and spec.loader:
                     module = importlib.util.module_from_spec(spec)
+                    sys.modules[spec.name] = module
                     spec.loader.exec_module(module)
 
                     for fn_cfg in custom.get("functions", []) or []:

--- a/tests/trainers/grpo/test_fitness_reward.py
+++ b/tests/trainers/grpo/test_fitness_reward.py
@@ -16,7 +16,12 @@ sys.path.insert(0, str(ROOT))
 # Also add GRPO src so rewards module is importable directly
 sys.path.insert(0, str(ROOT / "Trainers" / "grpo" / "src"))
 
-from rewards import fitness_reward, build_fitness_reward, _coerce_to_text
+from rewards import (
+    fitness_reward,
+    build_fitness_reward,
+    build_combined_reward_function,
+    _coerce_to_text,
+)
 
 
 # --- Valid Qwen-format tool call output for testing ---
@@ -185,3 +190,39 @@ class TestBuildFitnessReward:
         reward_fn([VALID_TOOL_CALL])
 
         mock_evaluator_cls.assert_called_with(config_path="my/custom/rules.yaml")
+
+
+def test_custom_reward_file_with_dataclass_loads(tmp_path):
+    reward_file = tmp_path / "custom_reward.py"
+    reward_file.write_text(
+        "\n".join(
+            [
+                "from dataclasses import dataclass",
+                "",
+                "@dataclass(frozen=True)",
+                "class RewardSettings:",
+                "    value: float = 0.75",
+                "",
+                "def dataclass_reward(completions, prompts=None, **kwargs):",
+                "    settings = RewardSettings()",
+                "    return [settings.value for _ in completions]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    reward_fn, plan = build_combined_reward_function(
+        {
+            "items": [],
+            "custom": {
+                "enabled": True,
+                "file": str(reward_file),
+                "functions": [{"name": "dataclass_reward", "weight": 1.0}],
+            },
+        },
+        base_dir=tmp_path,
+    )
+
+    assert plan == [{"type": "custom", "name": "dataclass_reward", "weight": 1.0}]
+    assert reward_fn(["a", "b"]) == [0.75, 0.75]


### PR DESCRIPTION
## Summary
- register dynamically loaded custom reward modules in sys.modules before exec_module
- add a GRPO reward-loader regression test covering dataclass-decorated custom rewards

## Why
Python dataclasses inspect sys.modules during class processing. Custom GRPO reward files that define dataclasses can crash during dynamic import if the module is not registered before execution.

## Validation
- python -m pytest synaptic-tuner/tests/trainers/grpo/test_fitness_reward.py -q
