### PR TITLE
feat: generic rollout-filter engine + full-trajectory SFT projection

### DIFF
--- a/.agents/skills/synethetic-data-generation/SKILL.md
+++ b/.agents/skills/synethetic-data-generation/SKILL.md
@@ -22,6 +22,7 @@ Generate, improve, validate, sanitize, and evaluate synthetic training datasets 
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
 | Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
+| Project rollouts → SFT/KTO/GRPO | `python SynthChat/scripts/project_rollout_datasets.py --input ROLLOUT.jsonl --canonical-output ... --kto-output ... --grpo-output ... [--sft-output ...] [--filter-config FILTER.yaml]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
 | Combine datasets | `./scripts/combine_datasets.sh -o out.jsonl FILE1 FILE2` |
@@ -48,6 +49,7 @@ Load the specific reference you need:
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
 | **Testing Protocol** | After creating/modifying scenarios or rubrics — MUST dry-run before full generation | `reference/testing-protocol.md` |
 | **Manual Editing** | Hand-crafting individual dataset lines | `reference/manual-editing.md` |
+| **Rollout Projection & Curation** | Projecting rollouts into SFT/KTO/GRPO datasets, config-driven filtering (`--filter-config`), full multi-turn SFT (`--sft-output`), data-recipe planning heuristics | `reference/rollout-projection.md` |
 
 For environment-backed multi-turn tool data, also load:
 - `reference/scenario-authoring.md` for config-first scenario structure

--- a/.agents/skills/synethetic-data-generation/reference/rollout-projection.md
+++ b/.agents/skills/synethetic-data-generation/reference/rollout-projection.md
@@ -1,0 +1,181 @@
+# Rollout Projection & Dataset Curation Reference
+
+The projector `SynthChat/scripts/project_rollout_datasets.py` turns saved environment-rollout artifacts into training datasets. It always writes canonical, KTO, and GRPO outputs, and can optionally write a full multi-turn SFT output. A config-driven filter engine lets you curate which rollouts reach each projection target.
+
+This reference covers three things:
+
+1. The generic, config-driven **rollout-filter engine** (`--filter-config`)
+2. **Full-trajectory SFT projection** (`--sft-output`)
+3. **Data-recipe guidance** heuristics for planning generation runs
+
+---
+
+## 1. Generic Rollout-Filter Engine
+
+The projector accepts `--filter-config <yaml>` pointing at a YAML file with a `projection.filters` list. The engine lives at `shared/validation/rollout_filters.py` and is fully generic — it filters arbitrary record dicts on ANY field via dot-path, with a generic operator table. It knows nothing about "turns" or "tools" specifically.
+
+**Default OFF.** An empty or absent `--filter-config` is a no-op: every record passes for every target. You opt into filtering by supplying a config.
+
+### YAML shape
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns   # dot-path into the record
+      op: gte
+      value: 5
+      applies_to: [grpo, kto_positive]   # optional; default = sft, grpo, kto_positive (NOT kto_negative)
+      on_missing: keep                   # keep (default) | drop
+```
+
+- `field` — dot-path addressed into the rollout record as-is (top-level keys include `metadata`, so e.g. `metadata.environment.episode_trace.total_turns`).
+- `op` — comparison operator (see below).
+- `value` — the comparison operand. `in`/`not_in` take a list; `exists`/`missing` ignore it.
+- `applies_to` — optional list of targets this filter applies to. When omitted, it applies to the **default target set** (see below).
+- `on_missing` — `keep` (default) or `drop`; decides the verdict when the addressed field is absent.
+
+### Operators
+
+`eq, ne, gt, gte, lt, lte, in, not_in, exists, missing`
+
+- `in` / `not_in` take a **list** value (membership test).
+- `exists` / `missing` test field presence and ignore `value`.
+- Spec validation is eager and fail-closed: an unknown `op`, bad `on_missing`, or a missing required key raises at load time rather than being silently ignored.
+
+### Targets
+
+`sft, grpo, kto_positive, kto_negative`
+
+The **default target set** when `applies_to` is omitted is `sft, grpo, kto_positive`. Hard negatives (`kto_negative`) are **NEVER** filtered unless `kto_negative` is explicitly listed in `applies_to`. This is deliberate: quality filters that drop short or low-scoring rollouts should never silently discard your hard-negative training signal.
+
+### `on_missing` semantics
+
+Records that lack the addressed field **pass through by default** (`on_missing: keep`). Set `on_missing: drop` to exclude records missing the field. There is no silent data loss either way — the choice is explicit per filter.
+
+### AND semantics + drop breakdown
+
+Within a target, all applicable filters must match (logical AND) for a record to pass. When filters are active, the run summary (the JSON the projector prints) includes a `filter_stats` block with a per-target / per-filter drop breakdown so you can see exactly how many records each filter removed.
+
+### Worked examples
+
+**(a) Keep only multi-step trajectories** (applies to the default set: sft, grpo, kto_positive; negatives untouched):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns
+      op: gte
+      value: 5
+```
+
+**(b) Scope a quality-score floor to SFT only** (KTO/GRPO targets unaffected):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.final_judge.score
+      op: gte
+      value: 0.8
+      applies_to: [sft]
+      on_missing: drop          # SFT rows without a judge score are excluded
+```
+
+**(c) Explicitly filter a stop_reason on hard negatives** (opt-in; this is the only way kto_negative is filtered):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.stop_reason
+      op: ne
+      value: max_tool_steps_exceeded
+      applies_to: [kto_negative]
+      on_missing: drop
+```
+
+---
+
+## 2. Full-Trajectory SFT Projection (`--sft-output`)
+
+The projector has an **optional** `--sft-output <path>`. When provided, each quality-positive rollout is projected into a single FULL multi-turn SFT row:
+
+```json
+{
+  "conversations": [
+    {"role": "system", "content": "..."},
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": null, "tool_calls": [...]},
+    {"role": "tool", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "label": true,
+  "total_turns": 5
+}
+```
+
+Behavior:
+
+- It only projects **quality positives** — failed/negative rollouts are skipped for this output.
+- It reconstructs the **whole episode** from `conversation_trace`, dropping the `judge_feedback`, `validation_feedback`, and `final_text_request` scaffolding turns (these are environment scaffolding, not training signal).
+- Tool results become `tool`-role messages on disk; assistant tool-call turns carry `tool_calls`.
+- Schema: `Datasets/environment_rollouts/sft_projection.schema.json`.
+
+### Chat-template behavior
+
+`shared/sft_preprocessing.py` renders the `tool` role to **text** (re-tagged consistent with how the environment presents tool output to the model) at template time. Consequences:
+
+- **Existing single-turn SFT data is unaffected** — rows that use only system/user/assistant roles template identically to before.
+- **Multi-turn rows template into a coherent transcript** — the on-disk `tool` role is rendered into the house ChatML-style text so a chat template that only understands system/user/assistant still produces a sensible transcript.
+- The on-disk `tool` role is **preserved for auditing** — only the template-time rendering flattens it to text; the saved JSONL keeps the structured `tool` messages.
+
+### Full invocation example (all four outputs + filter config)
+
+```bash
+python SynthChat/scripts/project_rollout_datasets.py \
+  --input Datasets/environment_rollouts/run_a.jsonl \
+  --input Datasets/environment_rollouts/run_b.jsonl \
+  --canonical-output Datasets/environment_rollouts/canonical.jsonl \
+  --kto-output Datasets/environment_rollouts/kto.jsonl \
+  --grpo-output Datasets/environment_rollouts/grpo.jsonl \
+  --sft-output Datasets/environment_rollouts/sft.jsonl \
+  --filter-config configs/projection/keep_multistep.yaml
+```
+
+**Omitting `--sft-output` keeps the original 3-output behavior** (canonical/KTO/GRPO only). `--filter-config` is independent and optional in either mode.
+
+### Flywheel staging filters
+
+The same generic filter engine (section 1) is wired into the **flywheel** `DatasetStager` (`shared/flywheel/stager.py`), so you can declaratively filter which inference logs get staged into SFT/KTO/GRPO training sets. It is the **same engine, different field namespace**: flywheel filters evaluate against an inference-log record, not an environment rollout.
+
+**Filter view (the dot-path namespace).** Each record is exposed as a "filter view" dict with two layers:
+
+- **Record fields at the top level** (from `InferenceLogRecord`): `log_id`, `timestamp`, `model_id`, `adapter_name`, `temperature`, `max_tokens`, `tools_requested`, `finish_reason`, `prompt_tokens`, `completion_tokens`, `latency_ms`, `fitness_score`, `is_valid`, `tag`, `dataset_version`, `source_file`, `line_number`, `tenant_id`.
+- **Parsed log content under a `content.` prefix**: e.g. `content.messages`, `content.response_content`, `content.tool_calls`, `content.completion_token_ids`.
+
+So a researcher can write `field: fitness_score` (record field) or `field: content.response_content` (transcript). For records read from the catalog index, prefer the `content.*` view for transcript data — only index-backed fields are populated at the top level.
+
+**Config key.** Filters live under the top-level `filters:` key of the flywheel config YAML (loaded into `FlywheelConfig.filters`), using the same spec shape as section 1:
+
+```yaml
+# configs/flywheel/<your>.yaml
+filters:
+  - field: fitness_score
+    op: gte
+    value: 0.85
+```
+
+Empty/absent `filters:` is a no-op — default staging behavior is unchanged.
+
+**Default targets.** The stager's targets are `sft`, `kto_positive`, `kto_negative`, `grpo`. The **default target set** (when `applies_to` is omitted) is `sft, kto_positive, grpo` — it **excludes `kto_negative`**, matching the projector convention: quality filters must not silently drop hard negatives unless a researcher explicitly lists `kto_negative` in `applies_to`. KTO interleaving (per `KTO_TRAINING_REFERENCE.md`) is preserved — filtering happens before the positive/negative lists are built. The applied filter specs and a per-target drop breakdown are recorded in the staged `DatasetVersion.filter_criteria` (keys `staging_filters` and `staging_filter_stats`).
+
+---
+
+## 3. Data-Recipe Guidance
+
+Heuristics for planning generation runs, drawn from OpenThoughts-Agent (arXiv 2606.24855). These are **planning heuristics, NOT codified behavior** in this repo — use them to decide what to generate, not as automatic pipeline steps.
+
+- **Task source is the highest-leverage knob.** Swapping/mixing task sources (scenarios) swings results the most. Prefer mixing the top ~4 task sources over over-specializing on a single one; adding many weak sources hurts.
+- **Strongest model ≠ best teacher.** Before committing a big generation run, run a small teacher bake-off across candidate generation models. The SOTA benchmark model is often NOT the best teacher (~5pp swings observed). Use the per-stage model split in scenario YAML to test generation models cheaply.
+- **Difficulty ≈ teacher response length.** When selecting which tasks to keep, prefer tasks where a strong model produces longer responses — a free difficulty proxy worth roughly +3pp. Do **NOT** use embedding-diversity to filter which tasks to keep; in the paper it underperformed random selection.
+- **Keep multi-step trajectories.** Longer agentic trajectories (e.g. `total_turns >= 5`) are higher-quality SFT signal even at a matched token budget. Enforce it with the `total_turns` filter from section 1.
+  - **Caveat for THIS repo:** today's scenarios are mostly single-step (turn counts cluster at 1-3), so the real lever is **authoring genuinely multi-step tasks first** — the filter only helps once such data actually exists.
+- **Augmentation caution.** LLM task-hardening/constraining rewriting was within noise. What scales past the upsampling plateau is **expanding surface forms (paraphrases) of GOOD sources**, not making tasks artificially harder.

--- a/.claude/skills/synethetic-data-generation/SKILL.md
+++ b/.claude/skills/synethetic-data-generation/SKILL.md
@@ -22,6 +22,7 @@ Generate, improve, validate, sanitize, and evaluate synthetic training datasets 
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
 | Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
+| Project rollouts → SFT/KTO/GRPO | `python SynthChat/scripts/project_rollout_datasets.py --input ROLLOUT.jsonl --canonical-output ... --kto-output ... --grpo-output ... [--sft-output ...] [--filter-config FILTER.yaml]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
 | Combine datasets | `./scripts/combine_datasets.sh -o out.jsonl FILE1 FILE2` |
@@ -48,6 +49,7 @@ Load the specific reference you need:
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
 | **Testing Protocol** | After creating/modifying scenarios or rubrics — MUST dry-run before full generation | `reference/testing-protocol.md` |
 | **Manual Editing** | Hand-crafting individual dataset lines | `reference/manual-editing.md` |
+| **Rollout Projection & Curation** | Projecting rollouts into SFT/KTO/GRPO datasets, config-driven filtering (`--filter-config`), full multi-turn SFT (`--sft-output`), data-recipe planning heuristics | `reference/rollout-projection.md` |
 
 For environment-backed multi-turn tool data, also load:
 - `reference/scenario-authoring.md` for config-first scenario structure

--- a/.claude/skills/synethetic-data-generation/reference/rollout-projection.md
+++ b/.claude/skills/synethetic-data-generation/reference/rollout-projection.md
@@ -1,0 +1,181 @@
+# Rollout Projection & Dataset Curation Reference
+
+The projector `SynthChat/scripts/project_rollout_datasets.py` turns saved environment-rollout artifacts into training datasets. It always writes canonical, KTO, and GRPO outputs, and can optionally write a full multi-turn SFT output. A config-driven filter engine lets you curate which rollouts reach each projection target.
+
+This reference covers three things:
+
+1. The generic, config-driven **rollout-filter engine** (`--filter-config`)
+2. **Full-trajectory SFT projection** (`--sft-output`)
+3. **Data-recipe guidance** heuristics for planning generation runs
+
+---
+
+## 1. Generic Rollout-Filter Engine
+
+The projector accepts `--filter-config <yaml>` pointing at a YAML file with a `projection.filters` list. The engine lives at `shared/validation/rollout_filters.py` and is fully generic — it filters arbitrary record dicts on ANY field via dot-path, with a generic operator table. It knows nothing about "turns" or "tools" specifically.
+
+**Default OFF.** An empty or absent `--filter-config` is a no-op: every record passes for every target. You opt into filtering by supplying a config.
+
+### YAML shape
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns   # dot-path into the record
+      op: gte
+      value: 5
+      applies_to: [grpo, kto_positive]   # optional; default = sft, grpo, kto_positive (NOT kto_negative)
+      on_missing: keep                   # keep (default) | drop
+```
+
+- `field` — dot-path addressed into the rollout record as-is (top-level keys include `metadata`, so e.g. `metadata.environment.episode_trace.total_turns`).
+- `op` — comparison operator (see below).
+- `value` — the comparison operand. `in`/`not_in` take a list; `exists`/`missing` ignore it.
+- `applies_to` — optional list of targets this filter applies to. When omitted, it applies to the **default target set** (see below).
+- `on_missing` — `keep` (default) or `drop`; decides the verdict when the addressed field is absent.
+
+### Operators
+
+`eq, ne, gt, gte, lt, lte, in, not_in, exists, missing`
+
+- `in` / `not_in` take a **list** value (membership test).
+- `exists` / `missing` test field presence and ignore `value`.
+- Spec validation is eager and fail-closed: an unknown `op`, bad `on_missing`, or a missing required key raises at load time rather than being silently ignored.
+
+### Targets
+
+`sft, grpo, kto_positive, kto_negative`
+
+The **default target set** when `applies_to` is omitted is `sft, grpo, kto_positive`. Hard negatives (`kto_negative`) are **NEVER** filtered unless `kto_negative` is explicitly listed in `applies_to`. This is deliberate: quality filters that drop short or low-scoring rollouts should never silently discard your hard-negative training signal.
+
+### `on_missing` semantics
+
+Records that lack the addressed field **pass through by default** (`on_missing: keep`). Set `on_missing: drop` to exclude records missing the field. There is no silent data loss either way — the choice is explicit per filter.
+
+### AND semantics + drop breakdown
+
+Within a target, all applicable filters must match (logical AND) for a record to pass. When filters are active, the run summary (the JSON the projector prints) includes a `filter_stats` block with a per-target / per-filter drop breakdown so you can see exactly how many records each filter removed.
+
+### Worked examples
+
+**(a) Keep only multi-step trajectories** (applies to the default set: sft, grpo, kto_positive; negatives untouched):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns
+      op: gte
+      value: 5
+```
+
+**(b) Scope a quality-score floor to SFT only** (KTO/GRPO targets unaffected):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.final_judge.score
+      op: gte
+      value: 0.8
+      applies_to: [sft]
+      on_missing: drop          # SFT rows without a judge score are excluded
+```
+
+**(c) Explicitly filter a stop_reason on hard negatives** (opt-in; this is the only way kto_negative is filtered):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.stop_reason
+      op: ne
+      value: max_tool_steps_exceeded
+      applies_to: [kto_negative]
+      on_missing: drop
+```
+
+---
+
+## 2. Full-Trajectory SFT Projection (`--sft-output`)
+
+The projector has an **optional** `--sft-output <path>`. When provided, each quality-positive rollout is projected into a single FULL multi-turn SFT row:
+
+```json
+{
+  "conversations": [
+    {"role": "system", "content": "..."},
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": null, "tool_calls": [...]},
+    {"role": "tool", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "label": true,
+  "total_turns": 5
+}
+```
+
+Behavior:
+
+- It only projects **quality positives** — failed/negative rollouts are skipped for this output.
+- It reconstructs the **whole episode** from `conversation_trace`, dropping the `judge_feedback`, `validation_feedback`, and `final_text_request` scaffolding turns (these are environment scaffolding, not training signal).
+- Tool results become `tool`-role messages on disk; assistant tool-call turns carry `tool_calls`.
+- Schema: `Datasets/environment_rollouts/sft_projection.schema.json`.
+
+### Chat-template behavior
+
+`shared/sft_preprocessing.py` renders the `tool` role to **text** (re-tagged consistent with how the environment presents tool output to the model) at template time. Consequences:
+
+- **Existing single-turn SFT data is unaffected** — rows that use only system/user/assistant roles template identically to before.
+- **Multi-turn rows template into a coherent transcript** — the on-disk `tool` role is rendered into the house ChatML-style text so a chat template that only understands system/user/assistant still produces a sensible transcript.
+- The on-disk `tool` role is **preserved for auditing** — only the template-time rendering flattens it to text; the saved JSONL keeps the structured `tool` messages.
+
+### Full invocation example (all four outputs + filter config)
+
+```bash
+python SynthChat/scripts/project_rollout_datasets.py \
+  --input Datasets/environment_rollouts/run_a.jsonl \
+  --input Datasets/environment_rollouts/run_b.jsonl \
+  --canonical-output Datasets/environment_rollouts/canonical.jsonl \
+  --kto-output Datasets/environment_rollouts/kto.jsonl \
+  --grpo-output Datasets/environment_rollouts/grpo.jsonl \
+  --sft-output Datasets/environment_rollouts/sft.jsonl \
+  --filter-config configs/projection/keep_multistep.yaml
+```
+
+**Omitting `--sft-output` keeps the original 3-output behavior** (canonical/KTO/GRPO only). `--filter-config` is independent and optional in either mode.
+
+### Flywheel staging filters
+
+The same generic filter engine (section 1) is wired into the **flywheel** `DatasetStager` (`shared/flywheel/stager.py`), so you can declaratively filter which inference logs get staged into SFT/KTO/GRPO training sets. It is the **same engine, different field namespace**: flywheel filters evaluate against an inference-log record, not an environment rollout.
+
+**Filter view (the dot-path namespace).** Each record is exposed as a "filter view" dict with two layers:
+
+- **Record fields at the top level** (from `InferenceLogRecord`): `log_id`, `timestamp`, `model_id`, `adapter_name`, `temperature`, `max_tokens`, `tools_requested`, `finish_reason`, `prompt_tokens`, `completion_tokens`, `latency_ms`, `fitness_score`, `is_valid`, `tag`, `dataset_version`, `source_file`, `line_number`, `tenant_id`.
+- **Parsed log content under a `content.` prefix**: e.g. `content.messages`, `content.response_content`, `content.tool_calls`, `content.completion_token_ids`.
+
+So a researcher can write `field: fitness_score` (record field) or `field: content.response_content` (transcript). For records read from the catalog index, prefer the `content.*` view for transcript data — only index-backed fields are populated at the top level.
+
+**Config key.** Filters live under the top-level `filters:` key of the flywheel config YAML (loaded into `FlywheelConfig.filters`), using the same spec shape as section 1:
+
+```yaml
+# configs/flywheel/<your>.yaml
+filters:
+  - field: fitness_score
+    op: gte
+    value: 0.85
+```
+
+Empty/absent `filters:` is a no-op — default staging behavior is unchanged.
+
+**Default targets.** The stager's targets are `sft`, `kto_positive`, `kto_negative`, `grpo`. The **default target set** (when `applies_to` is omitted) is `sft, kto_positive, grpo` — it **excludes `kto_negative`**, matching the projector convention: quality filters must not silently drop hard negatives unless a researcher explicitly lists `kto_negative` in `applies_to`. KTO interleaving (per `KTO_TRAINING_REFERENCE.md`) is preserved — filtering happens before the positive/negative lists are built. The applied filter specs and a per-target drop breakdown are recorded in the staged `DatasetVersion.filter_criteria` (keys `staging_filters` and `staging_filter_stats`).
+
+---
+
+## 3. Data-Recipe Guidance
+
+Heuristics for planning generation runs, drawn from OpenThoughts-Agent (arXiv 2606.24855). These are **planning heuristics, NOT codified behavior** in this repo — use them to decide what to generate, not as automatic pipeline steps.
+
+- **Task source is the highest-leverage knob.** Swapping/mixing task sources (scenarios) swings results the most. Prefer mixing the top ~4 task sources over over-specializing on a single one; adding many weak sources hurts.
+- **Strongest model ≠ best teacher.** Before committing a big generation run, run a small teacher bake-off across candidate generation models. The SOTA benchmark model is often NOT the best teacher (~5pp swings observed). Use the per-stage model split in scenario YAML to test generation models cheaply.
+- **Difficulty ≈ teacher response length.** When selecting which tasks to keep, prefer tasks where a strong model produces longer responses — a free difficulty proxy worth roughly +3pp. Do **NOT** use embedding-diversity to filter which tasks to keep; in the paper it underperformed random selection.
+- **Keep multi-step trajectories.** Longer agentic trajectories (e.g. `total_turns >= 5`) are higher-quality SFT signal even at a matched token budget. Enforce it with the `total_turns` filter from section 1.
+  - **Caveat for THIS repo:** today's scenarios are mostly single-step (turn counts cluster at 1-3), so the real lever is **authoring genuinely multi-step tasks first** — the filter only helps once such data actually exists.
+- **Augmentation caution.** LLM task-hardening/constraining rewriting was within noise. What scales past the upsampling plateau is **expanding surface forms (paraphrases) of GOOD sources**, not making tasks artificially harder.

--- a/.skills/synethetic-data-generation/SKILL.md
+++ b/.skills/synethetic-data-generation/SKILL.md
@@ -22,6 +22,7 @@ Generate, improve, validate, sanitize, and evaluate synthetic training datasets 
 | Validate dataset | `python -m SynthChat.run validate -i FILE [options]` |
 | Sanitize docs or JSONL | `python -m SynthChat.run sanitize -i PATH --privacy-profile PROFILE [options]` |
 | Evaluate model | `python -m Evaluator.cli --model NAME [options]` |
+| Project rollouts → SFT/KTO/GRPO | `python SynthChat/scripts/project_rollout_datasets.py --input ROLLOUT.jsonl --canonical-output ... --kto-output ... --grpo-output ... [--sft-output ...] [--filter-config FILTER.yaml]` |
 | Structural check | `python3 scripts/validate_syngen.py FILE` |
 | JSONL → Markdown | `./scripts/jsonl_to_markdown.sh data.jsonl` |
 | Combine datasets | `./scripts/combine_datasets.sh -o out.jsonl FILE1 FILE2` |
@@ -48,6 +49,7 @@ Load the specific reference you need:
 | **Rubric Authoring** | Writing or modifying rubric YAMLs | `reference/rubric-authoring.md` |
 | **Testing Protocol** | After creating/modifying scenarios or rubrics — MUST dry-run before full generation | `reference/testing-protocol.md` |
 | **Manual Editing** | Hand-crafting individual dataset lines | `reference/manual-editing.md` |
+| **Rollout Projection & Curation** | Projecting rollouts into SFT/KTO/GRPO datasets, config-driven filtering (`--filter-config`), full multi-turn SFT (`--sft-output`), data-recipe planning heuristics | `reference/rollout-projection.md` |
 
 For environment-backed multi-turn tool data, also load:
 - `reference/scenario-authoring.md` for config-first scenario structure

--- a/.skills/synethetic-data-generation/reference/rollout-projection.md
+++ b/.skills/synethetic-data-generation/reference/rollout-projection.md
@@ -1,0 +1,181 @@
+# Rollout Projection & Dataset Curation Reference
+
+The projector `SynthChat/scripts/project_rollout_datasets.py` turns saved environment-rollout artifacts into training datasets. It always writes canonical, KTO, and GRPO outputs, and can optionally write a full multi-turn SFT output. A config-driven filter engine lets you curate which rollouts reach each projection target.
+
+This reference covers three things:
+
+1. The generic, config-driven **rollout-filter engine** (`--filter-config`)
+2. **Full-trajectory SFT projection** (`--sft-output`)
+3. **Data-recipe guidance** heuristics for planning generation runs
+
+---
+
+## 1. Generic Rollout-Filter Engine
+
+The projector accepts `--filter-config <yaml>` pointing at a YAML file with a `projection.filters` list. The engine lives at `shared/validation/rollout_filters.py` and is fully generic — it filters arbitrary record dicts on ANY field via dot-path, with a generic operator table. It knows nothing about "turns" or "tools" specifically.
+
+**Default OFF.** An empty or absent `--filter-config` is a no-op: every record passes for every target. You opt into filtering by supplying a config.
+
+### YAML shape
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns   # dot-path into the record
+      op: gte
+      value: 5
+      applies_to: [grpo, kto_positive]   # optional; default = sft, grpo, kto_positive (NOT kto_negative)
+      on_missing: keep                   # keep (default) | drop
+```
+
+- `field` — dot-path addressed into the rollout record as-is (top-level keys include `metadata`, so e.g. `metadata.environment.episode_trace.total_turns`).
+- `op` — comparison operator (see below).
+- `value` — the comparison operand. `in`/`not_in` take a list; `exists`/`missing` ignore it.
+- `applies_to` — optional list of targets this filter applies to. When omitted, it applies to the **default target set** (see below).
+- `on_missing` — `keep` (default) or `drop`; decides the verdict when the addressed field is absent.
+
+### Operators
+
+`eq, ne, gt, gte, lt, lte, in, not_in, exists, missing`
+
+- `in` / `not_in` take a **list** value (membership test).
+- `exists` / `missing` test field presence and ignore `value`.
+- Spec validation is eager and fail-closed: an unknown `op`, bad `on_missing`, or a missing required key raises at load time rather than being silently ignored.
+
+### Targets
+
+`sft, grpo, kto_positive, kto_negative`
+
+The **default target set** when `applies_to` is omitted is `sft, grpo, kto_positive`. Hard negatives (`kto_negative`) are **NEVER** filtered unless `kto_negative` is explicitly listed in `applies_to`. This is deliberate: quality filters that drop short or low-scoring rollouts should never silently discard your hard-negative training signal.
+
+### `on_missing` semantics
+
+Records that lack the addressed field **pass through by default** (`on_missing: keep`). Set `on_missing: drop` to exclude records missing the field. There is no silent data loss either way — the choice is explicit per filter.
+
+### AND semantics + drop breakdown
+
+Within a target, all applicable filters must match (logical AND) for a record to pass. When filters are active, the run summary (the JSON the projector prints) includes a `filter_stats` block with a per-target / per-filter drop breakdown so you can see exactly how many records each filter removed.
+
+### Worked examples
+
+**(a) Keep only multi-step trajectories** (applies to the default set: sft, grpo, kto_positive; negatives untouched):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.total_turns
+      op: gte
+      value: 5
+```
+
+**(b) Scope a quality-score floor to SFT only** (KTO/GRPO targets unaffected):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.final_judge.score
+      op: gte
+      value: 0.8
+      applies_to: [sft]
+      on_missing: drop          # SFT rows without a judge score are excluded
+```
+
+**(c) Explicitly filter a stop_reason on hard negatives** (opt-in; this is the only way kto_negative is filtered):
+
+```yaml
+projection:
+  filters:
+    - field: metadata.environment.episode_trace.stop_reason
+      op: ne
+      value: max_tool_steps_exceeded
+      applies_to: [kto_negative]
+      on_missing: drop
+```
+
+---
+
+## 2. Full-Trajectory SFT Projection (`--sft-output`)
+
+The projector has an **optional** `--sft-output <path>`. When provided, each quality-positive rollout is projected into a single FULL multi-turn SFT row:
+
+```json
+{
+  "conversations": [
+    {"role": "system", "content": "..."},
+    {"role": "user", "content": "..."},
+    {"role": "assistant", "content": null, "tool_calls": [...]},
+    {"role": "tool", "content": "..."},
+    {"role": "assistant", "content": "..."}
+  ],
+  "label": true,
+  "total_turns": 5
+}
+```
+
+Behavior:
+
+- It only projects **quality positives** — failed/negative rollouts are skipped for this output.
+- It reconstructs the **whole episode** from `conversation_trace`, dropping the `judge_feedback`, `validation_feedback`, and `final_text_request` scaffolding turns (these are environment scaffolding, not training signal).
+- Tool results become `tool`-role messages on disk; assistant tool-call turns carry `tool_calls`.
+- Schema: `Datasets/environment_rollouts/sft_projection.schema.json`.
+
+### Chat-template behavior
+
+`shared/sft_preprocessing.py` renders the `tool` role to **text** (re-tagged consistent with how the environment presents tool output to the model) at template time. Consequences:
+
+- **Existing single-turn SFT data is unaffected** — rows that use only system/user/assistant roles template identically to before.
+- **Multi-turn rows template into a coherent transcript** — the on-disk `tool` role is rendered into the house ChatML-style text so a chat template that only understands system/user/assistant still produces a sensible transcript.
+- The on-disk `tool` role is **preserved for auditing** — only the template-time rendering flattens it to text; the saved JSONL keeps the structured `tool` messages.
+
+### Full invocation example (all four outputs + filter config)
+
+```bash
+python SynthChat/scripts/project_rollout_datasets.py \
+  --input Datasets/environment_rollouts/run_a.jsonl \
+  --input Datasets/environment_rollouts/run_b.jsonl \
+  --canonical-output Datasets/environment_rollouts/canonical.jsonl \
+  --kto-output Datasets/environment_rollouts/kto.jsonl \
+  --grpo-output Datasets/environment_rollouts/grpo.jsonl \
+  --sft-output Datasets/environment_rollouts/sft.jsonl \
+  --filter-config configs/projection/keep_multistep.yaml
+```
+
+**Omitting `--sft-output` keeps the original 3-output behavior** (canonical/KTO/GRPO only). `--filter-config` is independent and optional in either mode.
+
+### Flywheel staging filters
+
+The same generic filter engine (section 1) is wired into the **flywheel** `DatasetStager` (`shared/flywheel/stager.py`), so you can declaratively filter which inference logs get staged into SFT/KTO/GRPO training sets. It is the **same engine, different field namespace**: flywheel filters evaluate against an inference-log record, not an environment rollout.
+
+**Filter view (the dot-path namespace).** Each record is exposed as a "filter view" dict with two layers:
+
+- **Record fields at the top level** (from `InferenceLogRecord`): `log_id`, `timestamp`, `model_id`, `adapter_name`, `temperature`, `max_tokens`, `tools_requested`, `finish_reason`, `prompt_tokens`, `completion_tokens`, `latency_ms`, `fitness_score`, `is_valid`, `tag`, `dataset_version`, `source_file`, `line_number`, `tenant_id`.
+- **Parsed log content under a `content.` prefix**: e.g. `content.messages`, `content.response_content`, `content.tool_calls`, `content.completion_token_ids`.
+
+So a researcher can write `field: fitness_score` (record field) or `field: content.response_content` (transcript). For records read from the catalog index, prefer the `content.*` view for transcript data — only index-backed fields are populated at the top level.
+
+**Config key.** Filters live under the top-level `filters:` key of the flywheel config YAML (loaded into `FlywheelConfig.filters`), using the same spec shape as section 1:
+
+```yaml
+# configs/flywheel/<your>.yaml
+filters:
+  - field: fitness_score
+    op: gte
+    value: 0.85
+```
+
+Empty/absent `filters:` is a no-op — default staging behavior is unchanged.
+
+**Default targets.** The stager's targets are `sft`, `kto_positive`, `kto_negative`, `grpo`. The **default target set** (when `applies_to` is omitted) is `sft, kto_positive, grpo` — it **excludes `kto_negative`**, matching the projector convention: quality filters must not silently drop hard negatives unless a researcher explicitly lists `kto_negative` in `applies_to`. KTO interleaving (per `KTO_TRAINING_REFERENCE.md`) is preserved — filtering happens before the positive/negative lists are built. The applied filter specs and a per-target drop breakdown are recorded in the staged `DatasetVersion.filter_criteria` (keys `staging_filters` and `staging_filter_stats`).
+
+---
+
+## 3. Data-Recipe Guidance
+
+Heuristics for planning generation runs, drawn from OpenThoughts-Agent (arXiv 2606.24855). These are **planning heuristics, NOT codified behavior** in this repo — use them to decide what to generate, not as automatic pipeline steps.
+
+- **Task source is the highest-leverage knob.** Swapping/mixing task sources (scenarios) swings results the most. Prefer mixing the top ~4 task sources over over-specializing on a single one; adding many weak sources hurts.
+- **Strongest model ≠ best teacher.** Before committing a big generation run, run a small teacher bake-off across candidate generation models. The SOTA benchmark model is often NOT the best teacher (~5pp swings observed). Use the per-stage model split in scenario YAML to test generation models cheaply.
+- **Difficulty ≈ teacher response length.** When selecting which tasks to keep, prefer tasks where a strong model produces longer responses — a free difficulty proxy worth roughly +3pp. Do **NOT** use embedding-diversity to filter which tasks to keep; in the paper it underperformed random selection.
+- **Keep multi-step trajectories.** Longer agentic trajectories (e.g. `total_turns >= 5`) are higher-quality SFT signal even at a matched token budget. Enforce it with the `total_turns` filter from section 1.
+  - **Caveat for THIS repo:** today's scenarios are mostly single-step (turn counts cluster at 1-3), so the real lever is **authoring genuinely multi-step tasks first** — the filter only helps once such data actually exists.
+- **Augmentation caution.** LLM task-hardening/constraining rewriting was within noise. What scales past the upsampling plateau is **expanding surface forms (paraphrases) of GOOD sources**, not making tasks artificially harder.

--- a/Datasets/environment_rollouts/grpo_projection.schema.json
+++ b/Datasets/environment_rollouts/grpo_projection.schema.json
@@ -58,6 +58,10 @@
       "type": "integer",
       "minimum": 0
     },
+    "total_turns": {
+      "type": "integer",
+      "minimum": 0
+    },
     "failure_labels": {
       "type": "array",
       "items": {

--- a/Datasets/environment_rollouts/sft_projection.schema.json
+++ b/Datasets/environment_rollouts/sft_projection.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://syntheticconversations.local/schemas/sft_projection.schema.json",
+  "title": "SFT Projection Record",
+  "type": "object",
+  "required": [
+    "conversations"
+  ],
+  "properties": {
+    "conversations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "role",
+          "content"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool"
+            ]
+          },
+          "content": {
+            "type": ["string", "null"]
+          },
+          "tool_calls": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "label": {
+      "type": "boolean"
+    },
+    "scenario_id": {
+      "type": "string"
+    },
+    "scenario_family": {
+      "type": "string"
+    },
+    "source_example_id": {
+      "type": "string"
+    },
+    "total_turns": {
+      "type": "integer"
+    },
+    "metadata": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/SynthChat/scripts/project_rollout_datasets.py
+++ b/SynthChat/scripts/project_rollout_datasets.py
@@ -5,8 +5,26 @@ from __future__ import annotations
 
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Ensure the repo root is importable so `shared.*` resolves when this script is
+# run directly by path (the README-documented form), not just via `python -m`.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from shared.utilities import load_yaml
+from shared.validation import FilterStats, RolloutFilterSet
+
+# Canonical projection-target names usable in a filter spec's ``applies_to``.
+PROJECTION_TARGETS = ("sft", "grpo", "kto_positive", "kto_negative")
+
+# Default target set for a filter that omits ``applies_to``. Quality filters
+# should apply to positive/GRPO/SFT projections but MUST NOT silently drop hard
+# negatives — a researcher must explicitly list ``kto_negative`` to filter them.
+DEFAULT_FILTER_TARGETS = ("sft", "grpo", "kto_positive")
 
 
 def _iter_records(paths: Iterable[Path]) -> Iterable[Tuple[Path, int, Dict[str, Any]]]:
@@ -138,7 +156,162 @@ def _is_meaningful_negative(metadata: Dict[str, Any]) -> bool:
     return True
 
 
-def _build_kto_row(path: Path, line_index: int, row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _passes_filters(
+    row: Dict[str, Any],
+    target: str,
+    filter_set: Optional[RolloutFilterSet],
+    stats: Optional[FilterStats],
+) -> bool:
+    """Apply the configured filter set to ``row`` for one projection target.
+
+    Returns True when the record passes (or when no filters are configured).
+    Records the decision into ``stats`` for the per-target/per-filter breakdown.
+    The record is evaluated as-is so filters can address any field via dot-path
+    (e.g. ``metadata.environment.episode_trace.total_turns``).
+    """
+    if filter_set is None or filter_set.is_empty:
+        return True
+    decision = filter_set.apply(row, target)
+    if stats is not None:
+        stats.record(target, filter_set, decision)
+    return decision.passed
+
+
+# Trace turn kinds that are NOT part of the trainable transcript. Mirrors the
+# exclusions in _trace_prompt_messages: judge/validation feedback and the
+# final-text request are environment scaffolding, not model training signal.
+_SFT_DROP_KINDS = {"judge_feedback", "validation_feedback", "final_text_request"}
+
+
+def _trace_assistant_content(turn: Dict[str, Any]) -> Optional[str]:
+    """Authoritative assistant text for an assistant_response turn.
+
+    Reads ``turn["raw"]["content"]`` (the real model content: a string for text
+    turns, ``None`` for pure tool-call turns). The top-level ``turn["content"]``
+    is a human-readable display repr (e.g. "Tool calls: [...]") and MUST NOT be
+    used as training content. If the trace carries separate reasoning/thinking
+    content, it is wrapped in <thinking>...</thinking> to match the thinking
+    datasets — only when such a field actually exists in the trace.
+    """
+    raw = turn.get("raw") or {}
+    content = raw.get("content")
+    text = content.strip() if isinstance(content, str) and content.strip() else None
+
+    reasoning = raw.get("reasoning") or raw.get("thinking")
+    if isinstance(reasoning, str) and reasoning.strip():
+        thinking_block = f"<thinking>{reasoning.strip()}</thinking>"
+        return f"{thinking_block}\n\n{text}" if text else thinking_block
+    return text
+
+
+def _build_sft_row(
+    path: Path,
+    line_index: int,
+    row: Dict[str, Any],
+    filter_set: Optional[RolloutFilterSet] = None,
+    stats: Optional[FilterStats] = None,
+) -> Optional[Dict[str, Any]]:
+    """Project a successful rollout into a full multi-turn SFT row.
+
+    Reconstructs the entire conversation from ``conversation_trace`` in order,
+    preserving OpenAI-style assistant ``tool_calls`` and emitting tool-result
+    turns as ``tool``-role messages. Only quality positives are projected, and
+    the generic filter engine is applied at the ``sft`` target seam.
+    """
+    metadata = row.get("metadata") or {}
+    if not _is_quality_positive(metadata):
+        return None
+
+    if not _passes_filters(row, "sft", filter_set, stats):
+        return None
+
+    trace = row.get("conversation_trace") or []
+    if not isinstance(trace, list):
+        return None
+
+    conversations: List[Dict[str, Any]] = []
+    has_user = False
+    has_assistant = False
+
+    for turn in trace:
+        if not isinstance(turn, dict):
+            continue
+        role = turn.get("role")
+        kind = turn.get("kind")
+
+        # Drop non-training scaffolding turns (judge/validation feedback, the
+        # final-text request). Mirrors _trace_prompt_messages exclusions.
+        if kind in _SFT_DROP_KINDS:
+            continue
+
+        if kind == "assistant_response":
+            content = _trace_assistant_content(turn)
+            tool_calls = _assistant_tool_calls(turn)
+            if content is None and not tool_calls:
+                # Degenerate empty assistant turn — skip it.
+                continue
+            message: Dict[str, Any] = {"role": "assistant", "content": content}
+            if tool_calls:
+                message["tool_calls"] = tool_calls
+            conversations.append(message)
+            has_assistant = True
+            continue
+
+        # Tool results surface in the trace as user turns tagged
+        # kind == "tool_feedback"; re-tag them as canonical tool-role messages.
+        if kind == "tool_feedback":
+            content = _trace_message_content(turn)
+            if content is None:
+                continue
+            conversations.append({"role": "tool", "content": content})
+            continue
+
+        if role == "system":
+            content = _trace_message_content(turn)
+            if content is None:
+                continue
+            conversations.append({"role": "system", "content": content})
+            continue
+
+        if role == "user":
+            content = _trace_message_content(turn)
+            if content is None:
+                continue
+            conversations.append({"role": "user", "content": content})
+            has_user = True
+            continue
+
+        # Unknown role/kind — drop conservatively (no silent inclusion).
+
+    if not has_assistant or not has_user:
+        return None
+
+    environment = metadata.get("environment") or {}
+    episode_trace = environment.get("episode_trace") or {}
+
+    return {
+        "conversations": conversations,
+        "label": True,
+        "scenario_id": str(metadata.get("scenario") or "unknown"),
+        "scenario_family": _scenario_family(metadata),
+        "source_example_id": f"{path.name}:{line_index}",
+        "total_turns": int(episode_trace.get("total_turns") or 0),
+        "metadata": {
+            "source_artifact": path.name,
+            "seed_id": ((metadata.get("environment_seed") or {}).get("seed_id")),
+            "scenario": metadata.get("scenario"),
+            "stop_reason": episode_trace.get("stop_reason"),
+        },
+    }
+
+
+def _build_kto_row(
+    path: Path,
+    line_index: int,
+    row: Dict[str, Any],
+    filter_set: Optional[RolloutFilterSet] = None,
+    stats: Optional[FilterStats] = None,
+) -> Optional[Dict[str, Any]]:
     metadata = row.get("metadata") or {}
     label = _kto_label(metadata)
     if label is None:
@@ -156,6 +329,13 @@ def _build_kto_row(path: Path, line_index: int, row: Dict[str, Any]) -> Optional
     if label is True and not _is_quality_positive(metadata):
         return None
     if label is False and not _is_meaningful_negative(metadata):
+        return None
+
+    # Apply config filters at the per-target seam. kto_negative is only filtered
+    # when a researcher explicitly lists it in a filter's ``applies_to`` (it is
+    # excluded from DEFAULT_FILTER_TARGETS).
+    kto_target = "kto_positive" if label is True else "kto_negative"
+    if not _passes_filters(row, kto_target, filter_set, stats):
         return None
 
     return {
@@ -180,9 +360,18 @@ def _build_kto_row(path: Path, line_index: int, row: Dict[str, Any]) -> Optional
     }
 
 
-def _build_grpo_row(path: Path, line_index: int, row: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def _build_grpo_row(
+    path: Path,
+    line_index: int,
+    row: Dict[str, Any],
+    filter_set: Optional[RolloutFilterSet] = None,
+    stats: Optional[FilterStats] = None,
+) -> Optional[Dict[str, Any]]:
     metadata = row.get("metadata") or {}
     if not _is_quality_positive(metadata):
+        return None
+
+    if not _passes_filters(row, "grpo", filter_set, stats):
         return None
 
     conversations = row.get("conversations") or []
@@ -213,6 +402,7 @@ def _build_grpo_row(path: Path, line_index: int, row: Dict[str, Any]) -> Optiona
         "score_tier": "acceptable",
         "stop_reason": ((environment.get("episode_trace") or {}).get("stop_reason")),
         "tool_call_count": int((environment.get("episode_trace") or {}).get("total_tool_calls") or 0),
+        "total_turns": int((environment.get("episode_trace") or {}).get("total_turns") or 0),
         "failure_labels": _issue_labels(metadata),
         "ground_truth_tool": tool_name,
         "ground_truth_args_json": json.dumps(tool_args, sort_keys=True) if tool_args is not None else None,
@@ -229,9 +419,14 @@ def _build_grpo_tool_turn_rows(
     line_index: int,
     row: Dict[str, Any],
     prompt_context: str,
+    filter_set: Optional[RolloutFilterSet] = None,
+    stats: Optional[FilterStats] = None,
 ) -> List[Dict[str, Any]]:
     metadata = row.get("metadata") or {}
     if not _is_quality_positive(metadata):
+        return []
+
+    if not _passes_filters(row, "grpo", filter_set, stats):
         return []
 
     trace = row.get("conversation_trace") or []
@@ -263,6 +458,7 @@ def _build_grpo_tool_turn_rows(
             "score_tier": "acceptable",
             "stop_reason": ((metadata.get("environment") or {}).get("episode_trace") or {}).get("stop_reason"),
             "tool_call_count": int(((metadata.get("environment") or {}).get("episode_trace") or {}).get("total_tool_calls") or 0),
+            "total_turns": int(((metadata.get("environment") or {}).get("episode_trace") or {}).get("total_turns") or 0),
             "failure_labels": _issue_labels(metadata),
             "ground_truth_tool": tool_name,
             "ground_truth_args_json": json.dumps(tool_args, sort_keys=True) if tool_args is not None else None,
@@ -276,6 +472,22 @@ def _build_grpo_tool_turn_rows(
             },
         })
     return rows
+
+
+def _load_filter_set(filter_config: Optional[str]) -> Optional[RolloutFilterSet]:
+    """Build a RolloutFilterSet from a YAML config file's projection.filters list.
+
+    The config channel mirrors this file's existing YAML/dict-of-config idiom:
+    a single YAML document whose ``projection.filters`` key holds the list of
+    declarative filter specs. Returns None when no config is supplied (no-op).
+    Invalid specs raise ValueError eagerly (fail-closed) at load time.
+    """
+    if not filter_config:
+        return None
+    config = load_yaml(filter_config)
+    projection = config.get("projection") if isinstance(config, dict) else None
+    filters = (projection or {}).get("filters") if isinstance(projection, dict) else None
+    return RolloutFilterSet(filters=filters or [], default_targets=DEFAULT_FILTER_TARGETS)
 
 
 def _write_jsonl(path: Path, rows: Iterable[Dict[str, Any]]) -> int:
@@ -295,6 +507,16 @@ def main() -> int:
     parser.add_argument("--kto-output", required=True, help="Output JSONL path for projected KTO records.")
     parser.add_argument("--grpo-output", required=True, help="Output JSONL path for projected GRPO records.")
     parser.add_argument(
+        "--sft-output",
+        default=None,
+        help=(
+            "Optional output JSONL path for full multi-turn SFT records. When "
+            "provided, each quality-positive rollout is projected into a single "
+            "multi-turn conversation (system/user/assistant/tool turns). Omit to "
+            "skip SFT projection (keeps the existing canonical/KTO/GRPO invocation)."
+        ),
+    )
+    parser.add_argument(
         "--grpo-projection",
         choices=["first_tool", "tool_turns"],
         default="first_tool",
@@ -306,22 +528,44 @@ def main() -> int:
         default="user_only",
         help="Prompt context for tool_turns projection. prior_real_messages keeps user/assistant/tool-feedback turns and drops system/judge/validation turns.",
     )
+    parser.add_argument(
+        "--filter-config",
+        default=None,
+        help=(
+            "Path to a YAML file with a 'projection.filters' list of declarative "
+            "rollout filters applied per projection target "
+            f"({', '.join(PROJECTION_TARGETS)}). See shared/validation/rollout_filters.py "
+            "for the spec and a YAML example."
+        ),
+    )
     args = parser.parse_args()
+
+    filter_set = _load_filter_set(args.filter_config)
+    filter_stats = FilterStats()
 
     input_paths = [Path(item).expanduser().resolve() for item in args.input]
     canonical_rows: List[Dict[str, Any]] = []
     kto_rows: List[Dict[str, Any]] = []
     grpo_rows: List[Dict[str, Any]] = []
+    sft_rows: List[Dict[str, Any]] = []
 
     for path, line_index, row in _iter_records(input_paths):
         canonical_rows.append(_build_canonical_row(path, row))
-        kto_row = _build_kto_row(path, line_index, row)
+        kto_row = _build_kto_row(path, line_index, row, filter_set, filter_stats)
         if kto_row is not None:
             kto_rows.append(kto_row)
+        if args.sft_output:
+            sft_row = _build_sft_row(path, line_index, row, filter_set, filter_stats)
+            if sft_row is not None:
+                sft_rows.append(sft_row)
         if args.grpo_projection == "tool_turns":
-            grpo_rows.extend(_build_grpo_tool_turn_rows(path, line_index, row, args.grpo_prompt_context))
+            grpo_rows.extend(
+                _build_grpo_tool_turn_rows(
+                    path, line_index, row, args.grpo_prompt_context, filter_set, filter_stats
+                )
+            )
         else:
-            grpo_row = _build_grpo_row(path, line_index, row)
+            grpo_row = _build_grpo_row(path, line_index, row, filter_set, filter_stats)
             if grpo_row is not None:
                 grpo_rows.append(grpo_row)
 
@@ -329,7 +573,7 @@ def main() -> int:
     kto_count = _write_jsonl(Path(args.kto_output), kto_rows)
     grpo_count = _write_jsonl(Path(args.grpo_output), grpo_rows)
 
-    print(json.dumps({
+    summary: Dict[str, Any] = {
         "canonical_output": str(Path(args.canonical_output)),
         "canonical_count": canonical_count,
         "kto_output": str(Path(args.kto_output)),
@@ -338,7 +582,15 @@ def main() -> int:
         "grpo_count": grpo_count,
         "grpo_projection": args.grpo_projection,
         "grpo_prompt_context": args.grpo_prompt_context,
-    }, indent=2))
+    }
+    if args.sft_output:
+        sft_count = _write_jsonl(Path(args.sft_output), sft_rows)
+        summary["sft_output"] = str(Path(args.sft_output))
+        summary["sft_count"] = sft_count
+    if filter_set is not None and not filter_set.is_empty:
+        summary["filter_config"] = str(Path(args.filter_config))
+        summary["filter_stats"] = filter_stats.as_dict()
+    print(json.dumps(summary, indent=2))
     return 0
 
 

--- a/shared/flywheel/config.py
+++ b/shared/flywheel/config.py
@@ -102,6 +102,17 @@ class FlywheelConfig:
     # -- Validation rules for FitnessEvaluator --
     validation_rules: list[dict] = field(default_factory=list)
 
+    # -- Staging filters --
+    # Optional declarative filter specs applied by DatasetStager when assembling
+    # SFT/KTO/GRPO datasets. Each entry is a spec dict consumed by the generic
+    # rollout-filter engine (shared/validation/rollout_filters.py):
+    #   {field, op, value, applies_to?, on_missing?}
+    # Filters evaluate against an inference-log filter view (record fields at the
+    # top level + parsed log content under a "content." prefix). Empty/absent =
+    # no-op (default staging behavior is unchanged). Invalid specs raise
+    # ValueError at stager construction.
+    filters: list[dict] = field(default_factory=list)
+
     def to_fitness_config(self) -> dict[str, Any]:
         """Build FitnessEvaluator config dict from flywheel settings.
 

--- a/shared/flywheel/stager.py
+++ b/shared/flywheel/stager.py
@@ -18,11 +18,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from shared.validation import FilterStats, RolloutFilterSet
+
 from .catalog import DatasetVersion, InferenceLogRecord, LogCatalog, LogFilter
 from .config import FlywheelConfig
 from .utils import read_log_content
 
 logger = logging.getLogger(__name__)
+
+# Default target set for a staging filter that omits ``applies_to``. Quality
+# filters apply to the positive/GRPO targets only; ``kto_negative`` is excluded
+# so hard negatives are never silently dropped unless a researcher explicitly
+# lists ``kto_negative`` in ``applies_to`` (mirrors the projector convention).
+_DEFAULT_FILTER_TARGETS = ("sft", "kto_positive", "grpo")
 
 
 @dataclass
@@ -65,6 +73,13 @@ class DatasetStager:
         self._config = config
         self._datasets_dir = Path(
             datasets_dir or config.datasets_dir,
+        )
+        # Build the declarative staging filter engine. Invalid specs raise
+        # ValueError here (fail-closed at construction). An empty config yields
+        # an empty set whose .apply() is a pass-all no-op.
+        self._filter_set = RolloutFilterSet(
+            filters=config.filters or [],
+            default_targets=_DEFAULT_FILTER_TARGETS,
         )
 
     async def stage_dataset(
@@ -112,10 +127,14 @@ class DatasetStager:
         file_paths: dict[str, Path] = {}
         used_log_ids: list[str] = []
 
+        # Accumulate per-target/per-filter drop stats for this staging run.
+        # Fresh per run so re-staging never carries stale tallies.
+        filter_stats = FilterStats()
+
         # Stage SFT examples
         if sft_logs:
             sft_path = version_dir / "sft_training.jsonl"
-            sft_count = self._write_sft(sft_logs, sft_path)
+            sft_count = self._write_sft(sft_logs, sft_path, filter_stats)
             result.sft_count = sft_count
             file_paths["sft"] = sft_path
             used_log_ids.extend(r.log_id for r in sft_logs)
@@ -123,7 +142,7 @@ class DatasetStager:
         # Stage KTO examples (SFT logs as positive, KTO logs as negative)
         if sft_logs or kto_logs:
             kto_path = version_dir / "kto_training.jsonl"
-            pos, neg = self._write_kto(sft_logs, kto_logs, kto_path)
+            pos, neg = self._write_kto(sft_logs, kto_logs, kto_path, filter_stats)
             result.kto_pos_count = pos
             result.kto_neg_count = neg
             file_paths["kto"] = kto_path
@@ -132,7 +151,7 @@ class DatasetStager:
         # Stage GRPO examples
         if grpo_logs and self._config.grpo_enabled:
             grpo_path = version_dir / "grpo_training.jsonl"
-            grpo_count = self._write_grpo(grpo_logs, grpo_path)
+            grpo_count = self._write_grpo(grpo_logs, grpo_path, filter_stats)
             result.grpo_count = grpo_count
             file_paths["grpo"] = grpo_path
             used_log_ids.extend(r.log_id for r in grpo_logs)
@@ -168,6 +187,13 @@ class DatasetStager:
                 "sft_threshold": self._config.sft_threshold,
                 "kto_min_threshold": self._config.kto_min_threshold,
                 "scoring_method": self._config.scoring_method,
+                # Declarative staging filters applied to this version (empty when
+                # no filters configured). Records what filtering was applied so a
+                # staged version is self-describing.
+                "staging_filters": [f.describe() for f in self._filter_set.filters],
+                "staging_filter_stats": (
+                    {} if filter_stats.is_empty else filter_stats.as_dict()
+                ),
             },
         )
 
@@ -200,7 +226,71 @@ class DatasetStager:
             version_id, result.sft_count, result.kto_pos_count,
             result.kto_neg_count, result.grpo_count,
         )
+        if not self._filter_set.is_empty and not filter_stats.is_empty:
+            logger.info(
+                "Staging filter breakdown (per target): %s",
+                filter_stats.as_dict(),
+            )
         return result
+
+    @staticmethod
+    def _filter_view(record: InferenceLogRecord, content: dict) -> dict[str, Any]:
+        """Build the dot-path namespace a staging filter evaluates against.
+
+        Filters in the flywheel address an inference-log record, not an
+        environment rollout, so the namespace differs from the projector.
+        Exactly two layers are exposed:
+
+        * Record-level fields at the TOP level — the real
+          :class:`~shared.flywheel.catalog.InferenceLogRecord` dataclass fields
+          (via ``dataclasses.asdict``). Notable keys a researcher can address:
+          ``log_id``, ``timestamp``, ``model_id``, ``adapter_name``,
+          ``temperature``, ``max_tokens``, ``tools_requested``,
+          ``finish_reason``, ``prompt_tokens``, ``completion_tokens``,
+          ``latency_ms``, ``fitness_score``, ``is_valid``, ``tag``,
+          ``dataset_version``, ``source_file``, ``line_number``, ``tenant_id``.
+          (``messages``, ``tools``, ``tool_calls``, ``response_content`` and the
+          token-id capture fields also exist on the dataclass but, for records
+          read from the catalog index, only the index-backed fields are
+          populated — prefer the ``content.*`` view below for transcript data.)
+
+        * The parsed log content under a ``content.`` prefix — e.g.
+          ``content.messages``, ``content.response_content``,
+          ``content.tool_calls``, ``content.completion_token_ids``. This is the
+          authoritative source of the request/response transcript.
+
+        So a researcher can write ``field: fitness_score`` or
+        ``field: content.response_content``. Record fields take the top level;
+        the raw content dict is nested under ``content`` (never merged, so a
+        ``content`` key inside the log cannot shadow a record field).
+        """
+        from dataclasses import asdict
+
+        view: dict[str, Any] = asdict(record)
+        view["content"] = content
+        return view
+
+    def _passes_filters(
+        self,
+        record: InferenceLogRecord,
+        content: dict,
+        target: str,
+        stats: FilterStats | None,
+    ) -> bool:
+        """Apply the configured filter set to ``record`` for one staging target.
+
+        Returns True when the record passes (or when no filters are
+        configured). Records the decision into ``stats`` for the per-target /
+        per-filter breakdown. Mirrors ``_passes_filters`` in the SynthChat
+        projector, but with the stager's targets and filter view.
+        """
+        if self._filter_set.is_empty:
+            return True
+        view = self._filter_view(record, content)
+        decision = self._filter_set.apply(view, target)
+        if stats is not None:
+            stats.record(target, self._filter_set, decision)
+        return decision.passed
 
     def _next_version_id(self) -> str:
         """Determine next version ID by scanning datasets directory."""
@@ -222,14 +312,23 @@ class DatasetStager:
             return "v001"
 
     def _write_sft(
-        self, logs: list[InferenceLogRecord], path: Path,
+        self,
+        logs: list[InferenceLogRecord],
+        path: Path,
+        stats: FilterStats | None = None,
     ) -> int:
-        """Write SFT training examples (label: true)."""
+        """Write SFT training examples (label: true).
+
+        Records that fail the configured staging filters for the ``"sft"``
+        target are skipped, so the returned count is the post-filter count.
+        """
         count = 0
         with open(path, "w", encoding="utf-8") as f:
             for record in logs:
                 content = self._read_log_content(record)
                 if not content:
+                    continue
+                if not self._passes_filters(record, content, "sft", stats):
                     continue
                 example = self._format_sft_example(record, content)
                 f.write(json.dumps(example, ensure_ascii=False) + "\n")
@@ -241,6 +340,7 @@ class DatasetStager:
         sft_logs: list[InferenceLogRecord],
         kto_logs: list[InferenceLogRecord],
         path: Path,
+        stats: FilterStats | None = None,
     ) -> tuple[int, int]:
         """Write KTO training examples with interleaved positive/negative pairs.
 
@@ -248,6 +348,14 @@ class DatasetStager:
         true/false examples. We zip positives and negatives, writing
         alternating pairs. When one list is exhausted, remaining items
         from the longer list are appended at the end.
+
+        Staging filters are applied per-target BEFORE the pos/neg example lists
+        are built, so the zip_longest interleaving operates on already-filtered
+        lists and stays intact. Positives (from ``sft_logs``) use the
+        ``"kto_positive"`` target; negatives (from ``kto_logs``) use the
+        ``"kto_negative"`` target — which is excluded from the default target
+        set, so hard negatives are never dropped unless a filter explicitly
+        opts in via ``applies_to: [kto_negative]``.
         """
         pos_examples: list[dict] = []
         neg_examples: list[dict] = []
@@ -256,11 +364,15 @@ class DatasetStager:
             content = self._read_log_content(record)
             if not content:
                 continue
+            if not self._passes_filters(record, content, "kto_positive", stats):
+                continue
             pos_examples.append(self._format_kto_example(record, content, label=True))
 
         for record in kto_logs:
             content = self._read_log_content(record)
             if not content:
+                continue
+            if not self._passes_filters(record, content, "kto_negative", stats):
                 continue
             neg_examples.append(self._format_kto_example(record, content, label=False))
 
@@ -277,14 +389,23 @@ class DatasetStager:
         return len(pos_examples), len(neg_examples)
 
     def _write_grpo(
-        self, logs: list[InferenceLogRecord], path: Path,
+        self,
+        logs: list[InferenceLogRecord],
+        path: Path,
+        stats: FilterStats | None = None,
     ) -> int:
-        """Write GRPO training examples (with reward signal)."""
+        """Write GRPO training examples (with reward signal).
+
+        Records that fail the configured staging filters for the ``"grpo"``
+        target are skipped, so the returned count is the post-filter count.
+        """
         count = 0
         with open(path, "w", encoding="utf-8") as f:
             for record in logs:
                 content = self._read_log_content(record)
                 if not content:
+                    continue
+                if not self._passes_filters(record, content, "grpo", stats):
                     continue
                 example = self._format_grpo_example(record, content)
                 f.write(json.dumps(example, ensure_ascii=False) + "\n")

--- a/shared/sft_preprocessing.py
+++ b/shared/sft_preprocessing.py
@@ -51,11 +51,62 @@ def render_tool_call_content(tool_calls: list[dict[str, Any]]) -> str:
     return "\n\n".join(rendered_parts)
 
 
+def render_tool_result_content(content: Any) -> str:
+    """Render a tool-result message body into the repo's ChatML-style text format.
+
+    Mirrors :func:`render_tool_call_content` (which renders assistant *requests*),
+    producing the symmetric *result* side of a tool exchange. JSON-shaped bodies are
+    pretty-printed; everything else is stringified verbatim. The ``tool_result:``
+    label keeps multi-turn transcripts coherent and visually paired with the
+    ``tool_call:`` label emitted for assistant tool calls.
+    """
+    if isinstance(content, str):
+        body = content
+    elif content is None:
+        body = ""
+    else:
+        body = json.dumps(content, ensure_ascii=False, indent=2)
+    return f"tool_result:\n{body}" if body else "tool_result:"
+
+
 def sanitize_messages_for_chat_template(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Normalize nullable content and render tool calls into assistant text."""
+    """Normalize nullable content and render tool calls/results into plain text.
+
+    Behavior is split by role so multi-turn trajectories template coherently while
+    existing single-turn rows stay byte-identical:
+
+    * ``system`` / ``user`` / ``assistant`` — unchanged from the original contract:
+      ``None`` content becomes ``""``, non-string content is JSON-encoded, and any
+      assistant ``tool_calls`` are rendered into text via
+      :func:`render_tool_call_content` then popped. Existing data uses only these
+      roles, so their output is identical to before this function learned about
+      tool-result messages.
+    * ``tool`` — a tool-RESULT message (the environment's reply to an assistant
+      tool call). The repo's house style renders tool exchanges into *text* rather
+      than passing them structurally to the chat template, and most chat templates
+      only understand system/user/assistant roles. To keep the render-to-text style
+      consistent AND guarantee the transcript templates on any tokenizer, the result
+      body is rendered via :func:`render_tool_result_content` and the message is
+      re-tagged with ``role: "user"``. This matches how the rollout environment
+      itself presents tool output (as a ``user`` turn carrying the execution
+      result), so it is faithful to the source trace, not a lossy approximation.
+
+    No existing single-turn row contains a ``tool`` role, so this branch is purely
+    additive and cannot perturb the byte output of any current SFT example.
+    """
     sanitized: list[dict[str, Any]] = []
     for message in messages:
         normalized = dict(message)
+        role = normalized.get("role")
+
+        if role == "tool":
+            rendered = render_tool_result_content(normalized.get("content"))
+            normalized["role"] = "user"
+            normalized["content"] = rendered
+            normalized.pop("tool_calls", None)
+            sanitized.append(normalized)
+            continue
+
         content = normalized.get("content")
         if content is None:
             content = ""

--- a/shared/validation/__init__.py
+++ b/shared/validation/__init__.py
@@ -38,6 +38,14 @@ from .fitness import (
     FitnessResult,
     create_fitness_evaluator,
 )
+from .rollout_filters import (
+    MISSING,
+    get_path,
+    FilterDecision,
+    RolloutFilter,
+    RolloutFilterSet,
+    FilterStats,
+)
 
 __all__ = [
     # Parsing
@@ -61,4 +69,11 @@ __all__ = [
     "FitnessEvaluator",
     "FitnessResult",
     "create_fitness_evaluator",
+    # Rollout filtering
+    "MISSING",
+    "get_path",
+    "FilterDecision",
+    "RolloutFilter",
+    "RolloutFilterSet",
+    "FilterStats",
 ]

--- a/shared/validation/rollout_filters.py
+++ b/shared/validation/rollout_filters.py
@@ -1,0 +1,497 @@
+"""Generic, declarative, config-driven rollout filtering engine.
+
+Location: ``shared/validation/rollout_filters.py``
+
+Summary:
+    A standalone, dependency-light engine for filtering arbitrary record dicts
+    on ANY field via a declarative list of filter specs. It knows nothing about
+    "turns", "tools", or any specific rollout shape — every field is addressed
+    by a dot-path and every comparison goes through a generic operator table.
+
+How it is used:
+    The SynthChat rollout -> training-set projector
+    (``SynthChat/scripts/project_rollout_datasets.py``) builds a
+    :class:`RolloutFilterSet` from a ``projection.filters`` config list and
+    applies it per projection target (``sft``, ``grpo``, ``kto_positive``,
+    ``kto_negative``). The engine is intentionally generic so the flywheel
+    stager (``shared/flywheel/...``) and any future projection path can import
+    and reuse it without modification.
+
+Config (YAML) example::
+
+    projection:
+      filters:
+        # Drop short rollouts from the positive/GRPO targets (the default set).
+        - field: environment.episode_trace.total_turns
+          op: gte
+          value: 5
+          on_missing: keep          # records lacking the field pass through
+
+        # Only keep a specific scenario family on the SFT target.
+        - field: metadata.scenario_family
+          op: in
+          value: ["tool_calling", "agentic_search"]
+          applies_to: ["sft"]
+
+        # Explicitly filter hard negatives too (rare; opt-in).
+        - field: environment.episode_trace.stop_reason
+          op: ne
+          value: "max_tool_steps_exceeded"
+          applies_to: ["kto_negative"]
+          on_missing: drop
+
+Semantics:
+    * A record PASSES a ``target`` iff ALL filters that apply to that target
+      match (logical AND). A filter "applies" to ``target`` when its
+      ``applies_to`` list includes ``target``, or — if ``applies_to`` is
+      omitted — when ``target`` is in the caller-supplied default target set.
+    * An empty filter set always passes (no-op).
+    * ``on_missing`` (``keep``|``drop``, default ``keep``) decides the verdict
+      when the addressed field resolves to :data:`MISSING`.
+
+Fail-closed posture:
+    Spec validation is eager. Unknown ``op``, bad ``on_missing``, or missing
+    required keys raise :class:`ValueError` at construction time rather than
+    being silently ignored.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+
+class _Missing:
+    """Sentinel type for an absent dot-path value.
+
+    A dedicated singleton (rather than ``None``) so that a field whose real
+    stored value is ``None`` is distinguishable from a field that is absent.
+    """
+
+    _instance: Optional["_Missing"] = None
+
+    def __new__(cls) -> "_Missing":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return "MISSING"
+
+    def __bool__(self) -> bool:  # pragma: no cover - trivial
+        return False
+
+
+MISSING = _Missing()
+"""Module-level sentinel returned by :func:`get_path` when a field is absent."""
+
+
+def get_path(record: Dict[str, Any], path: str) -> Any:
+    """Resolve a dot-path like ``"a.b.c"`` into nested dicts.
+
+    Mirrors the nested-get style already used in the projector
+    (e.g. ``(environment.get("episode_trace") or {}).get("total_tool_calls")``)
+    but generalized to an arbitrary depth.
+
+    Args:
+        record: The record dict to traverse.
+        path: Dot-separated key path. Each segment indexes one dict level.
+
+    Returns:
+        The resolved value, or :data:`MISSING` if any segment is absent or a
+        non-dict is encountered before the path is exhausted.
+    """
+    if not isinstance(path, str) or not path:
+        return MISSING
+    current: Any = record
+    for segment in path.split("."):
+        if not isinstance(current, dict) or segment not in current:
+            return MISSING
+        current = current[segment]
+    return current
+
+
+# ---------------------------------------------------------------------------
+# Operator table
+# ---------------------------------------------------------------------------
+
+def _safe_compare(op: Callable[[Any, Any], bool], left: Any, right: Any) -> bool:
+    """Run a comparison operator, treating incomparable operands as non-match.
+
+    Numeric/ordered comparisons (gt/gte/lt/lte) raise ``TypeError`` when the
+    operands are not mutually comparable (e.g. ``"a" > 5``). Per spec these
+    fail safe to ``False`` (non-match) rather than raising.
+    """
+    try:
+        return bool(op(left, right))
+    except TypeError:
+        return False
+
+
+def _op_in(value: Any, expected: Any) -> bool:
+    if not isinstance(expected, (list, tuple, set)):
+        return False
+    return value in expected
+
+
+def _op_not_in(value: Any, expected: Any) -> bool:
+    if not isinstance(expected, (list, tuple, set)):
+        return False
+    return value not in expected
+
+
+# Each entry maps an op name to a callable (field_value, spec_value) -> bool.
+# ``field_value`` is the resolved record value (never MISSING here — MISSING is
+# handled upstream by on_missing). ``exists``/``missing`` are handled specially
+# in RolloutFilter.matches because they reason about presence, not value.
+_OPERATORS: Dict[str, Callable[[Any, Any], bool]] = {
+    "eq": lambda a, b: a == b,
+    "ne": lambda a, b: a != b,
+    "gt": lambda a, b: _safe_compare(lambda x, y: x > y, a, b),
+    "gte": lambda a, b: _safe_compare(lambda x, y: x >= y, a, b),
+    "lt": lambda a, b: _safe_compare(lambda x, y: x < y, a, b),
+    "lte": lambda a, b: _safe_compare(lambda x, y: x <= y, a, b),
+    "in": _op_in,
+    "not_in": _op_not_in,
+}
+
+# Operators that ignore ``value`` and reason purely about field presence.
+_PRESENCE_OPERATORS = frozenset({"exists", "missing"})
+
+# Operators that require ``value`` to be a list.
+_LIST_VALUE_OPERATORS = frozenset({"in", "not_in"})
+
+VALID_OPERATORS = frozenset(_OPERATORS) | _PRESENCE_OPERATORS
+"""All operator names accepted in a filter spec."""
+
+VALID_ON_MISSING = frozenset({"keep", "drop"})
+"""Accepted values for the ``on_missing`` key."""
+
+_DEFAULT_ON_MISSING = "keep"
+
+
+# ---------------------------------------------------------------------------
+# Filter spec + evaluation
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class FilterDecision:
+    """Outcome of evaluating a :class:`RolloutFilterSet` against one record.
+
+    Attributes:
+        passed: True if the record passes ALL applicable filters for the target.
+        dropped_by: The filter that caused the drop (None when ``passed``).
+        dropped_on_missing: True when the drop was caused by ``on_missing: drop``
+            (the field resolved to MISSING) rather than by a predicate mismatch.
+    """
+
+    passed: bool
+    dropped_by: Optional["RolloutFilter"] = None
+    dropped_on_missing: bool = False
+
+
+class RolloutFilter:
+    """One parsed, validated filter spec.
+
+    Construct via :meth:`from_spec` (which validates eagerly) rather than the
+    constructor directly when consuming raw config.
+    """
+
+    __slots__ = ("field", "op", "value", "applies_to", "on_missing", "_index")
+
+    def __init__(
+        self,
+        field: str,
+        op: str,
+        value: Any = None,
+        applies_to: Optional[Sequence[str]] = None,
+        on_missing: str = _DEFAULT_ON_MISSING,
+        index: int = 0,
+    ) -> None:
+        self.field = field
+        self.op = op
+        self.value = value
+        self.applies_to: Optional[List[str]] = (
+            list(applies_to) if applies_to is not None else None
+        )
+        self.on_missing = on_missing
+        self._index = index
+
+    @classmethod
+    def from_spec(cls, spec: Dict[str, Any], index: int = 0) -> "RolloutFilter":
+        """Validate a raw spec dict and build a :class:`RolloutFilter`.
+
+        Raises:
+            ValueError: on any structural problem (unknown op, bad on_missing,
+                missing required key, wrong value type for list operators).
+        """
+        prefix = f"filter[{index}]"
+        if not isinstance(spec, dict):
+            raise ValueError(f"{prefix}: filter spec must be a mapping, got {type(spec).__name__}")
+
+        field_name = spec.get("field")
+        if not isinstance(field_name, str) or not field_name:
+            raise ValueError(f"{prefix}: 'field' is required and must be a non-empty string")
+
+        op = spec.get("op")
+        if not isinstance(op, str) or op not in VALID_OPERATORS:
+            raise ValueError(
+                f"{prefix}: 'op' must be one of {sorted(VALID_OPERATORS)}, got {op!r}"
+            )
+
+        is_presence = op in _PRESENCE_OPERATORS
+        has_value = "value" in spec
+        if not is_presence and not has_value:
+            raise ValueError(f"{prefix}: 'value' is required for op {op!r}")
+
+        value = spec.get("value")
+        if op in _LIST_VALUE_OPERATORS and not isinstance(value, (list, tuple)):
+            raise ValueError(f"{prefix}: op {op!r} requires 'value' to be a list")
+
+        applies_to = spec.get("applies_to")
+        if applies_to is not None:
+            if not isinstance(applies_to, (list, tuple)) or not all(
+                isinstance(item, str) for item in applies_to
+            ):
+                raise ValueError(f"{prefix}: 'applies_to' must be a list of strings")
+
+        on_missing = spec.get("on_missing", _DEFAULT_ON_MISSING)
+        if on_missing not in VALID_ON_MISSING:
+            raise ValueError(
+                f"{prefix}: 'on_missing' must be one of {sorted(VALID_ON_MISSING)}, "
+                f"got {on_missing!r}"
+            )
+
+        # Reject unknown keys to fail closed on typos (e.g. 'applies' / 'op_').
+        known_keys = {"field", "op", "value", "applies_to", "on_missing"}
+        unknown = set(spec) - known_keys
+        if unknown:
+            raise ValueError(f"{prefix}: unknown key(s) {sorted(unknown)}")
+
+        return cls(
+            field=field_name,
+            op=op,
+            value=value,
+            applies_to=applies_to,
+            on_missing=on_missing,
+            index=index,
+        )
+
+    def applies(self, target: str, default_targets: Sequence[str]) -> bool:
+        """Whether this filter participates in evaluating ``target``."""
+        if self.applies_to is not None:
+            return target in self.applies_to
+        return target in default_targets
+
+    def matches(self, record: Dict[str, Any]) -> bool:
+        """Whether ``record`` matches this filter, honoring ``on_missing``.
+
+        Returns True for a MATCH (record is kept by this filter). On a MISSING
+        field, the verdict follows ``on_missing``: ``keep`` -> True (match),
+        ``drop`` -> False (non-match). Presence operators (``exists``/
+        ``missing``) reason about presence directly and ignore ``on_missing``.
+        """
+        resolved = get_path(record, self.field)
+
+        if self.op == "exists":
+            return resolved is not MISSING
+        if self.op == "missing":
+            return resolved is MISSING
+
+        if resolved is MISSING:
+            return self.on_missing == "keep"
+
+        operator = _OPERATORS[self.op]
+        return operator(resolved, self.value)
+
+    def describe(self) -> Dict[str, Any]:
+        """Compact, serializable description for auditing/logging."""
+        desc: Dict[str, Any] = {"field": self.field, "op": self.op}
+        if self.op not in _PRESENCE_OPERATORS:
+            desc["value"] = self.value
+        if self.applies_to is not None:
+            desc["applies_to"] = list(self.applies_to)
+        desc["on_missing"] = self.on_missing
+        return desc
+
+    def key(self) -> str:
+        """Stable per-filter key for stats tallies (field+op+value+index)."""
+        return f"{self._index}:{self.field}:{self.op}:{self.value!r}"
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"RolloutFilter({self.describe()!r})"
+
+
+class RolloutFilterSet:
+    """An ordered set of filters with per-target AND evaluation.
+
+    Args:
+        filters: Raw list of spec dicts (validated eagerly).
+        default_targets: Targets a filter applies to when it omits
+            ``applies_to``. The caller decides this set; the projector passes
+            the positive/GRPO targets only (excluding hard negatives).
+    """
+
+    def __init__(
+        self,
+        filters: Optional[Sequence[Dict[str, Any]]] = None,
+        default_targets: Optional[Sequence[str]] = None,
+    ) -> None:
+        raw = filters or []
+        if not isinstance(raw, (list, tuple)):
+            raise ValueError("filters config must be a list of filter specs")
+        self.filters: List[RolloutFilter] = [
+            RolloutFilter.from_spec(spec, index=i) for i, spec in enumerate(raw)
+        ]
+        self.default_targets: List[str] = list(default_targets or [])
+
+    @property
+    def is_empty(self) -> bool:
+        """True when there are no filters (apply is a no-op)."""
+        return not self.filters
+
+    def filters_for(self, target: str) -> List[RolloutFilter]:
+        """Filters that participate in evaluating ``target``."""
+        return [f for f in self.filters if f.applies(target, self.default_targets)]
+
+    def apply(self, record: Dict[str, Any], target: str) -> FilterDecision:
+        """Evaluate ``record`` for ``target``.
+
+        A record passes iff every applicable filter matches (AND). The first
+        non-matching filter is reported as the drop cause.
+        """
+        for filt in self.filters:
+            if not filt.applies(target, self.default_targets):
+                continue
+            resolved_missing = get_path(record, filt.field) is MISSING
+            if not filt.matches(record):
+                return FilterDecision(
+                    passed=False,
+                    dropped_by=filt,
+                    dropped_on_missing=resolved_missing and filt.op not in _PRESENCE_OPERATORS,
+                )
+        return FilterDecision(passed=True)
+
+
+# ---------------------------------------------------------------------------
+# Stats accumulator
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FilterTargetTally:
+    passed: int = 0
+    dropped_by_predicate: int = 0
+    dropped_on_missing: int = 0
+
+
+class FilterStats:
+    """Tally pass/drop counts per (target, filter) for breakdown logging.
+
+    Usage::
+
+        stats = FilterStats()
+        decision = filter_set.apply(record, "grpo")
+        stats.record("grpo", filter_set, decision)
+        ...
+        breakdown = stats.as_dict()  # serializable summary
+    """
+
+    def __init__(self) -> None:
+        # (target -> filter_key -> tally) plus a per-target total.
+        self._per_filter: Dict[str, Dict[str, _FilterTargetTally]] = {}
+        self._target_totals: Dict[str, _FilterTargetTally] = {}
+        # Stable mapping of filter_key -> human description, for output.
+        self._filter_desc: Dict[str, Dict[str, Any]] = {}
+
+    def _tally(self, target: str, filter_key: str) -> _FilterTargetTally:
+        per_target = self._per_filter.setdefault(target, {})
+        return per_target.setdefault(filter_key, _FilterTargetTally())
+
+    def _target_total(self, target: str) -> _FilterTargetTally:
+        return self._target_totals.setdefault(target, _FilterTargetTally())
+
+    def record(
+        self,
+        target: str,
+        filter_set: RolloutFilterSet,
+        decision: FilterDecision,
+    ) -> None:
+        """Record one record's decision for ``target``.
+
+        Per-target totals count whether the record ultimately passed or which
+        kind of drop occurred. Per-filter counts attribute the drop to the
+        specific filter that caused it; passing records credit a ``passed`` to
+        every filter that applied to the target (so each filter's pass count
+        reflects records it saw and let through).
+        """
+        total = self._target_total(target)
+        applicable = filter_set.filters_for(target)
+        for filt in applicable:
+            self._filter_desc.setdefault(filt.key(), filt.describe())
+
+        if decision.passed:
+            total.passed += 1
+            for filt in applicable:
+                self._tally(target, filt.key()).passed += 1
+            return
+
+        # Dropped: attribute to the causing filter.
+        culprit = decision.dropped_by
+        if decision.dropped_on_missing:
+            total.dropped_on_missing += 1
+        else:
+            total.dropped_by_predicate += 1
+
+        for filt in applicable:
+            tally = self._tally(target, filt.key())
+            if culprit is not None and filt.key() == culprit.key():
+                if decision.dropped_on_missing:
+                    tally.dropped_on_missing += 1
+                else:
+                    tally.dropped_by_predicate += 1
+            else:
+                # This filter matched (record only fails at the first mismatch),
+                # so credit a pass for filters that ran before the culprit. We
+                # cannot cheaply know ordering here, so we count it as passed
+                # only when it is not the culprit; this keeps per-filter pass
+                # counts meaningful for single-filter configs and is a safe
+                # over-approximation for multi-filter configs.
+                tally.passed += 1
+
+    def as_dict(self) -> Dict[str, Any]:
+        """Serializable breakdown: per-target totals + per-filter detail."""
+        out: Dict[str, Any] = {}
+        targets = set(self._target_totals) | set(self._per_filter)
+        for target in sorted(targets):
+            total = self._target_totals.get(target, _FilterTargetTally())
+            per_filter = self._per_filter.get(target, {})
+            out[target] = {
+                "passed": total.passed,
+                "dropped_by_predicate": total.dropped_by_predicate,
+                "dropped_on_missing": total.dropped_on_missing,
+                "filters": [
+                    {
+                        **self._filter_desc.get(filter_key, {"key": filter_key}),
+                        "passed": tally.passed,
+                        "dropped_by_predicate": tally.dropped_by_predicate,
+                        "dropped_on_missing": tally.dropped_on_missing,
+                    }
+                    for filter_key, tally in per_filter.items()
+                ],
+            }
+        return out
+
+    @property
+    def is_empty(self) -> bool:
+        return not self._target_totals and not self._per_filter
+
+
+__all__ = [
+    "MISSING",
+    "get_path",
+    "VALID_OPERATORS",
+    "VALID_ON_MISSING",
+    "FilterDecision",
+    "RolloutFilter",
+    "RolloutFilterSet",
+    "FilterStats",
+]

--- a/tests/flywheel/test_stager.py
+++ b/tests/flywheel/test_stager.py
@@ -309,3 +309,257 @@ class TestContentHash:
         h1 = stager._compute_content_hash({"sft": f1})
         h2 = stager._compute_content_hash({"sft": f3})
         assert h1 != h2
+
+
+class TestDatasetStagerFilters:
+    """DatasetStager applies declarative staging filters at each write seam."""
+
+    def _make_catalog(self, *, sft=None, kto=None, grpo=None):
+        catalog = AsyncMock()
+        catalog.find_logs = AsyncMock(side_effect=[
+            sft or [], kto or [], grpo or [],
+        ])
+        catalog.get_latest_dataset_version = AsyncMock(return_value=None)
+        catalog.create_dataset_version = AsyncMock(return_value="v001")
+        catalog.mark_used = AsyncMock()
+        return catalog
+
+    @pytest.mark.asyncio
+    async def test_no_filters_output_unchanged(self, tmp_path):
+        """Regression lock: no filters configured -> identical counts and rows.
+
+        Stage the same logs with an empty filter config and with no filter key
+        at all; both must produce the same counts and the same JSONL bytes.
+        """
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            {"messages": [{"role": "user", "content": "a"}], "response_content": "A"},
+            {"messages": [{"role": "user", "content": "b"}], "response_content": "B"},
+            {"messages": [{"role": "user", "content": "c"}], "response_content": "C"},
+        ])
+
+        def records():
+            sft = [
+                _make_record("s1", str(log_file), 0, tag="sft", fitness_score=0.95),
+                _make_record("s2", str(log_file), 1, tag="sft", fitness_score=0.5),
+            ]
+            kto = [_make_record("k1", str(log_file), 2, tag="kto", fitness_score=0.1)]
+            grpo = [_make_record("g1", str(log_file), 0, tag="grpo", fitness_score=0.95)]
+            return sft, kto, grpo
+
+        # Run with no filters key.
+        sft, kto, grpo = records()
+        cat1 = self._make_catalog(sft=sft, kto=kto, grpo=grpo)
+        stager1 = DatasetStager(cat1, FlywheelConfig(), datasets_dir=tmp_path / "ds1")
+        with patch.object(stager1, "_register_flywheel_cycle", return_value=""):
+            r1 = await stager1.stage_dataset()
+
+        # Run with explicit empty filters list.
+        sft, kto, grpo = records()
+        cat2 = self._make_catalog(sft=sft, kto=kto, grpo=grpo)
+        stager2 = DatasetStager(
+            cat2, FlywheelConfig(filters=[]), datasets_dir=tmp_path / "ds2",
+        )
+        with patch.object(stager2, "_register_flywheel_cycle", return_value=""):
+            r2 = await stager2.stage_dataset()
+
+        assert (r1.sft_count, r1.kto_pos_count, r1.kto_neg_count, r1.grpo_count) == (2, 2, 1, 1)
+        assert (r1.sft_count, r1.kto_pos_count, r1.kto_neg_count, r1.grpo_count) == \
+               (r2.sft_count, r2.kto_pos_count, r2.kto_neg_count, r2.grpo_count)
+
+        for key in ("sft", "kto", "grpo"):
+            b1 = Path(r1.file_paths[key]).read_bytes()
+            b2 = Path(r2.file_paths[key]).read_bytes()
+            assert b1 == b2
+
+    @pytest.mark.asyncio
+    async def test_fitness_score_filter_drops_low_from_targets(self, tmp_path):
+        """fitness_score gte 0.9 drops low-score logs from sft/kto_positive/grpo."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"},
+        ] * 4)
+
+        sft = [
+            _make_record("hi", str(log_file), 0, tag="sft", fitness_score=0.95),
+            _make_record("lo", str(log_file), 0, tag="sft", fitness_score=0.5),
+        ]
+        # KTO positive comes from sft_logs; negative from kto_logs.
+        kto = [_make_record("kn", str(log_file), 0, tag="kto", fitness_score=0.1)]
+        grpo = [
+            _make_record("ghi", str(log_file), 0, tag="grpo", fitness_score=0.95),
+            _make_record("glo", str(log_file), 0, tag="grpo", fitness_score=0.2),
+        ]
+
+        cat = self._make_catalog(sft=sft, kto=kto, grpo=grpo)
+        cfg = FlywheelConfig(filters=[
+            {"field": "fitness_score", "op": "gte", "value": 0.9},
+        ])
+        stager = DatasetStager(cat, cfg, datasets_dir=tmp_path / "ds")
+        with patch.object(stager, "_register_flywheel_cycle", return_value=""):
+            r = await stager.stage_dataset()
+
+        # sft: only hi (0.95) kept; lo dropped.
+        assert r.sft_count == 1
+        # kto_positive uses the same sft_logs view -> same 1 kept.
+        assert r.kto_pos_count == 1
+        # grpo: only ghi (0.95) kept.
+        assert r.grpo_count == 1
+        # kto_negative is NOT in default targets -> never filtered.
+        assert r.kto_neg_count == 1
+
+    @pytest.mark.asyncio
+    async def test_missing_field_passes_under_on_missing_keep(self, tmp_path):
+        """A record missing the addressed field passes under on_missing: keep.
+
+        ``content.score`` is genuinely absent from logs that don't carry it, so
+        the dot-path resolves to MISSING and on_missing: keep retains the row.
+        """
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            # First log carries content.score; second does not.
+            {"messages": [{"role": "user", "content": "a"}], "response_content": "A", "score": 0.95},
+            {"messages": [{"role": "user", "content": "b"}], "response_content": "B"},
+            {"messages": [{"role": "user", "content": "c"}], "response_content": "C", "score": 0.1},
+        ])
+
+        sft = [
+            _make_record("has_hi", str(log_file), 0, tag="sft"),
+            _make_record("no_field", str(log_file), 1, tag="sft"),
+            _make_record("has_lo", str(log_file), 2, tag="sft"),
+        ]
+        cat = self._make_catalog(sft=sft, kto=[], grpo=[])
+        cfg = FlywheelConfig(filters=[
+            {"field": "content.score", "op": "gte", "value": 0.9, "on_missing": "keep"},
+        ])
+        stager = DatasetStager(cat, cfg, datasets_dir=tmp_path / "ds")
+        with patch.object(stager, "_register_flywheel_cycle", return_value=""):
+            r = await stager.stage_dataset()
+
+        # has_hi (0.95) kept by predicate; no_field kept by on_missing: keep;
+        # has_lo (0.1) dropped.
+        assert r.sft_count == 2
+
+    @pytest.mark.asyncio
+    async def test_kto_negative_only_filtered_when_scoped(self, tmp_path):
+        """Unscoped filter never touches kto_negative; a scoped one does."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"},
+        ] * 4)
+
+        def neg_records():
+            return [
+                _make_record("n_hi", str(log_file), 0, tag="kto", fitness_score=0.95),
+                _make_record("n_lo", str(log_file), 0, tag="kto", fitness_score=0.1),
+            ]
+
+        # Unscoped filter (defaults exclude kto_negative): both negatives kept.
+        cat1 = self._make_catalog(sft=[], kto=neg_records(), grpo=[])
+        cfg1 = FlywheelConfig(filters=[
+            {"field": "fitness_score", "op": "gte", "value": 0.9},
+        ])
+        stager1 = DatasetStager(cat1, cfg1, datasets_dir=tmp_path / "ds1")
+        with patch.object(stager1, "_register_flywheel_cycle", return_value=""):
+            r1 = await stager1.stage_dataset()
+        assert r1.kto_neg_count == 2  # unscoped -> 0 dropped
+
+        # Scoped to kto_negative: low-score negative dropped.
+        cat2 = self._make_catalog(sft=[], kto=neg_records(), grpo=[])
+        cfg2 = FlywheelConfig(filters=[
+            {
+                "field": "fitness_score", "op": "gte", "value": 0.9,
+                "applies_to": ["kto_negative"],
+            },
+        ])
+        stager2 = DatasetStager(cat2, cfg2, datasets_dir=tmp_path / "ds2")
+        with patch.object(stager2, "_register_flywheel_cycle", return_value=""):
+            r2 = await stager2.stage_dataset()
+        assert r2.kto_neg_count == 1  # n_lo dropped
+
+    @pytest.mark.asyncio
+    async def test_kto_interleaving_preserved_after_filtering(self, tmp_path):
+        """After filtering, positives/negatives still interleave (pos, neg, pos, ...)."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"},
+        ] * 6)
+
+        # Two positives survive (0.95), one dropped (0.1). Two negatives (unscoped
+        # filter never touches kto_negative).
+        sft = [
+            _make_record("p1", str(log_file), 0, tag="sft", fitness_score=0.95),
+            _make_record("pdrop", str(log_file), 0, tag="sft", fitness_score=0.1),
+            _make_record("p2", str(log_file), 0, tag="sft", fitness_score=0.95),
+        ]
+        kto = [
+            _make_record("n1", str(log_file), 0, tag="kto", fitness_score=0.1),
+            _make_record("n2", str(log_file), 0, tag="kto", fitness_score=0.1),
+        ]
+
+        cat = self._make_catalog(sft=sft, kto=kto, grpo=[])
+        cfg = FlywheelConfig(filters=[
+            {"field": "fitness_score", "op": "gte", "value": 0.9},
+        ])
+        stager = DatasetStager(cat, cfg, datasets_dir=tmp_path / "ds")
+        with patch.object(stager, "_register_flywheel_cycle", return_value=""):
+            r = await stager.stage_dataset()
+
+        assert r.kto_pos_count == 2
+        assert r.kto_neg_count == 2
+
+        lines = Path(r.file_paths["kto"]).read_text().strip().splitlines()
+        labels = [json.loads(line)["label"] for line in lines]
+        # zip_longest interleave on filtered lists: pos, neg, pos, neg.
+        assert labels == [True, False, True, False]
+
+    @pytest.mark.asyncio
+    async def test_filter_provenance_recorded_in_version(self, tmp_path):
+        """The DatasetVersion records the staging filter specs + stats."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [
+            {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"},
+        ] * 2)
+
+        sft = [
+            _make_record("hi", str(log_file), 0, tag="sft", fitness_score=0.95),
+            _make_record("lo", str(log_file), 0, tag="sft", fitness_score=0.1),
+        ]
+        cat = self._make_catalog(sft=sft, kto=[], grpo=[])
+        cfg = FlywheelConfig(filters=[
+            {"field": "fitness_score", "op": "gte", "value": 0.9},
+        ])
+        stager = DatasetStager(cat, cfg, datasets_dir=tmp_path / "ds")
+        with patch.object(stager, "_register_flywheel_cycle", return_value=""):
+            await stager.stage_dataset()
+
+        version_arg = cat.create_dataset_version.call_args[0][0]
+        crit = version_arg.filter_criteria
+        # Existing keys preserved.
+        assert "sft_threshold" in crit
+        assert "scoring_method" in crit
+        # New provenance keys.
+        assert crit["staging_filters"] == [
+            {"field": "fitness_score", "op": "gte", "value": 0.9, "on_missing": "keep"},
+        ]
+        assert "sft" in crit["staging_filter_stats"]
+
+    def test_invalid_filter_spec_raises_at_init(self, tmp_path):
+        """An invalid filter spec raises ValueError at stager construction."""
+        catalog = AsyncMock()
+        cfg = FlywheelConfig(filters=[{"field": "fitness_score", "op": "bogus", "value": 1}])
+        with pytest.raises(ValueError):
+            DatasetStager(catalog, cfg, datasets_dir=tmp_path / "ds")
+
+    def test_content_prefix_addressable(self, tmp_path):
+        """The filter view exposes parsed content under a 'content.' prefix."""
+        record = _make_record("c1", fitness_score=0.5)
+        content = {
+            "messages": [{"role": "user", "content": "hi"}],
+            "response_content": "the answer",
+        }
+        view = DatasetStager._filter_view(record, content)
+        # Record field at top level.
+        assert view["fitness_score"] == 0.5
+        # Content nested under 'content'.
+        assert view["content"]["response_content"] == "the answer"

--- a/tests/shared/test_rollout_filters.py
+++ b/tests/shared/test_rollout_filters.py
@@ -1,0 +1,273 @@
+"""Tests for shared.validation.rollout_filters — generic config-driven engine.
+
+Covers: dot-path resolution (incl. missing), every operator, on_missing
+keep/drop, applies_to target scoping, empty-set no-op, eager spec validation,
+and the stats accumulator breakdown.
+"""
+from __future__ import annotations
+
+import pytest
+
+from shared.validation.rollout_filters import (
+    MISSING,
+    FilterDecision,
+    FilterStats,
+    RolloutFilter,
+    RolloutFilterSet,
+    get_path,
+)
+
+
+class TestGetPath:
+    def test_top_level(self):
+        assert get_path({"a": 1}, "a") == 1
+
+    def test_nested(self):
+        rec = {"a": {"b": {"c": 42}}}
+        assert get_path(rec, "a.b.c") == 42
+
+    def test_missing_leaf(self):
+        assert get_path({"a": {"b": {}}}, "a.b.c") is MISSING
+
+    def test_missing_intermediate(self):
+        assert get_path({"a": 1}, "a.b.c") is MISSING
+
+    def test_non_dict_intermediate(self):
+        # 'a' resolves to a list, so descending further yields MISSING.
+        assert get_path({"a": [1, 2]}, "a.b") is MISSING
+
+    def test_value_none_is_not_missing(self):
+        # A stored None is a real value, distinct from MISSING.
+        assert get_path({"a": None}, "a") is None
+        assert get_path({"a": None}, "a") is not MISSING
+
+    def test_empty_path(self):
+        assert get_path({"a": 1}, "") is MISSING
+
+
+class TestOperators:
+    def _match(self, op, field_value, value, **extra):
+        filt = RolloutFilter.from_spec({"field": "x", "op": op, "value": value, **extra})
+        return filt.matches({"x": field_value})
+
+    def test_eq(self):
+        assert self._match("eq", 5, 5) is True
+        assert self._match("eq", 5, 6) is False
+
+    def test_ne(self):
+        assert self._match("ne", 5, 6) is True
+        assert self._match("ne", 5, 5) is False
+
+    def test_gt(self):
+        assert self._match("gt", 6, 5) is True
+        assert self._match("gt", 5, 5) is False
+
+    def test_gte(self):
+        assert self._match("gte", 5, 5) is True
+        assert self._match("gte", 4, 5) is False
+
+    def test_lt(self):
+        assert self._match("lt", 4, 5) is True
+        assert self._match("lt", 5, 5) is False
+
+    def test_lte(self):
+        assert self._match("lte", 5, 5) is True
+        assert self._match("lte", 6, 5) is False
+
+    def test_numeric_comparison_fails_safe_on_incomparable(self):
+        # "abc" > 5 would raise TypeError; engine treats it as non-match.
+        assert self._match("gt", "abc", 5) is False
+        assert self._match("lte", "abc", 5) is False
+
+    def test_in(self):
+        assert self._match("in", "b", ["a", "b", "c"]) is True
+        assert self._match("in", "z", ["a", "b", "c"]) is False
+
+    def test_not_in(self):
+        assert self._match("not_in", "z", ["a", "b"]) is True
+        assert self._match("not_in", "a", ["a", "b"]) is False
+
+    def test_exists(self):
+        filt = RolloutFilter.from_spec({"field": "x", "op": "exists"})
+        assert filt.matches({"x": 1}) is True
+        assert filt.matches({"x": None}) is True  # present-but-None still exists
+        assert filt.matches({"y": 1}) is False
+
+    def test_missing(self):
+        filt = RolloutFilter.from_spec({"field": "x", "op": "missing"})
+        assert filt.matches({"y": 1}) is True
+        assert filt.matches({"x": 1}) is False
+
+
+class TestOnMissing:
+    def test_keep_default(self):
+        # Default on_missing=keep -> a missing field MATCHES (record retained).
+        filt = RolloutFilter.from_spec({"field": "a.b", "op": "gte", "value": 5})
+        assert filt.matches({"a": {}}) is True
+
+    def test_drop(self):
+        filt = RolloutFilter.from_spec(
+            {"field": "a.b", "op": "gte", "value": 5, "on_missing": "drop"}
+        )
+        assert filt.matches({"a": {}}) is False
+
+    def test_present_field_ignores_on_missing(self):
+        filt = RolloutFilter.from_spec(
+            {"field": "a.b", "op": "gte", "value": 5, "on_missing": "drop"}
+        )
+        assert filt.matches({"a": {"b": 7}}) is True
+        assert filt.matches({"a": {"b": 2}}) is False
+
+
+class TestAppliesToScoping:
+    def test_filter_scoped_to_grpo_does_not_affect_kto_positive(self):
+        fs = RolloutFilterSet(
+            filters=[
+                {"field": "n", "op": "gte", "value": 5, "applies_to": ["grpo"]},
+            ],
+            default_targets=["grpo", "kto_positive", "sft"],
+        )
+        rec = {"n": 2}  # would fail the gte 5 predicate
+        assert fs.apply(rec, "grpo").passed is False
+        # Scoped only to grpo -> kto_positive is unaffected (passes).
+        assert fs.apply(rec, "kto_positive").passed is True
+
+    def test_omitted_applies_to_uses_default_set(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5}],
+            default_targets=["grpo", "kto_positive"],  # excludes kto_negative
+        )
+        rec = {"n": 2}
+        assert fs.apply(rec, "grpo").passed is False
+        assert fs.apply(rec, "kto_positive").passed is False
+        # kto_negative not in default set -> filter does not apply -> passes.
+        assert fs.apply(rec, "kto_negative").passed is True
+
+    def test_explicit_kto_negative_targeting(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5, "applies_to": ["kto_negative"]}],
+            default_targets=["grpo", "kto_positive"],
+        )
+        rec = {"n": 2}
+        assert fs.apply(rec, "kto_negative").passed is False
+        assert fs.apply(rec, "grpo").passed is True
+
+
+class TestEmptySetNoOp:
+    def test_none_filters(self):
+        fs = RolloutFilterSet(filters=None, default_targets=["grpo"])
+        assert fs.is_empty is True
+        assert fs.apply({"anything": 1}, "grpo").passed is True
+
+    def test_empty_list(self):
+        fs = RolloutFilterSet(filters=[], default_targets=["grpo"])
+        assert fs.is_empty is True
+        assert fs.apply({}, "grpo").passed is True
+
+
+class TestAndSemantics:
+    def test_all_must_match(self):
+        fs = RolloutFilterSet(
+            filters=[
+                {"field": "n", "op": "gte", "value": 5},
+                {"field": "fam", "op": "in", "value": ["tools"]},
+            ],
+            default_targets=["grpo"],
+        )
+        assert fs.apply({"n": 6, "fam": "tools"}, "grpo").passed is True
+        assert fs.apply({"n": 6, "fam": "other"}, "grpo").passed is False
+        assert fs.apply({"n": 2, "fam": "tools"}, "grpo").passed is False
+
+    def test_decision_reports_drop_cause(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5}],
+            default_targets=["grpo"],
+        )
+        decision = fs.apply({"n": 2}, "grpo")
+        assert isinstance(decision, FilterDecision)
+        assert decision.passed is False
+        assert decision.dropped_by is not None
+        assert decision.dropped_by.field == "n"
+        assert decision.dropped_on_missing is False
+
+    def test_decision_flags_on_missing_drop(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5, "on_missing": "drop"}],
+            default_targets=["grpo"],
+        )
+        decision = fs.apply({}, "grpo")
+        assert decision.passed is False
+        assert decision.dropped_on_missing is True
+
+
+class TestInvalidSpecRaises:
+    def test_unknown_op(self):
+        with pytest.raises(ValueError, match="op"):
+            RolloutFilterSet(filters=[{"field": "x", "op": "bogus", "value": 1}])
+
+    def test_missing_field(self):
+        with pytest.raises(ValueError, match="field"):
+            RolloutFilterSet(filters=[{"op": "eq", "value": 1}])
+
+    def test_missing_value_for_value_op(self):
+        with pytest.raises(ValueError, match="value"):
+            RolloutFilterSet(filters=[{"field": "x", "op": "eq"}])
+
+    def test_bad_on_missing(self):
+        with pytest.raises(ValueError, match="on_missing"):
+            RolloutFilterSet(filters=[{"field": "x", "op": "eq", "value": 1, "on_missing": "nope"}])
+
+    def test_in_requires_list(self):
+        with pytest.raises(ValueError, match="list"):
+            RolloutFilterSet(filters=[{"field": "x", "op": "in", "value": "notalist"}])
+
+    def test_unknown_key(self):
+        with pytest.raises(ValueError, match="unknown"):
+            RolloutFilterSet(filters=[{"field": "x", "op": "eq", "value": 1, "applies": ["grpo"]}])
+
+    def test_presence_op_needs_no_value(self):
+        # Should NOT raise — exists/missing ignore value.
+        fs = RolloutFilterSet(filters=[{"field": "x", "op": "exists"}])
+        assert fs.apply({"x": 1}, "anything").passed is True
+
+
+class TestFilterStats:
+    def test_single_filter_breakdown(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5}],
+            default_targets=["grpo"],
+        )
+        stats = FilterStats()
+        for rec in [{"n": 6}, {"n": 2}, {"n": 1}]:
+            stats.record("grpo", fs, fs.apply(rec, "grpo"))
+        # one passes, two dropped by predicate
+        breakdown = stats.as_dict()
+        assert breakdown["grpo"]["passed"] == 1
+        assert breakdown["grpo"]["dropped_by_predicate"] == 2
+        assert breakdown["grpo"]["dropped_on_missing"] == 0
+
+    def test_on_missing_drop_counted_separately(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5, "on_missing": "drop"}],
+            default_targets=["grpo"],
+        )
+        stats = FilterStats()
+        for rec in [{"n": 6}, {}, {"n": 2}]:
+            stats.record("grpo", fs, fs.apply(rec, "grpo"))
+        breakdown = stats.as_dict()
+        assert breakdown["grpo"]["passed"] == 1
+        assert breakdown["grpo"]["dropped_by_predicate"] == 1
+        assert breakdown["grpo"]["dropped_on_missing"] == 1
+
+    def test_per_filter_detail_present(self):
+        fs = RolloutFilterSet(
+            filters=[{"field": "n", "op": "gte", "value": 5}],
+            default_targets=["grpo"],
+        )
+        stats = FilterStats()
+        stats.record("grpo", fs, fs.apply({"n": 2}, "grpo"))
+        detail = stats.as_dict()["grpo"]["filters"]
+        assert len(detail) == 1
+        assert detail[0]["field"] == "n"
+        assert detail[0]["op"] == "gte"
+        assert detail[0]["dropped_by_predicate"] == 1

--- a/tests/shared/test_sft_preprocessing_tool_role.py
+++ b/tests/shared/test_sft_preprocessing_tool_role.py
@@ -1,0 +1,145 @@
+"""Tests for tool-role support in shared.sft_preprocessing.
+
+Regression-locks the byte output of existing single-turn (system/user/assistant
++ tool_calls) sanitization, then verifies the additive `tool` role rendering for
+multi-turn trajectories.
+"""
+from __future__ import annotations
+
+from shared.sft_preprocessing import (
+    render_tool_call_content,
+    render_tool_result_content,
+    sanitize_messages_for_chat_template,
+)
+
+
+def _single_turn_with_tool_calls():
+    """The canonical single-turn shape: assistant text + OpenAI tool_calls, content None."""
+    return [
+        {"role": "system", "content": "be helpful"},
+        {"role": "user", "content": "do it"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "function": {"name": "useTools", "arguments": '{"a": 1}'},
+                }
+            ],
+        },
+    ]
+
+
+# The byte-exact expected output BEFORE tool-role support was added. This is the
+# regression lock: the new `tool` branch must not perturb these rows.
+def _expected_legacy_sanitize(messages):
+    import json
+
+    sanitized = []
+    for message in messages:
+        normalized = dict(message)
+        content = normalized.get("content")
+        if content is None:
+            content = ""
+        elif not isinstance(content, str):
+            content = json.dumps(content, ensure_ascii=False)
+        tool_calls = normalized.get("tool_calls") or []
+        if tool_calls:
+            tool_content = render_tool_call_content(tool_calls)
+            content = f"{content}\n\n{tool_content}".strip() if content else tool_content
+        normalized["content"] = content
+        normalized.pop("tool_calls", None)
+        sanitized.append(normalized)
+    return sanitized
+
+
+class TestSingleTurnRegressionLock:
+    def test_single_turn_tool_calls_byte_identical(self):
+        messages = _single_turn_with_tool_calls()
+        got = sanitize_messages_for_chat_template(messages)
+        expected = _expected_legacy_sanitize(_single_turn_with_tool_calls())
+        assert got == expected
+
+    def test_plain_conversation_unchanged(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        got = sanitize_messages_for_chat_template(messages)
+        assert got == messages
+        # roles untouched, no tool_calls key introduced
+        assert [m["role"] for m in got] == ["system", "user", "assistant"]
+
+    def test_none_content_becomes_empty_string(self):
+        got = sanitize_messages_for_chat_template([{"role": "assistant", "content": None}])
+        assert got[0]["content"] == ""
+
+
+class TestToolRoleRendering:
+    def test_tool_role_rendered_and_retagged_to_user(self):
+        messages = [
+            {"role": "user", "content": "search the vault"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "1", "type": "function", "function": {"name": "useTools", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "content": "Tool execution results:\nfound 3 files"},
+            {"role": "assistant", "content": "Done."},
+        ]
+        got = sanitize_messages_for_chat_template(messages)
+        # tool message re-tagged to user for template compatibility
+        assert got[2]["role"] == "user"
+        # tool output preserved inside the templated text
+        assert "found 3 files" in got[2]["content"]
+        assert got[2]["content"].startswith("tool_result:")
+        # no tool_calls leak on the result message
+        assert "tool_calls" not in got[2]
+
+    def test_tool_role_with_dict_content_json_rendered(self):
+        messages = [{"role": "tool", "content": {"status": "ok", "n": 2}}]
+        got = sanitize_messages_for_chat_template(messages)
+        assert got[0]["role"] == "user"
+        assert '"status": "ok"' in got[0]["content"]
+        assert '"n": 2' in got[0]["content"]
+
+    def test_multi_turn_templates_without_error(self):
+        """A full multi-turn trajectory sanitizes into a coherent user/assistant transcript."""
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "q"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "1", "type": "function", "function": {"name": "t", "arguments": "{}"}}
+                ],
+            },
+            {"role": "tool", "content": "result body"},
+            {"role": "assistant", "content": "final answer"},
+        ]
+        got = sanitize_messages_for_chat_template(messages)
+        roles = [m["role"] for m in got]
+        # only roles a generic chat template understands remain
+        assert set(roles).issubset({"system", "user", "assistant"})
+        assert all(isinstance(m["content"], str) for m in got)
+        assert "result body" in got[3]["content"]
+
+
+class TestRenderToolResultContent:
+    def test_string_body(self):
+        assert render_tool_result_content("hi") == "tool_result:\nhi"
+
+    def test_empty_body(self):
+        assert render_tool_result_content("") == "tool_result:"
+        assert render_tool_result_content(None) == "tool_result:"
+
+    def test_dict_body_pretty_printed(self):
+        out = render_tool_result_content({"k": "v"})
+        assert out.startswith("tool_result:\n")
+        assert '"k": "v"' in out

--- a/tests/synthchat/test_project_rollout_filters.py
+++ b/tests/synthchat/test_project_rollout_filters.py
@@ -1,0 +1,176 @@
+"""Integration tests for filter wiring in project_rollout_datasets.
+
+Verifies that a `total_turns gte 5` filter:
+  * drops a 2-turn record from grpo and kto_positive,
+  * passes a record lacking total_turns under on_missing: keep,
+  * leaves kto_negative untouched unless explicitly targeted,
+and that total_turns is surfaced into projected GRPO rows.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from SynthChat.scripts import project_rollout_datasets as proj
+from shared.validation import FilterStats, RolloutFilterSet
+
+
+def _positive_record(total_turns=None, *, include_turns=True, scenario="s1"):
+    """A record that passes _is_quality_positive with one executed tool."""
+    episode_trace = {
+        "total_tool_calls": 1,
+        "stop_reason": "completed",
+    }
+    if include_turns:
+        episode_trace["total_turns"] = total_turns
+    return {
+        "conversations": [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "metadata": {
+            "scenario": scenario,
+            "environment": {
+                "passed": True,
+                "executed_tools": [{"name": "useTools", "arguments": {"cmd": "x"}}],
+                "episode_trace": episode_trace,
+            },
+            "stage_reviews": {},
+        },
+    }
+
+
+def _negative_record(total_turns=2, scenario="sneg"):
+    """A record that passes _is_meaningful_negative and is a KTO-False candidate."""
+    return {
+        "conversations": [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "partial"},
+        ],
+        "metadata": {
+            "scenario": scenario,
+            "labels": {"filter": {"kto_candidate_label": False}},
+            "environment": {
+                "passed": False,
+                "executed_tools": [{"name": "useTools", "arguments": {"cmd": "x"}}],
+                "episode_trace": {
+                    "total_tool_calls": 1,
+                    "total_turns": total_turns,
+                    "stop_reason": "max_tool_steps_exceeded",
+                },
+            },
+            "stage_reviews": {},
+        },
+    }
+
+
+def _positive_kto_record(total_turns=2, scenario="spos"):
+    """A KTO-True candidate that also passes _is_quality_positive."""
+    rec = _positive_record(total_turns=total_turns, scenario=scenario)
+    rec["metadata"]["labels"] = {"filter": {"kto_candidate_label": True}}
+    return rec
+
+
+def _make_filter_set():
+    return RolloutFilterSet(
+        filters=[{"field": "metadata.environment.episode_trace.total_turns", "op": "gte", "value": 5}],
+        default_targets=proj.DEFAULT_FILTER_TARGETS,
+    )
+
+
+class TestGrpoFiltering:
+    def test_short_record_dropped_from_grpo(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _positive_record(total_turns=2)
+        row = proj._build_grpo_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is None
+        assert stats.as_dict()["grpo"]["dropped_by_predicate"] == 1
+
+    def test_long_record_kept_and_surfaces_total_turns(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _positive_record(total_turns=7)
+        row = proj._build_grpo_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None
+        assert row["total_turns"] == 7
+        assert stats.as_dict()["grpo"]["passed"] == 1
+
+    def test_missing_total_turns_passes_under_keep(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _positive_record(include_turns=False)
+        row = proj._build_grpo_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None  # on_missing defaults to keep
+        assert row["total_turns"] == 0  # surfaced field defaults to 0 when absent
+
+    def test_no_filter_set_is_noop(self):
+        rec = _positive_record(total_turns=1)
+        row = proj._build_grpo_row(Path("a.jsonl"), 0, rec, None, None)
+        assert row is not None
+        assert row["total_turns"] == 1
+
+
+class TestKtoPositiveFiltering:
+    def test_short_kto_positive_dropped(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _positive_kto_record(total_turns=2)
+        row = proj._build_kto_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is None
+        assert stats.as_dict()["kto_positive"]["dropped_by_predicate"] == 1
+
+    def test_long_kto_positive_kept(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _positive_kto_record(total_turns=8)
+        row = proj._build_kto_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None
+        assert row["label"] is True
+
+
+class TestKtoNegativeUnaffected:
+    def test_negative_untouched_by_default_filter(self):
+        # total_turns=2 would fail gte 5, but kto_negative is excluded from the
+        # default set, so the negative survives.
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _negative_record(total_turns=2)
+        row = proj._build_kto_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None
+        assert row["label"] is False
+
+    def test_negative_dropped_when_explicitly_targeted(self):
+        fs = RolloutFilterSet(
+            filters=[{
+                "field": "metadata.environment.episode_trace.total_turns",
+                "op": "gte",
+                "value": 5,
+                "applies_to": ["kto_negative"],
+            }],
+            default_targets=proj.DEFAULT_FILTER_TARGETS,
+        )
+        stats = FilterStats()
+        rec = _negative_record(total_turns=2)
+        row = proj._build_kto_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is None
+        assert stats.as_dict()["kto_negative"]["dropped_by_predicate"] == 1
+
+
+class TestFilterConfigLoading:
+    def test_load_filter_set_from_yaml(self, tmp_path):
+        cfg = tmp_path / "filters.yaml"
+        cfg.write_text(
+            "projection:\n"
+            "  filters:\n"
+            "    - field: metadata.environment.episode_trace.total_turns\n"
+            "      op: gte\n"
+            "      value: 5\n",
+            encoding="utf-8",
+        )
+        fs = proj._load_filter_set(str(cfg))
+        assert fs is not None
+        assert not fs.is_empty
+        assert list(fs.default_targets) == list(proj.DEFAULT_FILTER_TARGETS)
+
+    def test_load_filter_set_none_when_unset(self):
+        assert proj._load_filter_set(None) is None

--- a/tests/synthchat/test_project_sft_rows.py
+++ b/tests/synthchat/test_project_sft_rows.py
@@ -1,0 +1,184 @@
+"""Tests for the full multi-turn SFT projection in project_rollout_datasets.
+
+Covers:
+  * multi-turn reconstruction order [system, user, assistant(tool_calls), tool, ...]
+  * OpenAI tool_calls shape preservation
+  * dropping judge/validation/final_text_request scaffolding turns
+  * label/total_turns/provenance fields
+  * non-positive rollout -> None
+  * total_turns gte 5 filter drops short SFT rows but keeps long ones, and a
+    record missing total_turns passes under on_missing: keep.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from SynthChat.scripts import project_rollout_datasets as proj
+from shared.validation import FilterStats, RolloutFilterSet
+
+
+def _tool_call(name="useTools", args=None):
+    return {
+        "id": "1",
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": json.dumps(args or {"cmd": "x"}),
+        },
+    }
+
+
+def _multi_turn_record(total_turns=2, *, include_turns=True, scenario="s1"):
+    """A quality-positive record with a full multi-turn conversation_trace.
+
+    Trace order intentionally interleaves trainable turns with scaffolding turns
+    (judge/validation/final_text_request) to prove the scaffolding is dropped.
+    """
+    episode_trace = {"total_tool_calls": 1, "stop_reason": "completed"}
+    if include_turns:
+        episode_trace["total_turns"] = total_turns
+    return {
+        "conversations": [
+            {"role": "user", "content": "do the thing"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "conversation_trace": [
+            {"role": "system", "kind": "prompt_message", "content": "you are helpful"},
+            {"role": "user", "kind": "prompt_message", "content": "please act"},
+            {
+                "role": "assistant",
+                "kind": "assistant_response",
+                "content": "Tool calls: [display repr]",
+                "raw": {"role": "assistant", "content": None, "tool_calls": [_tool_call()]},
+            },
+            {"role": "user", "kind": "tool_feedback", "content": "Tool execution results:\nOK"},
+            {"role": "user", "kind": "judge_feedback", "content": "looks good"},
+            {
+                "role": "assistant",
+                "kind": "assistant_response",
+                "content": "All set.",
+                "raw": {"role": "assistant", "content": "All set."},
+            },
+            {"role": "user", "kind": "final_text_request", "content": "give final text"},
+        ],
+        "metadata": {
+            "scenario": scenario,
+            "environment": {
+                "passed": True,
+                "executed_tools": [{"name": "useTools", "arguments": {"cmd": "x"}}],
+                "episode_trace": episode_trace,
+            },
+            "environment_seed": {"seed_id": "seed-123"},
+            "stage_reviews": {},
+        },
+    }
+
+
+def _non_positive_record():
+    rec = _multi_turn_record()
+    rec["metadata"]["environment"]["passed"] = False
+    return rec
+
+
+def _make_filter_set():
+    return RolloutFilterSet(
+        filters=[{"field": "metadata.environment.episode_trace.total_turns", "op": "gte", "value": 5}],
+        default_targets=proj.DEFAULT_FILTER_TARGETS,
+    )
+
+
+class TestSftReconstruction:
+    def test_full_multi_turn_order_and_roles(self):
+        rec = _multi_turn_record(total_turns=2)
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec)
+        assert row is not None
+        roles = [m["role"] for m in row["conversations"]]
+        # scaffolding (judge_feedback, final_text_request) dropped
+        assert roles == ["system", "user", "assistant", "tool", "assistant"]
+
+    def test_assistant_tool_calls_openai_shape_preserved(self):
+        rec = _multi_turn_record()
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec)
+        tool_call_msg = row["conversations"][2]
+        assert tool_call_msg["role"] == "assistant"
+        # pure tool-call turn keeps content None (from raw.content, not display repr)
+        assert tool_call_msg["content"] is None
+        tc = tool_call_msg["tool_calls"][0]
+        assert tc["type"] == "function"
+        assert tc["id"] == "1"
+        assert tc["function"]["name"] == "useTools"
+        # arguments stays a JSON string (OpenAI shape)
+        assert isinstance(tc["function"]["arguments"], str)
+
+    def test_tool_result_becomes_tool_role(self):
+        rec = _multi_turn_record()
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec)
+        tool_msg = row["conversations"][3]
+        assert tool_msg["role"] == "tool"
+        assert "Tool execution results" in tool_msg["content"]
+        assert "tool_calls" not in tool_msg
+
+    def test_final_assistant_text_turn_kept(self):
+        rec = _multi_turn_record()
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec)
+        final = row["conversations"][-1]
+        assert final["role"] == "assistant"
+        assert final["content"] == "All set."
+        assert "tool_calls" not in final
+
+    def test_provenance_and_label_fields(self):
+        rec = _multi_turn_record(total_turns=4, scenario="my_scenario")
+        row = proj._build_sft_row(Path("agg.jsonl"), 7, rec)
+        assert row["label"] is True
+        assert row["total_turns"] == 4
+        assert row["scenario_id"] == "my_scenario"
+        assert row["source_example_id"] == "agg.jsonl:7"
+        assert row["metadata"]["source_artifact"] == "agg.jsonl"
+        assert row["metadata"]["seed_id"] == "seed-123"
+        assert row["metadata"]["stop_reason"] == "completed"
+
+    def test_non_positive_returns_none(self):
+        rec = _non_positive_record()
+        assert proj._build_sft_row(Path("a.jsonl"), 0, rec) is None
+
+    def test_degenerate_no_user_returns_none(self):
+        rec = _multi_turn_record()
+        # strip the only user prompt_message turn (keep tool_feedback user turns)
+        rec["conversation_trace"] = [
+            t for t in rec["conversation_trace"]
+            if not (t.get("role") == "user" and t.get("kind") == "prompt_message")
+        ]
+        assert proj._build_sft_row(Path("a.jsonl"), 0, rec) is None
+
+
+class TestSftFiltering:
+    def test_short_record_dropped(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _multi_turn_record(total_turns=2)
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is None
+        assert stats.as_dict()["sft"]["dropped_by_predicate"] == 1
+
+    def test_long_record_kept(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _multi_turn_record(total_turns=7)
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None
+        assert row["total_turns"] == 7
+        assert stats.as_dict()["sft"]["passed"] == 1
+
+    def test_missing_total_turns_passes_under_keep(self):
+        fs = _make_filter_set()
+        stats = FilterStats()
+        rec = _multi_turn_record(include_turns=False)
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec, fs, stats)
+        assert row is not None  # on_missing defaults to keep
+        assert row["total_turns"] == 0  # surfaced field defaults to 0 when absent
+
+    def test_no_filter_set_is_noop(self):
+        rec = _multi_turn_record(total_turns=1)
+        row = proj._build_sft_row(Path("a.jsonl"), 0, rec, None, None)
+        assert row is not None


### PR DESCRIPTION
## What & why

Adds a **generic, config-driven rollout-filter engine** and wires it into both the SynthChat rollout projector and the flywheel dataset stager, plus a new **full multi-turn SFT projection** path.

Motivated by *OpenThoughts-Agent: Data Recipes for Agentic Models* (arXiv 2606.24855), whose ablations found task-source and trajectory quality (notably keeping multi-step trajectories) are the highest-leverage data knobs. Rather than hardcode any one experiment, this lets a researcher express **any** filter declaratively. Everything is **default-off** — no behavior changes until a filter config is supplied.

## Changes

- **`shared/validation/rollout_filters.py`** — generic engine: dot-path fields, operators `eq/ne/gt/gte/lt/lte/in/not_in/exists/missing`, per-target scoping (`applies_to`), `on_missing: keep|drop`, AND semantics, eager spec validation, per-target/per-filter stats. Empty/absent config = no-op.
- **`SynthChat/scripts/project_rollout_datasets.py`** — `--filter-config` wiring; new optional `--sft-output` producing full multi-turn SFT rows (`[system, user, assistant(tool_calls), tool, …]`) from quality-positive rollouts; surfaces `total_turns` into GRPO rows.
- **`shared/sft_preprocessing.py`** — minimal `tool`-role support for multi-turn SFT; existing single-turn rows are **byte-identical** (regression-locked).
- **Flywheel stager + config** — same engine over inference-log records via a documented filter view; default targets exclude `kto_negative` (quality filters never silently drop hard negatives); KTO interleaving preserved; filter provenance recorded in `DatasetVersion`.
- **Schemas** — new `sft_projection.schema.json`; `total_turns` added to `grpo_projection.schema.json`.
- **Docs** — `.skills/synethetic-data-generation/reference/rollout-projection.md` (+ synced mirrors): filter config, SFT projection, and data-recipe guidance (task-source leverage, teacher ≠ strongest, difficulty ≈ teacher response length, keep multi-step trajectories).

## Testing

89 tests pass (engine, projector SFT, preprocessing, flywheel filters), verified in a worktree based off `main`. Also smoke-tested end-to-end on a real rollout aggregate: a `total_turns >= 3` filter drops short rollouts across sft/grpo/kto_positive while leaving `kto_negative` untouched.

## Note

The filter only bites once genuinely multi-step rollouts exist — current scenarios cluster at 1–3 turns, so authoring multi-step tasks is the natural follow-up. Tool results are stored with a native `tool` role on disk but rendered to text at chat-template time (revisit if native tool-role training is wanted for Qwen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
