### PR TITLE
Support native chat template kwargs in GRPO

### DIFF
--- a/Trainers/grpo/src/data_loader.py
+++ b/Trainers/grpo/src/data_loader.py
@@ -8,7 +8,7 @@ Expected dataset shape for tool-calling:
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Any, Optional
 
 from datasets import Dataset, load_dataset
 
@@ -47,10 +47,12 @@ def format_dataset_for_grpo(
     tokenizer: object,
     prompt_column: str = "prompt",
     num_proc: int = 1,
+    chat_template_kwargs: Optional[dict[str, Any]] = None,
 ) -> Dataset:
     """
     Ensure dataset has a string `prompt` field usable by GRPOTrainer.
     """
+    template_kwargs = dict(chat_template_kwargs or {})
 
     def _format_example(example):
         prompt_value = example.get(prompt_column)
@@ -64,6 +66,7 @@ def format_dataset_for_grpo(
                 prompt_value,
                 tokenize=False,
                 add_generation_prompt=True,
+                **template_kwargs,
             )
 
         # Keep all original fields (for rewards), but replace prompt with string

--- a/Trainers/grpo/train_grpo.py
+++ b/Trainers/grpo/train_grpo.py
@@ -237,8 +237,11 @@ def run(args: argparse.Namespace) -> Dict[str, Any]:
 
     # Apply chat template (config override wins; else inferred)
     chat_template_name = model_cfg.get('chat_template') or _detect_chat_template(model_cfg['model_name'])
-    tokenizer = get_chat_template(tokenizer, chat_template=chat_template_name)
-    print(f"✓ Applied {chat_template_name} chat template via Unsloth")
+    if str(chat_template_name).lower() in {"native", "tokenizer"}:
+        print("Preserving tokenizer-native chat template")
+    else:
+        tokenizer = get_chat_template(tokenizer, chat_template=chat_template_name)
+        print(f"✓ Applied {chat_template_name} chat template via Unsloth")
 
     # Apply LoRA for GRPO training
     # (If loading from SFT checkpoint, the SFT LoRA was already merged into base weights)
@@ -339,6 +342,7 @@ def run(args: argparse.Namespace) -> Dict[str, Any]:
         tokenizer=tokenizer,
         prompt_column=dataset_cfg.get('prompt_column', 'prompt'),
         num_proc=dataset_cfg.get('num_proc', 1),
+        chat_template_kwargs=training_cfg.get('chat_template_kwargs'),
     )
 
     # Training args

--- a/tests/trainers/grpo/test_data_loader_chat_template_kwargs.py
+++ b/tests/trainers/grpo/test_data_loader_chat_template_kwargs.py
@@ -1,0 +1,55 @@
+"""chat_template_kwargs passthrough for GRPO prompt formatting."""
+
+from pathlib import Path
+import sys
+
+from datasets import Dataset
+
+
+GRPO_SRC = Path(__file__).resolve().parents[3] / "Trainers" / "grpo" / "src"
+sys.path.insert(0, str(GRPO_SRC))
+
+import data_loader  # noqa: E402
+
+
+class RecordingTokenizer:
+    def __init__(self):
+        self.calls = []
+
+    def apply_chat_template(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        return f"formatted prompt | enable_thinking={kwargs.get('enable_thinking')}"
+
+
+def test_format_dataset_for_grpo_forwards_chat_template_kwargs():
+    tokenizer = RecordingTokenizer()
+    dataset = Dataset.from_list(
+        [
+            {
+                "prompt": [{"role": "user", "content": "Question?"}],
+                "label": "known",
+            }
+        ]
+    )
+
+    formatted = data_loader.format_dataset_for_grpo(
+        dataset,
+        tokenizer=tokenizer,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert formatted[0]["prompt"] == "formatted prompt | enable_thinking=False"
+
+
+def test_format_dataset_for_grpo_skips_template_for_preformatted_prompt():
+    tokenizer = RecordingTokenizer()
+    dataset = Dataset.from_list([{"prompt": "already formatted", "label": "known"}])
+
+    formatted = data_loader.format_dataset_for_grpo(
+        dataset,
+        tokenizer=tokenizer,
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    assert formatted[0]["prompt"] == "already formatted"
+    assert tokenizer.calls == []


### PR DESCRIPTION
## Summary
- Add GRPO formatter passthrough for tokenizer.apply_chat_template kwargs
- Add a native/tokenizer chat-template mode so Qwen-style tokenizer-native templates can be preserved
- Cover kwargs passthrough with focused GRPO data-loader tests

## Validation
- python -m pytest synaptic-tuner/tests/trainers/grpo/test_data_loader_chat_template_kwargs.py -q
- python -m pytest experiment/phase1/grpo/tests/test_humility_reward.py experiment/phase1/grpo/tests/test_build_grpo_dataset.py synaptic-tuner/tests/trainers/grpo/test_data_loader_chat_template_kwargs.py synaptic-tuner/tests/trainers/grpo/test_fitness_reward.py -q
- Local base GRPO smoke completed with native Qwen template and nonzero reward variance under project config