### PR TITLE
feat: config-driven quality gate, name-leak gate, token usage, progress stream

### DIFF
--- a/Evaluator/reporting.py
+++ b/Evaluator/reporting.py
@@ -42,6 +42,61 @@ def _judge_normalized_score(records: Sequence[EvaluationRecord]) -> Optional[flo
     return sum(composites) / len(composites)
 
 
+def _judge_case_quality_gated(record: EvaluationRecord) -> Optional[float]:
+    """Per-case "quality gated" composite = mean of each rubric's gated score.
+
+    The gated score is the optional floors-as-gates composite the judge layer
+    computes when a rubric carries a ``quality_gate`` config (0.0 on a floor
+    breach, else the renormalized quality-only composite). Returns None when the
+    case has no judge result or no rubric carried a gated score (so a run without
+    any quality_gate stays byte-identical -- no gated stat is emitted). For the
+    single-rubric case this degenerates to that rubric's gated score.
+    """
+    judge = record.judge
+    if judge is None:
+        return None
+    gated = [
+        s.quality_gated_score
+        for s in judge.judge_result.scores
+        if s.quality_gated_score is not None
+    ]
+    if not gated:
+        return None
+    return sum(gated) / len(gated)
+
+
+def _quality_gated_normalized_score(records: Sequence[EvaluationRecord]) -> Optional[float]:
+    """Run-level quality-gated gradient = mean across cases of each gated composite.
+
+    Parallel to _judge_normalized_score but over the floors-as-gates composite.
+    None when no case carries a gated score (no rubric in the run had a
+    quality_gate configured), so the stat is simply absent on the default-off
+    path and the existing judge_normalized_score is never affected.
+    """
+    gated = [g for record in records if (g := _judge_case_quality_gated(record)) is not None]
+    if not gated:
+        return None
+    return sum(gated) / len(gated)
+
+
+def _quality_gated_min_normalized_score(records: Sequence[EvaluationRecord]) -> Optional[float]:
+    """Run-level WORST-case quality-gated score = min across cases of each gated composite.
+
+    Parallel to _quality_gated_normalized_score but takes the MIN instead of the
+    mean, so a candidate is scored by its weakest case rather than its average.
+    Selecting the optimizer on this applies topic-diversity selection pressure: a
+    prompt that aces one topic but drifts off another is penalized by the drifted
+    case, whereas the mean would let a strong case mask it. None under exactly the
+    same condition as the mean variant (no case carries a gated score -- no rubric
+    had a quality_gate configured), so the stat is absent on the default-off path
+    and never affects the existing judge/mean gradients.
+    """
+    gated = [g for record in records if (g := _judge_case_quality_gated(record)) is not None]
+    if not gated:
+        return None
+    return min(gated)
+
+
 def aggregate_stats(records: Sequence[EvaluationRecord]) -> Dict[str, Any]:
     total = len(records)
     errors = sum(1 for record in records if record.error)
@@ -71,6 +126,16 @@ def aggregate_stats(records: Sequence[EvaluationRecord]) -> Dict[str, Any]:
     # judge composite so normalized_score can reflect it when path-scoring is
     # absent. None when no case has a judge (non-judge runs are unaffected).
     judge_normalized_score = _judge_normalized_score(records)
+    # Optional floors-as-gates selection gradient: present only when a rubric in
+    # the run carries a quality_gate config (else None -> absent stat, the
+    # judge_normalized_score path is byte-identical). The optimizer selects on this
+    # by pointing objective.metric at stats.quality_gated_normalized_score.
+    quality_gated_normalized_score = _quality_gated_normalized_score(records)
+    # Worst-case sibling of the gated mean: min across cases of the gated composite.
+    # Same None condition (no rubric carried a quality_gate -> absent stat). The
+    # optimizer applies topic-diversity selection pressure by pointing
+    # objective.metric at stats.quality_gated_min_normalized_score.
+    quality_gated_min_normalized_score = _quality_gated_min_normalized_score(records)
     episode_recoveries = sum(
         1
         for record in records
@@ -223,6 +288,16 @@ def aggregate_stats(records: Sequence[EvaluationRecord]) -> Dict[str, Any]:
         # Surfaced separately so the report shows the judge gradient's provenance
         # (None when no judge ran).
         "judge_normalized_score": judge_normalized_score,
+        # Optional floors-as-gates selection gradient (None unless a rubric carried
+        # a quality_gate config). Emitted ALONGSIDE judge_normalized_score; the
+        # weighted composite path above is untouched. The optimizer can select on
+        # this via objective.metric=stats.quality_gated_normalized_score.
+        "quality_gated_normalized_score": quality_gated_normalized_score,
+        # Worst-case sibling of the gated mean (min across cases). Emitted alongside
+        # the mean; None unless a rubric carried a quality_gate. The optimizer can
+        # select on this via objective.metric=stats.quality_gated_min_normalized_score
+        # to apply topic-diversity selection pressure.
+        "quality_gated_min_normalized_score": quality_gated_min_normalized_score,
         "episode_recoveries": episode_recoveries,
         "by_tag": {
             tag: {

--- a/shared/judge/judge_service.py
+++ b/shared/judge/judge_service.py
@@ -10,7 +10,7 @@ Summary: Executes a single LLM judge call via BaseLLMClient.structured_output(),
 
 import logging
 import time
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from shared.llm import BaseLLMClient
 
@@ -217,6 +217,8 @@ class JudgeService:
 
         composite = max(0.0, min(1.0, composite))
 
+        quality_gated_score = self._compute_quality_gated_score(rubric, per_dimension)
+
         return JudgeScore(
             rubric_key=rubric.key,
             rubric_name=rubric.name,
@@ -225,7 +227,102 @@ class JudgeService:
             pass_threshold=rubric.pass_threshold,
             feedback=feedback,
             per_dimension=per_dimension,
+            quality_gated_score=quality_gated_score,
         )
+
+    def _compute_quality_gated_score(
+        self,
+        rubric: RubricDef,
+        per_dimension: List[Dict[str, Any]],
+    ) -> Optional[float]:
+        """Compute the floors-as-gates "quality gated" composite, or None.
+
+        This is a SECOND, optional selection composite that pulls the rubric's
+        safety-floor dimensions OUT of the weighted score and treats them as hard
+        gates instead. It is config-driven and fully generic: every domain-specific
+        value (which dims are floors, the floor threshold, the quality weights)
+        comes from ``rubric.quality_gate`` (loaded from the rubric YAML). When no
+        quality_gate is configured this returns None and the default-off path is
+        byte-identical (no gated stat is ever emitted downstream).
+
+        Mechanism (architect-ratified, floors-as-gates / gate-not-weight):
+          * If ANY configured floor dim scores < floor_threshold, the case is
+            hard-eliminated: the gated composite is 0.0.
+          * Otherwise the gated composite is the weighted sum over the configured
+            NON-floor "quality" dimensions, using the renormalized quality_weights.
+
+        FAIL-CLOSED contract: if a configured floor or quality dimension key is
+        absent from the judge's per-dimension output, this raises ValueError rather
+        than silently treating the missing dim as passing/zero. A missing floor dim
+        must never silently pass the gate (it is a privacy/quality safety control),
+        and a missing quality dim means a malformed config that must surface, not
+        produce a quietly-wrong selection score. judge() converts the raise into a
+        failed JudgeResult, so the candidate is not selected on a bad metric.
+
+        Args:
+            rubric: The dimensioned rubric (carries the optional quality_gate).
+            per_dimension: The per-dimension breakdown already computed for this
+                rubric (list of {key, name, weight, reasoning, score}).
+
+        Returns:
+            The gated composite (0.0-1.0), 0.0 on a floor breach, or None when the
+            rubric has no quality_gate configured.
+
+        Raises:
+            ValueError: On a structurally invalid quality_gate config or a
+                configured dimension key missing from per_dimension (fail-closed).
+        """
+        gate = rubric.quality_gate
+        if not gate:
+            return None
+
+        floor_dims = gate.get("floor_dims") or []
+        quality_weights = gate.get("quality_weights") or {}
+        if not isinstance(floor_dims, list) or not isinstance(quality_weights, dict):
+            raise ValueError(
+                f"Rubric '{rubric.key}' quality_gate must define a 'floor_dims' list "
+                f"and a 'quality_weights' mapping."
+            )
+        if not quality_weights:
+            raise ValueError(
+                f"Rubric '{rubric.key}' quality_gate.quality_weights is empty; "
+                f"a gated composite needs at least one quality dimension."
+            )
+        try:
+            floor_threshold = float(gate.get("floor_threshold", 0.0))
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Rubric '{rubric.key}' quality_gate.floor_threshold is not numeric: "
+                f"{gate.get('floor_threshold')!r}"
+            )
+
+        # Index the per-dimension scores the judge actually produced.
+        scores_by_key = {dim["key"]: dim["score"] for dim in per_dimension}
+
+        # FAIL-CLOSED: every configured floor dim must be present. A missing floor
+        # dim must NOT silently pass the gate.
+        for dim_key in floor_dims:
+            if dim_key not in scores_by_key:
+                raise ValueError(
+                    f"Rubric '{rubric.key}' quality_gate floor dim '{dim_key}' is not "
+                    f"in the judge's per-dimension output {sorted(scores_by_key)}; "
+                    f"failing closed rather than treating it as passing."
+                )
+            if scores_by_key[dim_key] < floor_threshold:
+                # Hard-eliminate: a floor breach zeroes the gated selection score.
+                return 0.0
+
+        # FAIL-CLOSED: every configured quality dim must be present too.
+        gated = 0.0
+        for dim_key, weight in quality_weights.items():
+            if dim_key not in scores_by_key:
+                raise ValueError(
+                    f"Rubric '{rubric.key}' quality_gate quality dim '{dim_key}' is not "
+                    f"in the judge's per-dimension output {sorted(scores_by_key)}."
+                )
+            gated += float(weight) * scores_by_key[dim_key]
+
+        return max(0.0, min(1.0, gated))
 
     def _validate_dimension_weights(self, rubric: RubricDef) -> Dict[str, float]:
         """Validate dimension weights and return a {key: weight} map.

--- a/shared/judge/models.py
+++ b/shared/judge/models.py
@@ -37,6 +37,22 @@ class RubricDef:
             contract and a sum != 1.0 (beyond tolerance) is a hard error. When
             False/None (placeholder rubrics pending client sign-off), a non-unit
             weight sum is normalized-and-warned instead of failing the run.
+        quality_gate: Optional, generic config for a SECOND selection composite
+            that pulls "safety floor" dimensions OUT of the weighted score and
+            treats them as hard gates instead (floors-as-gates). Absent (None),
+            behavior is byte-identical: only the weighted ``score`` composite is
+            computed. When present it is a dict with three keys, all generic so
+            the engine carries no domain knowledge (the actual dimension names,
+            threshold, and weights live in the rubric YAML):
+              * ``floor_dims`` (list[str]): dimension keys that act as hard gates.
+              * ``floor_threshold`` (float): any floor dim scoring below this
+                eliminates the case (gated composite -> 0.0).
+              * ``quality_weights`` (dict[str, float]): the weights over the
+                NON-floor "quality" dimensions used to compute the gated composite
+                when all floors pass. Keys must be dimensions present in
+                ``dimensions``; the engine FAILS CLOSED if a configured floor or
+                quality key is absent from the judge's per-dimension output (see
+                JudgeService._score_dimensioned_rubric).
     """
 
     key: str
@@ -49,6 +65,7 @@ class RubricDef:
     improver_prompt: Optional[str] = None
     dimensions: Optional[List[Dict[str, Any]]] = None
     weights_ratified: bool = False
+    quality_gate: Optional[Dict[str, Any]] = None
 
 
 @dataclass
@@ -71,6 +88,13 @@ class JudgeScore:
             ``key``, ``name``, ``weight``, ``reasoning`` (the judge's reason-first
             justification), and ``score`` (the bare per-dimension score). None for
             legacy single-composite rubrics.
+        quality_gated_score: Optional SECOND composite, populated only when the
+            rubric carries a ``quality_gate`` config (floors-as-gates). It is the
+            renormalized quality-only composite, or 0.0 when any floor dimension
+            scored below the configured floor_threshold (hard-eliminate). None when
+            no quality_gate is configured, so the default-off path is byte-identical
+            and downstream readers (reporting) emit no gated stat. This is a
+            SELECTION-alternative view; the weighted ``score`` above is untouched.
     """
 
     rubric_key: str
@@ -80,6 +104,7 @@ class JudgeScore:
     pass_threshold: float
     feedback: Optional[str] = None
     per_dimension: Optional[List[Dict[str, Any]]] = None
+    quality_gated_score: Optional[float] = None
 
 
 @dataclass
@@ -117,6 +142,7 @@ class JudgeResult:
                     "pass_threshold": s.pass_threshold,
                     "feedback": s.feedback,
                     "per_dimension": s.per_dimension,
+                    "quality_gated_score": s.quality_gated_score,
                 }
                 for s in self.scores
             ],

--- a/shared/judge/rubric_loader.py
+++ b/shared/judge/rubric_loader.py
@@ -82,6 +82,7 @@ class RubricLoader:
             improver_prompt=data.get("improver_prompt"),
             dimensions=data.get("dimensions"),
             weights_ratified=bool(data.get("weights_ratified", False)),
+            quality_gate=data.get("quality_gate"),
         )
 
     def load_many(self, rubric_keys: List[str]) -> List[RubricDef]:

--- a/shared/llm/providers/openai_responses.py
+++ b/shared/llm/providers/openai_responses.py
@@ -32,6 +32,12 @@ class OpenAIResponsesClient(BaseLLMClient):
         self.store = bool(store)
         self.structured_output_strict = bool(structured_output_strict)
         self.thinking_effort = _normalize_thinking_effort(thinking_effort)
+        # Token-usage from the most recent request, for cost instrumentation.
+        # The Responses API returns a ``usage`` block on every response; we cache
+        # it here (additively, no return-signature change) so callers that care
+        # about cost can read ``client.last_usage`` after a chat/structured_output
+        # call. None until the first request; None again if a response omits usage.
+        self.last_usage: Dict[str, Any] | None = None
 
     @property
     def provider_name(self) -> str:
@@ -186,7 +192,11 @@ class OpenAIResponsesClient(BaseLLMClient):
                 timeout=self.timeout_seconds,
             )
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+            # Cache token usage for cost instrumentation (additive; never raises).
+            usage = data.get("usage") if isinstance(data, dict) else None
+            self.last_usage = usage if isinstance(usage, dict) else None
+            return data
         except requests.exceptions.ConnectionError as e:
             raise LLMConnectionError(f"Cannot connect to OpenAI Responses API: {e}")
         except requests.exceptions.Timeout as e:

--- a/shared/prompt_optimization/evaluators.py
+++ b/shared/prompt_optimization/evaluators.py
@@ -47,6 +47,19 @@ class EvaluatorScoringAdapter:
             raise EvaluatorScoringConfigError("evaluation.evaluator.failure_policy must be 'score_floor' or 'raise'.")
         self.objective = _mapping(self.evaluator_config.get("objective"), "evaluation.evaluator.objective")
         self.objective_metric = str(self.objective.get("metric") or "stats.normalized_score")
+        # Optional, default-OFF per-case-records persistence. When enabled, each
+        # candidate's metrics carry a `case_records` array (one full per-case dict
+        # via reporting.record_to_dict) so downstream analysis reads ready-made
+        # judge/dimension/text fields instead of re-deriving them from a re-run.
+        # Default False keeps the candidate payload byte-identical (only the thin
+        # `records` summary survives), so this never bloats existing runs. The
+        # heavy `raw_response` blob is omitted from each case record by default
+        # (persist_raw_response) to keep the candidate stream small and tailable;
+        # a compact `usage` summary is extracted from it instead.
+        self.persist_case_records = bool(self.evaluator_config.get("persist_case_records", False))
+        self.persist_raw_response = bool(
+            self.evaluator_config.get("persist_raw_response", False)
+        )
         try:
             self.pass_threshold = float(self.objective.get("pass_threshold", 1.0))
         except (TypeError, ValueError) as exc:
@@ -79,7 +92,7 @@ class EvaluatorScoringAdapter:
     def _score(self, genome_values: Mapping[str, str], subjects: Sequence[PromptSubject]) -> PromptEvaluationScore:
         from Evaluator.client_factory import create_client, create_settings
         from Evaluator.config_loader import ConfigLoader
-        from Evaluator.reporting import aggregate_stats
+        from Evaluator.reporting import aggregate_stats, record_to_dict
         from Evaluator.runner import evaluate_cases
 
         config_dir = self._resolve_path(str(self.evaluator_config.get("config_dir", "Evaluator/config")))
@@ -223,33 +236,68 @@ class EvaluatorScoringAdapter:
             )
         raw_score = _resolve_metric(metric_context, self.objective_metric)
         normalized = _normalize_score(raw_score, self.objective)
+        metrics: dict[str, Any] = {
+            "normalized_score": normalized,
+            "objective_metric": self.objective_metric,
+            "objective_value": raw_score,
+            "evaluator_stats": stats,
+            "case_count": len(records),
+        }
+        # Default-OFF: only when persist_case_records is configured do we attach the
+        # full per-case dicts. This rides through _evolution_candidate_to_dict for
+        # free (metrics is serialized wholesale), so analysis tooling reads
+        # response_text / judge dimensions / correctness verdicts directly from the
+        # candidate stream instead of re-running the winner. Each record is reduced
+        # by _case_record_for_persistence (raw_response stripped to a compact usage
+        # summary unless explicitly opted in).
+        if self.persist_case_records:
+            metrics["case_records"] = [
+                _case_record_for_persistence(
+                    record_to_dict(record),
+                    include_raw_response=self.persist_raw_response,
+                )
+                for record in records
+            ]
         return PromptEvaluationScore(
             score=normalized,
-            metrics={
-                "normalized_score": normalized,
-                "objective_metric": self.objective_metric,
-                "objective_value": raw_score,
-                "evaluator_stats": stats,
-                "case_count": len(records),
-            },
+            metrics=metrics,
             passed=normalized >= self.pass_threshold,
             diagnostics=tuple(_record_diagnostics(records)),
         )
 
-    def _judge_metric_unresolved(self, stats: Mapping[str, Any]) -> bool:
-        """True when the objective targets the judge gradient but it is None.
+    # Judge-derived run-level gradient stats that legitimately go None when no
+    # case produced the underlying signal (no case judged, or -- for the gated
+    # variant -- every case was gate-rejected so there is no gradient to mean).
+    # Selecting on any of these must degrade to score_floor, not crash
+    # _resolve_metric on the None. The mapping is objective_metric -> stats key.
+    _NULLABLE_GRADIENT_METRICS = {
+        "stats.judge_normalized_score": "judge_normalized_score",
+        "stats.quality_gated_normalized_score": "quality_gated_normalized_score",
+        "stats.quality_gated_min_normalized_score": "quality_gated_min_normalized_score",
+    }
 
-        Only fires for the stats.judge_normalized_score objective (the judge
-        gradient is None when no case was judged). Any other objective keeps the
-        strict numeric contract enforced by _resolve_metric. Honours
-        failure_policy='raise' by NOT short-circuiting (the caller proceeds to
-        _resolve_metric, which raises on the None as before).
+    def _judge_metric_unresolved(self, stats: Mapping[str, Any]) -> bool:
+        """True when the objective targets a judge gradient stat but it is None.
+
+        Fires for any of the judge-derived gradient objectives in
+        _NULLABLE_GRADIENT_METRICS (the plain judge gradient
+        stats.judge_normalized_score, the floors-as-gates mean
+        stats.quality_gated_normalized_score, and its worst-case sibling
+        stats.quality_gated_min_normalized_score). The gradient is None when no case
+        produced the underlying signal -- for the gated metric, that includes the
+        ALL-REJECT edge where every candidate's cases trip a floor (each
+        per-case gated value is 0.0, which still yields a numeric mean; the None
+        case is when no rubric carried a quality_gate / no case was judged at all).
+        Any other objective keeps the strict numeric contract enforced by
+        _resolve_metric. Honours failure_policy='raise' by NOT short-circuiting
+        (the caller proceeds to _resolve_metric, which raises on the None as before).
         """
-        if self.objective_metric != "stats.judge_normalized_score":
+        stats_key = self._NULLABLE_GRADIENT_METRICS.get(self.objective_metric)
+        if stats_key is None:
             return False
         if self.failure_policy == "raise":
             return False
-        return stats.get("judge_normalized_score") is None
+        return stats.get(stats_key) is None
 
     def _runtime_failure_score(self, exc: Exception) -> PromptEvaluationScore:
         diagnostic = {
@@ -491,6 +539,56 @@ def _record_summary(record: Any) -> dict[str, Any]:
         "score": record.score,
         "scoring": scoring,
     }
+
+
+def _usage_summary(raw_response: Any) -> dict[str, Any] | None:
+    """Compact, analysis-ready token usage pulled from a target raw_response.
+
+    The OpenAI Responses provider stores the full response (including its
+    ``usage`` block) on ``record.raw_response`` (runner.py raw_response=response.raw).
+    This lifts just the token counts into a small dict so per-case cost is parseable
+    without carrying the whole response blob. Returns None when no usage block is
+    present (e.g. dry-run, structural-only, or a provider that omits usage), so the
+    field is simply absent rather than a misleading zero.
+    """
+    if not isinstance(raw_response, Mapping):
+        return None
+    usage = raw_response.get("usage")
+    if not isinstance(usage, Mapping):
+        return None
+    summary: dict[str, Any] = {}
+    # Responses API uses input_tokens/output_tokens/total_tokens; copy whatever is
+    # present (and the detail sub-dicts when given) without assuming a fixed shape.
+    for key in ("input_tokens", "output_tokens", "total_tokens"):
+        value = usage.get(key)
+        if isinstance(value, (int, float)):
+            summary[key] = value
+    for detail_key in ("input_tokens_details", "output_tokens_details"):
+        detail = usage.get(detail_key)
+        if isinstance(detail, Mapping):
+            summary[detail_key] = dict(detail)
+    return summary or None
+
+
+def _case_record_for_persistence(
+    record_dict: dict[str, Any], *, include_raw_response: bool
+) -> dict[str, Any]:
+    """Reduce a full record_to_dict() payload for candidate-stream persistence.
+
+    By default drops the heavy ``raw_response`` blob (it can be large and is not
+    needed for score analysis) and replaces it with a compact ``usage`` summary so
+    per-case token cost stays parseable. When ``include_raw_response`` is set, the
+    full blob is preserved verbatim instead. All other fields (judge dimensions,
+    correctness verdict, response_text, tags, ...) pass through unchanged.
+    """
+    out = dict(record_dict)
+    raw_response = out.get("raw_response")
+    usage = _usage_summary(raw_response)
+    if not include_raw_response:
+        out.pop("raw_response", None)
+    if usage is not None:
+        out["usage"] = usage
+    return out
 
 
 def _record_diagnostics(records: Iterable[Any]) -> list[dict[str, Any]]:

--- a/shared/prompt_optimization/service.py
+++ b/shared/prompt_optimization/service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import random
 import re
 from dataclasses import asdict, dataclass
@@ -233,6 +234,16 @@ class PromptOptimizationService:
         min_delta = float(stopping.get("min_delta", 0.0))
         score_floor = float(self.config.get("score_floor", 0.0))
 
+        # OPTIONAL per-candidate progress stream. When ``progress_stream`` is set
+        # (absolute path, or relative to output_dir), each candidate is appended
+        # to it the instant it is scored, so a long evolutionary run is observable
+        # in real time instead of silent until the run-end candidate_history flush.
+        # Disabled by default (None) — pure addition, no behavior change otherwise.
+        progress_stream_path = self._resolve_progress_stream_path(output_dir)
+        if progress_stream_path is not None:
+            progress_stream_path.parent.mkdir(parents=True, exist_ok=True)
+            progress_stream_path.write_text("", encoding="utf-8")  # fresh per run
+
         population = self._initial_population(subjects, population_size, rng)
         all_candidates: list[EvolutionCandidate] = []
         generation_rows: list[dict[str, Any]] = []
@@ -242,15 +253,22 @@ class PromptOptimizationService:
         stop_reason = "max_generations"
 
         for generation in range(max_generations):
-            evaluated = [
-                self._evaluate_genome(
+            evaluated = []
+            for candidate in population:
+                scored = self._evaluate_genome(
                     candidate,
                     subjects,
                     score_floor=score_floor,
                     evaluator_adapter=evaluator_adapter,
                 )
-                for candidate in population
-            ]
+                evaluated.append(scored)
+                # Stream this candidate the instant it is scored (if enabled), so
+                # progress is observable live rather than only at the run-end flush.
+                if progress_stream_path is not None:
+                    _append_jsonl_durable(
+                        progress_stream_path,
+                        self._evolution_candidate_to_dict(scored),
+                    )
             ranked = sorted(evaluated, key=lambda item: (item.score, -item.index, item.id), reverse=True)
             elites = ranked[:elite_count]
             selected_ids = {candidate.id for candidate in elites}
@@ -410,6 +428,21 @@ class PromptOptimizationService:
         path = Path(str(raw)).expanduser()
         if not path.is_absolute():
             path = self.repo_root / path
+        return path.resolve()
+
+    def _resolve_progress_stream_path(self, output_dir: Path) -> Path | None:
+        """Resolve the OPTIONAL per-candidate progress-stream path, or None.
+
+        ``progress_stream`` may be absolute, or relative to the run's output_dir
+        (the natural home for a run artifact). Absent/blank -> None (streaming
+        disabled; the run behaves exactly as before).
+        """
+        raw = self.config.get("progress_stream")
+        if not raw or not str(raw).strip():
+            return None
+        path = Path(str(raw)).expanduser()
+        if not path.is_absolute():
+            path = output_dir / path
         return path.resolve()
 
     def _load_subjects(self) -> list[PromptSubject]:
@@ -1191,3 +1224,18 @@ def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
     with path.open("w", encoding="utf-8") as fh:
         for row in rows:
             fh.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _append_jsonl_durable(path: Path, row: dict[str, Any]) -> None:
+    """Append one row to a JSONL and flush+fsync so a tailer sees it immediately.
+
+    Used for OPTIONAL per-candidate progress streaming: when ``progress_stream``
+    is configured, each candidate is appended the moment it is scored (rather than
+    only at the run-end ``candidate_history.jsonl`` flush), so an external watcher
+    can observe incremental progress in real time. The flush + fsync defeat OS
+    buffering; without them a long run looks silent until it completes.
+    """
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(row, sort_keys=True) + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())

--- a/tests/prompt_optimization/test_evaluator_adapter.py
+++ b/tests/prompt_optimization/test_evaluator_adapter.py
@@ -456,6 +456,119 @@ class _FakeRecord:
         return None
 
 
+# ---------------------------------------------------------------------------
+# _judge_metric_unresolved: the None-guard for judge-derived gradient metrics.
+# Extended (Task #23) to ALSO cover stats.quality_gated_normalized_score so the
+# all-reject / no-gate edges degrade to score_floor instead of crashing
+# _resolve_metric on a None. Unit-tested directly (no filesystem / LLM).
+# ---------------------------------------------------------------------------
+
+def _make_adapter(*, metric: str, failure_policy: str = "score_floor"):
+    from shared.prompt_optimization.evaluators import EvaluatorScoringAdapter
+
+    evaluation_config = {
+        "evaluator": {
+            "failure_policy": failure_policy,
+            "objective": {"metric": metric},
+            "prompt_placement": {
+                "mode": "system_overlay",
+                "template": "{candidate_prompt}\n\n{system}",
+            },
+        }
+    }
+    return EvaluatorScoringAdapter(
+        evaluation_config=evaluation_config,
+        config_path=Path("unused.yaml"),
+        repo_root=Path("."),
+        score_floor=0.2,
+    )
+
+
+def test_judge_metric_unresolved_fires_for_judge_gradient_when_none():
+    adapter = _make_adapter(metric="stats.judge_normalized_score")
+    assert adapter._judge_metric_unresolved({"judge_normalized_score": None}) is True
+
+
+def test_judge_metric_unresolved_fires_for_quality_gated_when_none():
+    """The new gated metric joins the None-guard: a None gated gradient (no rubric
+    carried a quality_gate / no case judged) degrades to floor, not a crash."""
+    adapter = _make_adapter(metric="stats.quality_gated_normalized_score")
+    assert adapter._judge_metric_unresolved({"quality_gated_normalized_score": None}) is True
+
+
+def test_quality_gated_all_reject_is_numeric_zero_not_none():
+    """ALL-REJECT edge: every case trips a floor -> each per-case gated value is 0.0
+    -> the run-level mean is a numeric 0.0, NOT None. So the guard does NOT fire and
+    _resolve_metric consumes 0.0 cleanly (worst candidate, no crash). This is the
+    distinction the guard's None-path and the helper's numeric-path must both honour.
+    """
+    from Evaluator.reporting import _quality_gated_normalized_score
+
+    class _Judge:
+        def __init__(self, scores):
+            self.judge_result = type("R", (), {"scores": scores})()
+
+    class _Score:
+        def __init__(self, gated):
+            self.quality_gated_score = gated
+
+    class _Record:
+        def __init__(self, judge):
+            self.judge = judge
+
+    # Two cases, BOTH gate-rejected (gated == 0.0 each).
+    records = [_Record(_Judge([_Score(0.0)])), _Record(_Judge([_Score(0.0)]))]
+    result = _quality_gated_normalized_score(records)
+    assert result == 0.0
+    assert result is not None  # numeric zero, not the None default-off path
+
+    # And the guard does NOT fire on a numeric 0.0 stat (only on None).
+    adapter = _make_adapter(metric="stats.quality_gated_normalized_score")
+    assert adapter._judge_metric_unresolved({"quality_gated_normalized_score": 0.0}) is False
+
+
+def test_judge_metric_unresolved_does_not_fire_for_other_metrics():
+    adapter = _make_adapter(metric="stats.pass_rate")
+    # Even with a None gated gradient present, a non-gradient objective keeps the
+    # strict numeric contract (guard returns False -> _resolve_metric handles it).
+    assert adapter._judge_metric_unresolved({"quality_gated_normalized_score": None}) is False
+
+
+def test_judge_metric_unresolved_respects_failure_policy_raise():
+    adapter = _make_adapter(metric="stats.quality_gated_normalized_score", failure_policy="raise")
+    # failure_policy='raise' must NOT short-circuit; caller proceeds to _resolve_metric
+    # which raises on the None as before.
+    assert adapter._judge_metric_unresolved({"quality_gated_normalized_score": None}) is False
+
+
+def test_all_cases_structural_gate_rejected_yields_none_then_guard_fires():
+    """The architect's named landmine path, end to end at the stats+guard layer:
+    every case fails the structural gate (--judge-mode and) -> NO case is judged
+    -> record.judge is None on every record -> _quality_gated_normalized_score
+    returns None (NOT 0.0; nothing was scored). The extended guard must then fire
+    so the candidate floors instead of crashing _resolve_metric on the None.
+
+    This is DISTINCT from the all-floor-breach case (which IS judged -> per-case
+    0.0 -> numeric 0.0 mean): here the rejection happens BEFORE the judge, so the
+    gated gradient is genuinely absent (None), which is exactly the case the
+    judge_normalized_score-only guard would have missed for the new metric key.
+    """
+    from Evaluator.reporting import _quality_gated_normalized_score
+
+    class _Record:
+        def __init__(self):
+            self.judge = None  # structurally gate-rejected -> never judged
+
+    records = [_Record(), _Record()]
+    gradient = _quality_gated_normalized_score(records)
+    assert gradient is None  # nothing judged -> genuinely absent, not 0.0
+
+    adapter = _make_adapter(metric="stats.quality_gated_normalized_score")
+    # The guard fires on the None gradient -> caller floors the candidate instead
+    # of passing None into _resolve_metric (which would crash).
+    assert adapter._judge_metric_unresolved({"quality_gated_normalized_score": gradient}) is True
+
+
 def _write_evaluator_config(tmp_path: Path) -> Path:
     config_dir = tmp_path / "EvaluatorConfig"
     scenarios_dir = config_dir / "scenarios"

--- a/tests/prompt_optimization/test_evolutionary_service.py
+++ b/tests/prompt_optimization/test_evolutionary_service.py
@@ -469,3 +469,131 @@ prompt_optimization:
     assert payload["data"]["strategy"] == "evolutionary"
     assert payload["data"]["generation_count"] == 1
     assert payload["data"]["stop_reason"] in {"target_score", "max_generations", "stagnation"}
+
+
+def test_evolutionary_progress_stream_appends_one_row_per_candidate(tmp_path):
+    """The OPTIONAL progress_stream appends each candidate the instant it is scored.
+
+    Drives the GA in fixture_assertions mode (no LLM) for the full run with an
+    unreachable target, so it spans every generation. Asserts the stream file
+    accumulates exactly population_size * generation_count rows (proving the emit
+    is PER-CANDIDATE across the whole run, not a single end-of-run flush), that
+    each row is valid candidate-history-shaped JSON, and that the stream union
+    equals candidate_history.jsonl (the stream is a live mirror of the canonical
+    artifact, not a divergent record).
+    """
+    source = tmp_path / "prompts.yaml"
+    source.write_text("prompt: Baseline.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    stream = tmp_path / "candidate_stream.jsonl"
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        f"""
+prompt_optimization:
+  schema_version: 2
+  strategy: evolutionary
+  run_id: evo-stream
+  seed: 5
+  output_dir: {output_dir.as_posix()}
+  progress_stream: {stream.as_posix()}
+  population_size: 3
+  max_generations: 3
+  elite_count: 1
+  mutation_rate: 1.0
+  crossover_rate: 0.0
+  stopping:
+    target_score: 1.1
+    max_stagnation: 99
+    min_delta: 0.0
+  subjects:
+    - id: main
+      path: {source.as_posix()}
+      dotted_path: prompt
+  operators:
+    - type: append
+      values:
+        - Extra guidance.
+  evaluation:
+    assertions:
+      - id: never_passes
+        type: contains
+        text: THIS_TEXT_IS_NEVER_PRESENT
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = PromptOptimizationService.from_config(config).run()
+
+    # Ran the full schedule (target unreachable, no stagnation cap hit).
+    assert result.generation_count == 3
+    assert result.stop_reason == "max_generations"
+
+    assert stream.exists()
+    stream_rows = [
+        json.loads(line)
+        for line in stream.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    # PER-CANDIDATE: one streamed row for every candidate of every generation.
+    assert len(stream_rows) == 3 * 3
+    # Each streamed row is candidate-history-shaped and in-range.
+    for row in stream_rows:
+        assert {"id", "candidate_id", "generation", "score", "selected"} <= set(row)
+        assert 0.0 <= row["score"] <= 1.0
+    assert {row["generation"] for row in stream_rows} == {0, 1, 2}
+
+    # The stream is a live mirror of the canonical run-end candidate_history.
+    history_ids = {
+        json.loads(line)["id"]
+        for line in (output_dir / "candidate_history.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    }
+    assert {row["id"] for row in stream_rows} == history_ids
+
+
+def test_evolutionary_progress_stream_absent_by_default(tmp_path):
+    """Without progress_stream, behavior is unchanged: no stream file is written."""
+    source = tmp_path / "prompts.yaml"
+    source.write_text("prompt: Baseline.\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        f"""
+prompt_optimization:
+  schema_version: 2
+  strategy: evolutionary
+  run_id: evo-no-stream
+  seed: 5
+  output_dir: {output_dir.as_posix()}
+  population_size: 3
+  max_generations: 2
+  elite_count: 1
+  mutation_rate: 1.0
+  crossover_rate: 0.0
+  stopping:
+    target_score: 1.1
+    max_stagnation: 99
+    min_delta: 0.0
+  subjects:
+    - id: main
+      path: {source.as_posix()}
+      dotted_path: prompt
+  operators:
+    - type: append
+      values:
+        - Extra guidance.
+  evaluation:
+    assertions:
+      - id: never_passes
+        type: contains
+        text: THIS_TEXT_IS_NEVER_PRESENT
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    result = PromptOptimizationService.from_config(config).run()
+
+    assert result.generation_count == 2
+    # No stream artifact anywhere in the output dir; canonical artifacts still present.
+    assert not list(output_dir.glob("*stream*"))
+    assert (output_dir / "candidate_history.jsonl").exists()

--- a/tests/shared/test_quality_gate_scoring.py
+++ b/tests/shared/test_quality_gate_scoring.py
@@ -1,0 +1,296 @@
+"""Tests for the optional floors-as-gates "quality gated" judge composite.
+
+Location: tests/shared/test_quality_gate_scoring.py
+Summary: Unit tests for the generic, config-driven quality_gate feature added to
+         the dimensioned-rubric judge path. Covers:
+           * DEFAULT-OFF: a rubric with no quality_gate produces a None gated
+             score and leaves the weighted composite byte-identical.
+           * RENORMALIZED quality composite when all floor dims pass.
+           * HARD-ELIMINATE (gated score 0.0) on a floor-dim breach.
+           * FAIL-CLOSED ValueError when a configured floor or quality dim is
+             absent from the judge's per-dimension output (and that this surfaces
+             as a failed JudgeResult through judge(), never a silent pass).
+           * The reporting helper _quality_gated_normalized_score: None on the
+             default-off path, mean across cases when present.
+
+         The engine is generic: every domain value (which dims are floors, the
+         threshold, the quality weights) comes from the rubric config here, never
+         from the engine. These fixtures use an example rubric shape (6 dims: 2
+         safety floors + 4 quality dims) but the engine knows none of those names.
+"""
+from __future__ import annotations
+
+import pytest
+
+from shared.judge.judge_service import JudgeService
+from shared.judge.models import JudgeConfig, RubricDef
+
+
+class _NoopClient:
+    """Minimal stand-in: the dimensioned-scoring path never calls the client."""
+
+
+# --- Fixtures -------------------------------------------------------------
+
+# The 6 dimensions are an example shape: 2 safety floors (specificity,
+# openness_neutrality) + 4 quality dims. Weights here are the ACTIVE
+# weighted-composite weights (sum 1.0); the quality_gate config below carries the
+# SEPARATE renormalized quality-only weights.
+_DIMENSIONS = [
+    {"key": "clarity", "name": "Clarity", "weight": 0.15},
+    {"key": "relevance", "name": "Relevance", "weight": 0.25},
+    {"key": "openness_neutrality", "name": "Openness & Neutrality", "weight": 0.20},
+    {"key": "specificity", "name": "Specificity", "weight": 0.15},
+    {"key": "actionability", "name": "Actionability", "weight": 0.15},
+    {"key": "fidelity_to_intent", "name": "Fidelity to Intent", "weight": 0.10},
+]
+
+# Floors-as-gates config: the two safety dims are hard gates at 0.60; the four
+# quality dims carry renormalized weights (relevance 0.45 / clarity 0.30 /
+# action 0.15 / fidelity 0.10, sum 1.0).
+_QUALITY_GATE = {
+    "floor_dims": ["specificity", "openness_neutrality"],
+    "floor_threshold": 0.60,
+    "quality_weights": {
+        "relevance": 0.45,
+        "clarity": 0.30,
+        "actionability": 0.15,
+        "fidelity_to_intent": 0.10,
+    },
+}
+
+
+def _rubric(*, with_gate: bool, key: str = "example_rubric") -> RubricDef:
+    return RubricDef(
+        key=key,
+        name="Example Rubric",
+        description="test rubric",
+        scope="response",
+        pass_threshold=0.85,
+        judge_prompt="Judge: {response}",
+        output_schema={"type": "object"},
+        dimensions=_DIMENSIONS,
+        quality_gate=_QUALITY_GATE if with_gate else None,
+    )
+
+
+def _raw(scores: dict) -> dict:
+    """Build a raw_output dict in the judge's per-dimension {reasoning, score} shape."""
+    return {
+        key: {"reasoning": "because", "score": value}
+        for key, value in scores.items()
+    }
+
+
+def _service() -> JudgeService:
+    return JudgeService(llm_client=_NoopClient(), judge_config=JudgeConfig())
+
+
+# Per-dim scores where BOTH floors pass (>= 0.60) and quality dims vary.
+_FLOORS_PASS = {
+    "clarity": 0.80,
+    "relevance": 0.70,
+    "openness_neutrality": 0.90,        # floor, passes
+    "specificity": 0.95,    # floor, passes
+    "actionability": 0.60,
+    "fidelity_to_intent": 0.50,
+}
+
+
+# --- Default-off (byte-identical) ----------------------------------------
+
+def test_no_quality_gate_yields_none_gated_score():
+    """A rubric without a quality_gate config never produces a gated score."""
+    service = _service()
+    result = service._score_dimensioned_rubric(_raw(_FLOORS_PASS), _rubric(with_gate=False), None)
+    assert result.quality_gated_score is None
+
+
+def test_no_quality_gate_leaves_weighted_composite_unchanged():
+    """The existing weighted composite is identical whether or not a gate is set.
+
+    Same per-dim scores, gate on vs off -> the .score (weighted composite) must be
+    byte-identical; only the optional gated field differs.
+    """
+    service = _service()
+    raw = _raw(_FLOORS_PASS)
+    without = service._score_dimensioned_rubric(raw, _rubric(with_gate=False), None)
+    with_ = service._score_dimensioned_rubric(raw, _rubric(with_gate=True), None)
+    assert without.score == with_.score
+    assert without.quality_gated_score is None
+    assert with_.quality_gated_score is not None
+
+
+# --- Renormalized quality composite (floors pass) ------------------------
+
+def test_gated_score_is_renormalized_quality_composite_when_floors_pass():
+    service = _service()
+    result = service._score_dimensioned_rubric(_raw(_FLOORS_PASS), _rubric(with_gate=True), None)
+    # relevance 0.45*0.70 + clarity 0.30*0.80 + action 0.15*0.60 + fidelity 0.10*0.50
+    expected = 0.45 * 0.70 + 0.30 * 0.80 + 0.15 * 0.60 + 0.10 * 0.50
+    assert result.quality_gated_score == pytest.approx(expected)
+
+
+def test_gated_score_excludes_floor_dims_from_the_quality_sum():
+    """Changing a FLOOR dim (while it still passes) must NOT move the gated score.
+
+    The floors are gates, not weighted contributors; only quality dims feed the
+    gated composite.
+    """
+    service = _service()
+    base = service._score_dimensioned_rubric(_raw(_FLOORS_PASS), _rubric(with_gate=True), None)
+    bumped = dict(_FLOORS_PASS)
+    bumped["openness_neutrality"] = 0.61   # still passes the 0.60 floor
+    bumped["specificity"] = 0.62
+    other = service._score_dimensioned_rubric(_raw(bumped), _rubric(with_gate=True), None)
+    assert base.quality_gated_score == pytest.approx(other.quality_gated_score)
+
+
+# --- Hard-eliminate on floor breach --------------------------------------
+
+def test_floor_breach_hard_eliminates_to_zero():
+    service = _service()
+    breached = dict(_FLOORS_PASS)
+    breached["openness_neutrality"] = 0.40  # below the 0.60 floor
+    result = service._score_dimensioned_rubric(_raw(breached), _rubric(with_gate=True), None)
+    assert result.quality_gated_score == 0.0
+
+
+def test_floor_breach_does_not_zero_the_weighted_composite():
+    """A floor breach zeroes ONLY the gated selection score; the audit/weighted
+    composite still reflects the actual per-dim scores."""
+    service = _service()
+    breached = dict(_FLOORS_PASS)
+    breached["specificity"] = 0.10  # below floor
+    result = service._score_dimensioned_rubric(_raw(breached), _rubric(with_gate=True), None)
+    assert result.quality_gated_score == 0.0
+    assert result.score > 0.0  # weighted composite is untouched
+
+
+def test_floor_dim_exactly_at_threshold_passes():
+    """floor_threshold is a strict-less-than gate: score == threshold passes."""
+    service = _service()
+    edge = dict(_FLOORS_PASS)
+    edge["openness_neutrality"] = 0.60  # exactly at the threshold -> passes
+    result = service._score_dimensioned_rubric(_raw(edge), _rubric(with_gate=True), None)
+    assert result.quality_gated_score is not None
+    assert result.quality_gated_score > 0.0
+
+
+# --- Fail-closed ----------------------------------------------------------
+
+def test_missing_floor_dim_fails_closed_with_valueerror():
+    """A configured floor dim absent from the judge output raises (never silently
+    passes the gate)."""
+    service = _service()
+    missing = dict(_FLOORS_PASS)
+    del missing["openness_neutrality"]  # drop a configured floor dim
+    # The dimensioned-rubric loop reads from rubric.dimensions, so to truly drop a
+    # dim from per_dimension we score it against a rubric whose dimension list also
+    # omits it but whose quality_gate still references it.
+    rubric = RubricDef(
+        key="example_rubric",
+        name="x", description="x", scope="response", pass_threshold=0.85,
+        judge_prompt="{response}", output_schema={"type": "object"},
+        dimensions=[d for d in _DIMENSIONS if d["key"] != "openness_neutrality"],
+        quality_gate=_QUALITY_GATE,  # still names openness_neutrality as a floor
+    )
+    with pytest.raises(ValueError, match="floor dim 'openness_neutrality'"):
+        service._score_dimensioned_rubric(_raw(missing), rubric, None)
+
+
+def test_missing_quality_dim_fails_closed_with_valueerror():
+    service = _service()
+    missing = dict(_FLOORS_PASS)
+    del missing["relevance"]
+    rubric = RubricDef(
+        key="example_rubric",
+        name="x", description="x", scope="response", pass_threshold=0.85,
+        judge_prompt="{response}", output_schema={"type": "object"},
+        dimensions=[d for d in _DIMENSIONS if d["key"] != "relevance"],
+        quality_gate=_QUALITY_GATE,  # still names relevance as a quality dim
+    )
+    with pytest.raises(ValueError, match="quality dim 'relevance'"):
+        service._score_dimensioned_rubric(_raw(missing), rubric, None)
+
+
+def test_empty_quality_weights_fails_closed():
+    service = _service()
+    rubric = _rubric(with_gate=True)
+    rubric.quality_gate = {"floor_dims": ["openness_neutrality"], "floor_threshold": 0.6, "quality_weights": {}}
+    with pytest.raises(ValueError, match="quality_weights is empty"):
+        service._score_dimensioned_rubric(_raw(_FLOORS_PASS), rubric, None)
+
+
+def test_fail_closed_surfaces_as_failed_judge_result_not_a_crash(monkeypatch):
+    """A fail-closed ValueError in scoring is caught by judge() and returned as a
+    failed JudgeResult (passed=False) -- never an uncaught crash, never a pass."""
+    service = _service()
+    rubric = RubricDef(
+        key="example_rubric",
+        name="x", description="x", scope="response", pass_threshold=0.85,
+        judge_prompt="{response}", output_schema={"type": "object"},
+        dimensions=[d for d in _DIMENSIONS if d["key"] != "openness_neutrality"],
+        quality_gate=_QUALITY_GATE,
+    )
+    # Stub the LLM call so judge() reaches _parse_scores with our crafted output.
+    monkeypatch.setattr(
+        service.llm_client,
+        "structured_output",
+        lambda **kwargs: _raw({k: v for k, v in _FLOORS_PASS.items() if k != "openness_neutrality"}),
+        raising=False,
+    )
+    result = service.judge(prompt="x", rubrics=[rubric])
+    assert result.passed is False
+    assert result.error is not None
+    assert "openness_neutrality" in result.error
+
+
+# --- Reporting helper -----------------------------------------------------
+
+def test_reporting_quality_gated_normalized_score_none_when_absent():
+    """_quality_gated_normalized_score returns None when no record carries a gated
+    score (default-off path), so the stat is simply absent."""
+    from Evaluator.reporting import _quality_gated_normalized_score
+
+    class _Judge:
+        def __init__(self, scores):
+            self.judge_result = type("R", (), {"scores": scores})()
+
+    class _Score:
+        def __init__(self, gated):
+            self.quality_gated_score = gated
+
+    class _Record:
+        def __init__(self, judge):
+            self.judge = judge
+
+    # No judge at all, and a judge whose scores all have gated=None.
+    records = [
+        _Record(None),
+        _Record(_Judge([_Score(None), _Score(None)])),
+    ]
+    assert _quality_gated_normalized_score(records) is None
+
+
+def test_reporting_quality_gated_normalized_score_means_across_cases():
+    from Evaluator.reporting import _quality_gated_normalized_score
+
+    class _Judge:
+        def __init__(self, scores):
+            self.judge_result = type("R", (), {"scores": scores})()
+
+    class _Score:
+        def __init__(self, gated):
+            self.quality_gated_score = gated
+
+    class _Record:
+        def __init__(self, judge):
+            self.judge = judge
+
+    records = [
+        _Record(_Judge([_Score(0.8)])),
+        _Record(_Judge([_Score(0.0)])),  # a hard-eliminated case pulls the mean down
+        _Record(None),                   # non-judge case ignored
+    ]
+    assert _quality_gated_normalized_score(records) == pytest.approx(0.4)

--- a/tests/shared/test_quality_gated_min_selection.py
+++ b/tests/shared/test_quality_gated_min_selection.py
@@ -1,0 +1,133 @@
+"""Tests for the WORST-CASE quality-gated selection metric (topic-diversity pressure).
+
+Location: tests/shared/test_quality_gated_min_selection.py
+Summary: Regression coverage for ``_quality_gated_min_normalized_score`` — the
+         run-level selection metric an optimizer run can select on
+         (``objective.metric: stats.quality_gated_min_normalized_score``). Its
+         sibling MEAN metric is already covered in test_quality_gate_scoring.py;
+         the MIN was shipped (worst-case hardening) with ZERO direct tests.
+
+         The MIN exists for ONE reason: a candidate that aces one case but drifts
+         off another must be scored by its WEAKEST case, so a strong case can NOT
+         mask a weak one (which the mean allows). These tests lock that property
+         in as a permanent guard, plus the None / default-off contract and the
+         floor-breach interaction (a hard-eliminated case drives the min to 0.0).
+
+         The engine is generic: this metric knows none of the domain dimension
+         names; it operates purely on per-record gated composites. The fixtures
+         here use minimal stand-in records mirroring the reporting helper's shape.
+"""
+from __future__ import annotations
+
+import pytest
+
+from Evaluator.reporting import (
+    _quality_gated_min_normalized_score,
+    _quality_gated_normalized_score,
+)
+
+
+# --- Minimal stand-in records mirroring the reporting helper's read shape ----
+# _judge_case_quality_gated(record) reads record.judge.judge_result.scores[*]
+# .quality_gated_score and returns the FIRST non-None gated score for the case
+# (or None when the case has no judge / no gated score).
+
+
+class _Score:
+    def __init__(self, gated):
+        self.quality_gated_score = gated
+
+
+class _Judge:
+    def __init__(self, gated_scores):
+        self.judge_result = type("R", (), {"scores": [_Score(g) for g in gated_scores]})()
+
+
+class _Record:
+    def __init__(self, gated_scores=None):
+        # gated_scores=None => a non-judge case (record.judge is None)
+        self.judge = _Judge(gated_scores) if gated_scores is not None else None
+
+
+# --- The load-bearing property: min, not mean -------------------------------
+
+
+def test_min_is_the_worst_case_not_the_average():
+    """A strong case must NOT mask a weak case — the metric is the WORST case.
+
+    This is the entire point of the worst-case hardening: a candidate aced one
+    case (~0.92) but drifted on another (~0.05); the 0.85 MEAN hid that. The MIN
+    surfaces the drifted case. Same records, mean vs min diverge sharply.
+    """
+    records = [
+        _Record([0.92]),   # strong case
+        _Record([0.05]),   # drifted case — the weakness that must dominate
+        _Record([0.80]),
+    ]
+    assert _quality_gated_min_normalized_score(records) == pytest.approx(0.05)
+    # And the mean would have MASKED it (sits up in the "passing" band):
+    assert _quality_gated_normalized_score(records) == pytest.approx((0.92 + 0.05 + 0.80) / 3)
+    # The divergence is the guard: if someone "simplifies" min->mean, this breaks.
+    assert _quality_gated_min_normalized_score(records) < _quality_gated_normalized_score(records)
+
+
+def test_min_rewards_consistent_across_topics_over_spiky():
+    """A prompt that clears every topic decently beats one that spikes then drifts.
+
+    Consistent candidate (all ~0.70) must outrank a spiky one (0.95 + 0.10) on the
+    MIN, even though the spiky one wins on the mean. This is the selection-pressure
+    inversion the min was introduced to create.
+    """
+    # Spiky is deliberately chosen so its MEAN beats consistent's, but its MIN
+    # (the drifted case) is far below — the exact mask the min must defeat.
+    consistent = [_Record([0.70]), _Record([0.70]), _Record([0.70])]   # mean 0.70, min 0.70
+    spiky = [_Record([0.99]), _Record([0.15]), _Record([0.99])]        # mean 0.71, min 0.15
+    min_consistent = _quality_gated_min_normalized_score(consistent)
+    min_spiky = _quality_gated_min_normalized_score(spiky)
+    assert min_consistent > min_spiky, "min must prefer the topic-consistent candidate"
+    # The mean would have INVERTED this preference (spiky edges ahead on the mean),
+    # so selecting on the mean would pick the drift-prone prompt — which is exactly
+    # why selection moved to the min.
+    assert _quality_gated_normalized_score(spiky) > _quality_gated_normalized_score(consistent)
+
+
+def test_floor_breach_case_drives_the_min_to_zero():
+    """A hard-eliminated case (gated 0.0 from a floor breach) makes the run min 0.0.
+
+    A floor breach on ANY single topic zeroes that case's gated score; the min then
+    hard-eliminates the whole candidate regardless of how strong its other topics
+    are. That is the floors-as-gates contract composing with worst-case selection.
+    """
+    records = [_Record([0.91]), _Record([0.0]), _Record([0.88])]
+    assert _quality_gated_min_normalized_score(records) == 0.0
+
+
+# --- None / default-off contract (byte-identical to the mean's condition) ----
+
+
+def test_min_is_none_when_no_case_carries_a_gated_score():
+    """Default-off: no rubric had a quality_gate => no case has a gated score =>
+    the min stat is absent (None), exactly like the mean variant."""
+    records = [
+        _Record(None),            # non-judge case
+        _Record([None, None]),    # judged but no gated score on any dim
+    ]
+    assert _quality_gated_min_normalized_score(records) is None
+    # Same None-condition as the mean — they must agree on absence.
+    assert _quality_gated_normalized_score(records) is None
+
+
+def test_min_ignores_non_judge_cases_but_counts_judged_ones():
+    """Non-judge cases (record.judge is None) are skipped; the min is over the
+    judged cases only — a non-judge case must not be treated as a 0.0 floor."""
+    records = [
+        _Record(None),       # skipped, NOT a 0.0
+        _Record([0.40]),     # the only gated case
+        _Record(None),       # skipped
+    ]
+    assert _quality_gated_min_normalized_score(records) == pytest.approx(0.40)
+
+
+def test_single_judged_case_min_equals_that_case():
+    records = [_Record([0.63])]
+    assert _quality_gated_min_normalized_score(records) == pytest.approx(0.63)

--- a/tests/test_name_leak_gate_regression.py
+++ b/tests/test_name_leak_gate_regression.py
@@ -1,0 +1,123 @@
+"""Name-leak structural-gate regression test.
+
+Location: tests/test_name_leak_gate_regression.py
+Summary: A DURABLE, deterministic (zero-API) guard that the structural name-leak
+         gate — a ``text_not_regex`` assertion over the serialized response
+         ``$.content`` — catches a planted entity name in a GENERATED output and
+         passes a properly-abstracted one. A privacy-abstraction contract rests on
+         this gate hard-failing when an entity name leaks; this test locks that
+         GREEN in permanently so a future refactor of the assertion verifier, the
+         response view, or the regex semantics can't silently weaken it.
+
+         The gate is PROMPT-INDEPENDENT: copywriting operators only mutate the
+         PROMPT fed to the target, never the gate logic, so a deterministic regex
+         test fully covers the gate's behavior with no live call. The mechanism is
+         generic (text_not_regex over $.content); the planted name + pattern below
+         use fictional entities and a neutral topic that exercise the same gate.
+"""
+from __future__ import annotations
+
+import json
+
+from shared.verifiers.builtins.assertion_verifier import evaluate_correctness
+from Evaluator.response_view import build_response_view
+
+
+def _name_leak_correct(pattern: str) -> dict:
+    """The structural gate as a scenario declares it: a single text_not_regex over
+    $.content (case-insensitive), under `all`."""
+    return {
+        "all": [
+            {"type": "text_not_regex", "name": "no_name_leak", "path": "$.content", "pattern": pattern},
+        ]
+    }
+
+
+def _content_view(content: str) -> dict:
+    """Build the response view the runner feeds to evaluate_correctness, with a
+    schema-nested result.{title,details} serialized into $.content."""
+    return build_response_view({"content": content})
+
+
+# A realistic abstracted (GOOD) output — no entity name, a ROLE named instead.
+_ABSTRACTED = json.dumps({
+    "result": {
+        "title": "Battery Storage and the Future of Urban Transit Networks",
+        "details": (
+            "For a piece on grid-scale battery storage, I'm looking to connect with transit "
+            "engineers and energy researchers who can discuss how cities balance peak demand "
+            "and storage capacity. What is realistic over the next few years, and where are the "
+            "current limits? Specialists and practitioners welcome."
+        ),
+    }
+})
+
+# The SAME output but with an entity name leaked into the details (BAD).
+_LEAKED = json.dumps({
+    "result": {
+        "title": "Battery Storage and the Future of Urban Transit Networks",
+        "details": (
+            "Dr. Priya Nadeau, a transit engineer, is available to discuss grid-scale battery "
+            "storage, including how cities balance peak demand and storage capacity. Reach out "
+            "to arrange an interview with the specialist."
+        ),
+    }
+})
+
+
+# --- The gate CATCHES a planted name (the load-bearing regression guard) ------
+
+
+def test_gate_fails_when_a_source_name_is_planted_in_the_output():
+    """A planted source name in the generated output MUST hard-fail the gate."""
+    result = evaluate_correctness(_name_leak_correct(r"(?i)nadeau"), _content_view(_LEAKED))
+    assert result.passed is False, "name-leak gate did NOT catch the planted source name"
+
+
+def test_gate_catches_multi_entity_leak_pattern():
+    """A multi-token pattern (name OR company) catches either leak."""
+    pattern = r"(?i)(okafor|helio grid|helio)"
+    leaked_company = _content_view(json.dumps({
+        "result": {
+            "title": "Open-Banking Credit Models and Mid-Size Lenders",
+            "details": (
+                "A risk officer at Helio Grid Partners can speak to how mid-size lenders "
+                "adapt credit models to open-banking data. Looking for risk analysts and "
+                "lending specialists to discuss the pitfalls."
+            ),
+        }
+    }))
+    result = evaluate_correctness(_name_leak_correct(pattern), leaked_company)
+    assert result.passed is False, "gate missed a leaked COMPANY token"
+
+
+# --- The gate PASSES a properly-abstracted output (no false positive) ---------
+
+
+def test_gate_passes_when_the_output_is_properly_abstracted():
+    """A correctly-abstracted output (role named, no source identity) MUST pass."""
+    result = evaluate_correctness(_name_leak_correct(r"(?i)nadeau"), _content_view(_ABSTRACTED))
+    assert result.passed is True, "gate false-positived on a clean, abstracted output"
+
+
+# --- Counter-test: the assertion is genuinely coupled to the pattern ----------
+
+
+def test_gate_is_coupled_to_the_pattern_not_vacuously_passing():
+    """Falsification guard: the SAME abstracted output that PASSES its own pattern
+    must FAIL a pattern matching a token it actually contains ('transit'). This
+    proves the gate's pass in the test above is the regex genuinely not matching —
+    not the assertion vacuously passing regardless of content."""
+    # 'transit' IS present in the abstracted output -> a not_regex on it must fail.
+    coupled = evaluate_correctness(_name_leak_correct(r"(?i)transit"), _content_view(_ABSTRACTED))
+    assert coupled.passed is False, (
+        "text_not_regex did not react to a token actually present in $.content — "
+        "the gate may be vacuously passing"
+    )
+
+
+def test_case_insensitivity_holds():
+    """The (?i) gate must catch the name regardless of casing in the output."""
+    upper = _content_view(json.dumps({"result": {"title": "T", "details": "Contact NADEAU today."}}))
+    result = evaluate_correctness(_name_leak_correct(r"(?i)nadeau"), upper)
+    assert result.passed is False, "case-insensitive gate missed an upper-cased leak"


### PR DESCRIPTION
## Summary

Additive, **default-off** engine features for the dimensioned-rubric judge path, the evolutionary optimizer, and the evaluator/reporting layer. With no config set, existing scoring is **byte-identical** -- every new behavior is opt-in via rubric/run config. Branched off current `main` (#113); no conflicts.

## What's included

**Quality gate (floors-as-gates composite)**
- Optional `quality_gate` on a dimensioned rubric: a set of floor dims gate at a threshold (hard-eliminate to 0.0 on breach) while the remaining quality dims form a renormalized composite. Default-off yields a `None` gated score and leaves the weighted composite unchanged. Fail-closed (`ValueError` surfaced as a failed `JudgeResult`) when a configured floor/quality dim is absent from the judge output -- never a silent pass.
- Run-level selection metrics in reporting: mean and worst-case (min) normalized gated scores across cases; both `None` when no case carries a gated score. The worst-case (min) metric lets a run select on its weakest case so a strong case can't mask a weak one.

**Name-leak structural gate**
- Deterministic, zero-API regression coverage for the `text_not_regex` structural gate over `$.content` (catches a planted entity name, passes a properly-abstracted output, holds case-insensitively, and is coupled-not-vacuous).

**Token usage + progress stream**
- The OpenAI Responses backend exposes last-request token usage for cost instrumentation.
- The optimizer can append a per-candidate progress stream (durable JSONL), absent by default.

## Tests

- 3 new test files: quality-gate scoring, worst-case gated-min selection, name-leak regression. Fixtures are **fictional / neutral** (no project-specific domain content).
- 2 existing optimizer tests extended.
- **Diff-relevant suite: 51 passed.**
- Full suite shows **no new failures vs `main`** -- the pre-existing failures are missing optional dependencies in CI-less environments (`lightgbm`, `aiosqlite`, `unsloth`) and unrelated upstream test drift; they fail identically on a clean `main` checkout.

## Notes

- `CLAUDE.md` is intentionally **excluded** from this PR (project/session context, not engine code).
- This is a focused engine PR -- no submodule or downstream-consumer changes are bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JaLaWcT6HAs9G3CgJ2t63H
