### PR TITLE
feat(sft): generic auxiliary scalar readout head (aux_head) — Phase A

### DIFF
--- a/.agents/skills/fine-tuning/reference/sft-training.md
+++ b/.agents/skills/fine-tuning/reference/sft-training.md
@@ -88,6 +88,40 @@ When `completion_only_loss: true` (default):
 - User prompt tokens ignored during training
 - Prevents model from learning to generate user messages
 
+### Auxiliary Readout Head (`aux_head`, optional)
+An optional auxiliary scalar readout head that learns to predict a per-row
+target from a frozen base model's hidden state (Phase A: the base/LoRA is
+frozen and only the small head trains; the LM loss is not used). The feature is
+**off by default** — when the `aux_head` block is absent or `enabled: false`,
+the SFT path is byte-identical to a standard run.
+
+When enabled, every training row must carry a finite numeric target under the
+column named by `target_field`; a missing, null, non-numeric, or non-finite
+value fails loudly (there is no silent default). After training, the head is
+written next to the model as a sidecar (`aux_head.safetensors` +
+`aux_head_config.json`) so it can be reloaded for inference independently of the
+base weights.
+
+```yaml
+aux_head:
+  enabled: true            # absent / false => feature fully off
+  layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
+  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  target_field: target     # per-row dataset column carrying the scalar target
+  loss: bce                # "bce" | "brier" (MSE on probability)
+  head_type: linear        # "linear" | "mlp"
+  hidden_dims: []          # hidden widths when head_type: mlp
+  out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
+  freeze_base: true        # Phase A = true
+  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  head_lr: null            # optional dedicated head LR; defaults to trainer LR
+```
+
+A complete runnable example lives at
+`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
+the hidden-state index is a deliberate per-run decision, so an enabled block
+without it fails fast.
+
 ---
 
 ## Training Workflow
@@ -159,6 +193,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/.claude/skills/fine-tuning/reference/sft-training.md
+++ b/.claude/skills/fine-tuning/reference/sft-training.md
@@ -88,6 +88,40 @@ When `completion_only_loss: true` (default):
 - User prompt tokens ignored during training
 - Prevents model from learning to generate user messages
 
+### Auxiliary Readout Head (`aux_head`, optional)
+An optional auxiliary scalar readout head that learns to predict a per-row
+target from a frozen base model's hidden state (Phase A: the base/LoRA is
+frozen and only the small head trains; the LM loss is not used). The feature is
+**off by default** — when the `aux_head` block is absent or `enabled: false`,
+the SFT path is byte-identical to a standard run.
+
+When enabled, every training row must carry a finite numeric target under the
+column named by `target_field`; a missing, null, non-numeric, or non-finite
+value fails loudly (there is no silent default). After training, the head is
+written next to the model as a sidecar (`aux_head.safetensors` +
+`aux_head_config.json`) so it can be reloaded for inference independently of the
+base weights.
+
+```yaml
+aux_head:
+  enabled: true            # absent / false => feature fully off
+  layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
+  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  target_field: target     # per-row dataset column carrying the scalar target
+  loss: bce                # "bce" | "brier" (MSE on probability)
+  head_type: linear        # "linear" | "mlp"
+  hidden_dims: []          # hidden widths when head_type: mlp
+  out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
+  freeze_base: true        # Phase A = true
+  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  head_lr: null            # optional dedicated head LR; defaults to trainer LR
+```
+
+A complete runnable example lives at
+`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
+the hidden-state index is a deliberate per-run decision, so an enabled block
+without it fails fast.
+
 ---
 
 ## Training Workflow
@@ -159,6 +193,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/.skills/fine-tuning/reference/sft-training.md
+++ b/.skills/fine-tuning/reference/sft-training.md
@@ -88,6 +88,40 @@ When `completion_only_loss: true` (default):
 - User prompt tokens ignored during training
 - Prevents model from learning to generate user messages
 
+### Auxiliary Readout Head (`aux_head`, optional)
+An optional auxiliary scalar readout head that learns to predict a per-row
+target from a frozen base model's hidden state (Phase A: the base/LoRA is
+frozen and only the small head trains; the LM loss is not used). The feature is
+**off by default** — when the `aux_head` block is absent or `enabled: false`,
+the SFT path is byte-identical to a standard run.
+
+When enabled, every training row must carry a finite numeric target under the
+column named by `target_field`; a missing, null, non-numeric, or non-finite
+value fails loudly (there is no silent default). After training, the head is
+written next to the model as a sidecar (`aux_head.safetensors` +
+`aux_head_config.json`) so it can be reloaded for inference independently of the
+base weights.
+
+```yaml
+aux_head:
+  enabled: true            # absent / false => feature fully off
+  layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
+  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  target_field: target     # per-row dataset column carrying the scalar target
+  loss: bce                # "bce" | "brier" (MSE on probability)
+  head_type: linear        # "linear" | "mlp"
+  hidden_dims: []          # hidden widths when head_type: mlp
+  out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
+  freeze_base: true        # Phase A = true
+  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  head_lr: null            # optional dedicated head LR; defaults to trainer LR
+```
+
+A complete runnable example lives at
+`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
+the hidden-state index is a deliberate per-run decision, so an enabled block
+without it fails fast.
+
 ---
 
 ## Training Workflow
@@ -159,6 +193,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/Trainers/sft/configs/aux_head_example.yaml
+++ b/Trainers/sft/configs/aux_head_example.yaml
@@ -1,0 +1,93 @@
+# ============================================================================
+# Example SFT config with an auxiliary scalar readout head (aux_head), Phase A.
+#
+# Phase A trains ONLY the head over a FROZEN base: the loss is a proper-scoring
+# loss between head(hidden_states[layer]) and a per-row target column. With the
+# aux_head block absent or enabled=false, training is byte-identical to a normal
+# SFT run.
+#
+# The base model, dataset, and target column below are placeholders — point them
+# at your own. The dataset must carry a per-row float in [0,1] (or a 0/1 label)
+# under `aux_head.target_field`; producing that column is the dataset's job.
+# ============================================================================
+
+model:
+  model_name: "unsloth/Qwen3-4B"
+  max_seq_length: 2048
+  dtype: null
+  load_in_4bit: false
+
+lora:
+  r: 64
+  lora_alpha: 128
+  lora_dropout: 0
+  bias: "none"
+  target_modules:
+    - "q_proj"
+    - "k_proj"
+    - "v_proj"
+    - "o_proj"
+  use_gradient_checkpointing: "unsloth"
+  random_state: 3407
+  use_rslora: false
+  use_dora: false
+
+training:
+  output_dir: "./aux_head_output"
+  per_device_train_batch_size: 8
+  gradient_accumulation_steps: 4
+  learning_rate: 1e-3            # head-only training tolerates a higher LR
+  max_grad_norm: 1.0
+  lr_scheduler_type: "linear"
+  max_seq_length: 2048
+  packing: false
+  completion_only_loss: true
+  assistant_only_loss: false
+  gradient_checkpointing: true
+  optim: "adamw_8bit"
+  fp16: false
+  bf16: true
+  num_train_epochs: 1
+  warmup_ratio: 0.02
+  logging_steps: 5
+  save_steps: 50
+  save_total_limit: 3
+  dataloader_num_workers: 0
+  dataloader_pin_memory: true
+  group_by_length: false
+  eval_strategy: "no"
+  eval_steps: 50
+
+dataset:
+  dataset_name: null
+  dataset_file: null
+  # Point this at a local JSONL whose rows carry the target column below.
+  local_file: "../../Datasets/your_dataset_with_target.jsonl"
+  num_proc: 1
+  test_size: 0.1
+  split_dataset: false
+  filter_desirable: false
+
+wandb:
+  enabled: false
+  project: null
+  run_name: null
+  entity: null
+
+seed: 42
+
+# ============================================================================
+# Auxiliary scalar readout head (Phase A: frozen base, no LM loss term).
+# ============================================================================
+aux_head:
+  enabled: true            # absent/false ⇒ feature fully off (backward compatible)
+  layer: 35                # which hidden_states index to read (0 = embeddings); required when enabled
+  token_position: last     # "last" (last non-pad token) | "mean" | int index
+  target_field: target     # per-row dataset column carrying the target float/label
+  loss: bce                # "bce" (binary/soft in [0,1]) | "brier" (MSE on prob)
+  head_type: linear        # "linear" | "mlp"
+  hidden_dims: []          # widths for the "mlp" head; ignored for "linear"
+  out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity" (raw logit)
+  freeze_base: true        # Phase A = true (Phase B flips this to co-train LoRA)
+  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term; Phase B sets > 0)
+  head_lr: null            # optional dedicated head LR; defaults to trainer LR if null

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -147,6 +147,28 @@ class EvolutionaryConfig:
 
 
 @dataclass
+class AuxHeadConfig:
+    """Auxiliary scalar readout head configuration (Phase A: frozen base).
+
+    Absent block / ``enabled=false`` ⇒ feature fully off (backward compatible).
+    Everything tunable lives here (config-first); nothing is hardcoded in the
+    trainer. ``layer`` is required when enabled (no silent default — other users
+    read a different layer than ours).
+    """
+    enabled: bool = False
+    layer: Optional[int] = None          # which hidden_states index to read (0 = embeddings)
+    token_position: Any = "last"         # "last" (last non-pad) | "mean" | int index
+    target_field: str = "target"         # per-row dataset column carrying the target
+    loss: str = "bce"                    # "bce" | "brier" (MSE on prob)
+    head_type: str = "linear"            # "linear" | "mlp"
+    hidden_dims: List[int] = field(default_factory=list)  # for "mlp"
+    out_activation: str = "sigmoid"      # "sigmoid" (prob in [0,1]) | "identity"
+    freeze_base: bool = True             # Phase A = true (Phase B flips this)
+    lm_loss_weight: float = 0.0          # Phase A = 0.0 (no LM term; Phase B > 0)
+    head_lr: Optional[float] = None      # optional; defaults to trainer LR if None
+
+
+@dataclass
 class Config:
     """Master configuration combining all sub-configs."""
     model: ModelConfig
@@ -155,6 +177,7 @@ class Config:
     dataset: DatasetConfig
     wandb: WandbConfig
     evolutionary: EvolutionaryConfig = field(default_factory=EvolutionaryConfig)
+    aux_head: AuxHeadConfig = field(default_factory=AuxHeadConfig)
     seed: int = 42
 
     @property
@@ -262,6 +285,39 @@ def load_evolutionary_config(evo_data: Dict[str, Any]) -> EvolutionaryConfig:
     )
 
 
+def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
+    """Load aux_head config from a YAML dict (mirrors load_evolutionary_config).
+
+    Returns a default (disabled) config on absent/empty input. When enabled, the
+    ``layer`` must be present — there is no silent default, so a misconfigured
+    block fails loudly rather than reading an arbitrary layer.
+    """
+    if not aux_data:
+        return AuxHeadConfig()
+
+    enabled = aux_data.get('enabled', False)
+    layer = aux_data.get('layer', None)
+    if enabled and layer is None:
+        raise ValueError(
+            "aux_head.enabled=true requires aux_head.layer to be set explicitly "
+            "(no silent default — choose the hidden_states index to read)."
+        )
+
+    return AuxHeadConfig(
+        enabled=enabled,
+        layer=layer,
+        token_position=aux_data.get('token_position', 'last'),
+        target_field=aux_data.get('target_field', 'target'),
+        loss=aux_data.get('loss', 'bce'),
+        head_type=aux_data.get('head_type', 'linear'),
+        hidden_dims=list(aux_data.get('hidden_dims', []) or []),
+        out_activation=aux_data.get('out_activation', 'sigmoid'),
+        freeze_base=aux_data.get('freeze_base', True),
+        lm_loss_weight=aux_data.get('lm_loss_weight', 0.0),
+        head_lr=aux_data.get('head_lr', None),
+    )
+
+
 def load_config(config_path: str = None) -> Config:
     """
     Load YAML config and convert to Config dataclass.
@@ -281,6 +337,7 @@ def load_config(config_path: str = None) -> Config:
     dataset_config = dict_to_dataclass(DatasetConfig, yaml_config['dataset'])
     wandb_config = dict_to_dataclass(WandbConfig, yaml_config.get('wandb', {}))
     evolutionary_config = load_evolutionary_config(yaml_config.get('evolutionary', {}))
+    aux_head_config = load_aux_head_config(yaml_config.get('aux_head', {}))
 
     return Config(
         model=model_config,
@@ -289,6 +346,7 @@ def load_config(config_path: str = None) -> Config:
         dataset=dataset_config,
         wandb=wandb_config,
         evolutionary=evolutionary_config,
+        aux_head=aux_head_config,
         seed=yaml_config.get('seed', 42)
     )
 

--- a/Trainers/sft/src/aux_head.py
+++ b/Trainers/sft/src/aux_head.py
@@ -1,0 +1,295 @@
+"""
+Auxiliary scalar readout head for SFT training.
+
+Location: Trainers/sft/src/aux_head.py
+
+Summary
+-------
+A small, generic, optional ``nn.Module`` that reads one hidden-layer activation
+from a base model and emits a single scalar in ``[0, 1]`` per row. It is trained
+by a proper-scoring loss against a per-row target while the base model stays
+frozen (Phase A). The head is portable: it is saved as a standalone sidecar
+artifact (``aux_head.safetensors`` + ``aux_head_config.json``) and reloaded for
+inference independently of the base checkpoint.
+
+How it is used
+--------------
+- ``aux_head_trainer.AuxHeadTrainer`` constructs an ``AuxHead`` (input_dim =
+  base hidden size), freezes the base, and calls ``reduce_hidden_states`` +
+  ``compute_aux_head_loss`` inside its ``compute_loss`` override.
+- ``train_sft.run`` wires the head behind ``config.aux_head.enabled`` and calls
+  ``save_aux_head`` after training.
+- Downstream callers reload via ``load_aux_head`` and score inputs with
+  ``infer_aux_scalar``.
+
+This module is intentionally task-neutral: the target is whatever per-row
+column the config names. No decision policy / threshold is baked in here — how
+the scalar is consumed is the caller's concern.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional, Sequence, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+VALID_HEAD_TYPES = ("linear", "mlp")
+VALID_LOSSES = ("bce", "brier")
+VALID_OUT_ACTIVATIONS = ("sigmoid", "identity")
+
+
+class AuxHead(nn.Module):
+    """A tiny scalar readout head over a single hidden-state vector.
+
+    Args:
+        input_dim: Width of the hidden state the head reads (base hidden size).
+        head_type: ``"linear"`` (default; a single ``nn.Linear(input_dim, 1)``)
+            or ``"mlp"`` (stacked ``Linear`` + ``GELU`` blocks per ``hidden_dims``
+            then a final ``Linear(..., 1)``).
+        hidden_dims: Hidden widths for the ``mlp`` head. Ignored for ``linear``.
+        out_activation: ``"sigmoid"`` (default) squashes the logit into ``[0, 1]``;
+            ``"identity"`` returns the raw logit (callers that want logits).
+
+    forward(hidden) -> Tensor:
+        ``hidden`` has shape ``[batch, input_dim]`` (already reduced over the
+        sequence). The pulled hidden state is cast to the head's parameter dtype
+        first, so a bf16/fp16 base can feed an fp32 head safely. Returns a
+        ``[batch]`` tensor; with ``out_activation="sigmoid"`` every element lies
+        in ``[0, 1]``.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        head_type: str = "linear",
+        hidden_dims: Sequence[int] = (),
+        out_activation: str = "sigmoid",
+    ) -> None:
+        super().__init__()
+        if input_dim <= 0:
+            raise ValueError(f"AuxHead input_dim must be positive, got {input_dim}.")
+        if head_type not in VALID_HEAD_TYPES:
+            raise ValueError(f"Unknown head_type {head_type!r}; expected one of {VALID_HEAD_TYPES}.")
+        if out_activation not in VALID_OUT_ACTIVATIONS:
+            raise ValueError(
+                f"Unknown out_activation {out_activation!r}; expected one of {VALID_OUT_ACTIVATIONS}."
+            )
+
+        self.input_dim = int(input_dim)
+        self.head_type = head_type
+        self.hidden_dims = tuple(int(d) for d in hidden_dims)
+        self.out_activation = out_activation
+
+        if head_type == "linear":
+            self.net: nn.Module = nn.Linear(self.input_dim, 1)
+        else:  # "mlp"
+            layers: list[nn.Module] = []
+            prev = self.input_dim
+            for width in self.hidden_dims:
+                layers.append(nn.Linear(prev, width))
+                layers.append(nn.GELU())
+                prev = width
+            layers.append(nn.Linear(prev, 1))
+            self.net = nn.Sequential(*layers)
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """Parameter dtype — the dtype the pulled hidden state is cast to."""
+        return next(self.parameters()).dtype
+
+    def forward(self, hidden: torch.Tensor) -> torch.Tensor:
+        # Cast the pulled hidden state to the head's dtype (bf16 base -> fp32 head).
+        hidden = hidden.to(self.dtype)
+        logits = self.net(hidden).squeeze(-1)  # [batch, 1] -> [batch]
+        if self.out_activation == "sigmoid":
+            return torch.sigmoid(logits)
+        return logits  # "identity"
+
+
+def reduce_hidden_states(
+    hidden: torch.Tensor,
+    attention_mask: torch.Tensor,
+    token_position: Union[str, int] = "last",
+) -> torch.Tensor:
+    """Reduce a ``[batch, seq, hidden]`` tensor to ``[batch, hidden]``.
+
+    The SFT collator right-pads, so the last *real* token per row is
+    ``attention_mask.sum(1) - 1`` (NOT ``seq_len - 1``).
+
+    Args:
+        hidden: ``[batch, seq, hidden]`` hidden states for one layer.
+        attention_mask: ``[batch, seq]`` 1/0 mask (1 = real token, right-padded).
+        token_position: ``"last"`` (last non-pad token), ``"mean"`` (mask-weighted
+            mean over real tokens), or an int index into the sequence.
+
+    Returns:
+        ``[batch, hidden]``.
+    """
+    if hidden.dim() != 3:
+        raise ValueError(f"reduce_hidden_states expects [batch, seq, hidden]; got shape {tuple(hidden.shape)}.")
+
+    batch_size = hidden.size(0)
+    arange = torch.arange(batch_size, device=hidden.device)
+
+    if token_position == "last":
+        lengths = attention_mask.to(hidden.device).long().sum(dim=1)
+        last_idx = (lengths - 1).clamp_min(0)  # all-zero mask is impossible, but cheap insurance
+        return hidden[arange, last_idx]
+
+    if token_position == "mean":
+        mask = attention_mask.to(hidden.device).to(hidden.dtype).unsqueeze(-1)  # [batch, seq, 1]
+        summed = (hidden * mask).sum(dim=1)  # [batch, hidden]
+        counts = mask.sum(dim=1).clamp_min(1.0)  # [batch, 1]
+        return summed / counts
+
+    if isinstance(token_position, int):
+        seq_len = hidden.size(1)
+        idx = token_position if token_position >= 0 else seq_len + token_position
+        if not 0 <= idx < seq_len:
+            raise ValueError(f"token_position index {token_position} out of range for seq_len {seq_len}.")
+        return hidden[:, idx, :]
+
+    raise ValueError(
+        f"Unsupported token_position {token_position!r}; expected 'last', 'mean', or an int index."
+    )
+
+
+def compute_aux_head_loss(pred: torch.Tensor, target: torch.Tensor, loss_type: str) -> torch.Tensor:
+    """Proper-scoring loss between predicted probabilities and per-row targets.
+
+    Computed in fp32 with autocast disabled: ``F.binary_cross_entropy`` is on the
+    autocast block-list and would raise inside a mixed-precision region, and fp32
+    is numerically safer for the score regardless.
+
+    Args:
+        pred: ``[batch]`` predicted probabilities in ``[0, 1]``.
+        target: ``[batch]`` per-row targets in ``[0, 1]`` (soft) or ``{0, 1}``.
+        loss_type: ``"bce"`` (binary cross-entropy) or ``"brier"`` (MSE on prob).
+    """
+    if loss_type not in VALID_LOSSES:
+        raise ValueError(f"Unknown loss {loss_type!r}; expected one of {VALID_LOSSES}.")
+
+    device_type = pred.device.type
+    with torch.autocast(device_type=device_type, enabled=False):
+        pred_f = pred.float()
+        target_f = target.float()
+        if loss_type == "bce":
+            return F.binary_cross_entropy(pred_f, target_f)
+        return F.mse_loss(pred_f, target_f)  # "brier"
+
+
+def save_aux_head(
+    aux_head: AuxHead,
+    output_dir: Union[str, Path],
+    *,
+    layer: int,
+    token_position: Union[str, int],
+    loss: str,
+) -> Path:
+    """Persist the head weights + the resolved config as a portable sidecar.
+
+    Writes ``aux_head.safetensors`` (state_dict) and ``aux_head_config.json``
+    (everything ``load_aux_head`` needs to reconstruct the module and everything
+    inference needs to read the right layer/token). Neither SFT save path
+    serializes an attached head, so this sidecar is the only persistence.
+    """
+    from safetensors.torch import save_file
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    state = {key: value.detach().contiguous().cpu() for key, value in aux_head.state_dict().items()}
+    save_file(state, str(out_dir / "aux_head.safetensors"))
+
+    resolved = {
+        "input_dim": aux_head.input_dim,
+        "head_type": aux_head.head_type,
+        "hidden_dims": list(aux_head.hidden_dims),
+        "out_activation": aux_head.out_activation,
+        "layer": layer,
+        "token_position": token_position,
+        "loss": loss,
+    }
+    (out_dir / "aux_head_config.json").write_text(json.dumps(resolved, indent=2), encoding="utf-8")
+    return out_dir
+
+
+def load_aux_head(run_dir: Union[str, Path], base_model: Optional[Any] = None) -> AuxHead:
+    """Reconstruct an :class:`AuxHead` from a sidecar and load its weights.
+
+    Args:
+        run_dir: Directory holding ``aux_head.safetensors`` + ``aux_head_config.json``.
+        base_model: Optional — when given, the head is moved onto the base model's
+            device/dtype so it can be fed hidden states directly. Reconstruction
+            itself does not depend on it (the head is standalone/portable).
+    """
+    from safetensors.torch import load_file
+
+    src = Path(run_dir)
+    config_path = src / "aux_head_config.json"
+    weights_path = src / "aux_head.safetensors"
+    if not config_path.exists() or not weights_path.exists():
+        raise FileNotFoundError(
+            f"aux_head sidecar incomplete in {src}: expected aux_head_config.json + aux_head.safetensors."
+        )
+
+    resolved = json.loads(config_path.read_text(encoding="utf-8"))
+    head = AuxHead(
+        input_dim=resolved["input_dim"],
+        head_type=resolved.get("head_type", "linear"),
+        hidden_dims=tuple(resolved.get("hidden_dims", []) or []),
+        out_activation=resolved.get("out_activation", "sigmoid"),
+    )
+    head.load_state_dict(load_file(str(weights_path)))
+
+    if base_model is not None:
+        try:
+            ref = next(base_model.parameters())
+            head = head.to(device=ref.device, dtype=ref.dtype)
+        except StopIteration:
+            pass
+    return head
+
+
+def read_aux_head_resolved_config(run_dir: Union[str, Path]) -> dict:
+    """Return the sidecar's resolved config dict (layer, token_position, loss, ...)."""
+    return json.loads((Path(run_dir) / "aux_head_config.json").read_text(encoding="utf-8"))
+
+
+def infer_aux_scalar(
+    model: Any,
+    aux_head: AuxHead,
+    *,
+    input_ids: torch.Tensor,
+    attention_mask: torch.Tensor,
+    layer: int,
+    token_position: Union[str, int] = "last",
+) -> torch.Tensor:
+    """Generic inference hook: base + head + input -> per-row scalar in ``[0, 1]``.
+
+    Runs the base with ``output_hidden_states=True``, reduces ``hidden_states[layer]``
+    at ``token_position``, and applies the head. No decision policy/threshold is
+    applied — that is the caller's concern.
+
+    Returns ``[batch]`` (one scalar per row).
+    """
+    was_training = model.training
+    model.eval()
+    try:
+        with torch.no_grad():
+            outputs = model(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                output_hidden_states=True,
+            )
+            hidden = outputs.hidden_states[layer]
+            reduced = reduce_hidden_states(hidden, attention_mask, token_position)
+            return aux_head(reduced)
+    finally:
+        if was_training:
+            model.train()

--- a/Trainers/sft/src/aux_head.py
+++ b/Trainers/sft/src/aux_head.py
@@ -111,6 +111,29 @@ class AuxHead(nn.Module):
         return logits  # "identity"
 
 
+def resolve_hidden_size(model: Any) -> int:
+    """Resolve the base model's hidden size for the aux_head input dim.
+
+    The model returned by the PEFT/Unsloth wrap usually proxies ``.config`` to the
+    base, but not always — fall back to the base model's config, then to the input
+    embedding width.
+
+    This lives in the unsloth-free head module (not the ``train_sft`` entry point,
+    which imports unsloth at module load) so all three fallback branches are
+    importable and unit-testable. ``train_sft.run`` imports and calls it.
+    """
+    config_obj = getattr(model, "config", None)
+    hidden_size = getattr(config_obj, "hidden_size", None)
+    if hidden_size is None:
+        base = getattr(model, "base_model", None)
+        base_config = getattr(base, "config", None)
+        hidden_size = getattr(base_config, "hidden_size", None)
+    if hidden_size is None:
+        embeddings = model.get_input_embeddings()
+        hidden_size = getattr(embeddings, "embedding_dim", None) or embeddings.weight.shape[1]
+    return int(hidden_size)
+
+
 def reduce_hidden_states(
     hidden: torch.Tensor,
     attention_mask: torch.Tensor,

--- a/Trainers/sft/src/aux_head_trainer.py
+++ b/Trainers/sft/src/aux_head_trainer.py
@@ -51,6 +51,20 @@ class AuxHeadTrainer(Trainer):
         self.aux_head = aux_head
         self.aux_head_config = aux_head_config
 
+        # Fail loud on the load-bearing dependency, not deep inside compute_loss.
+        # The per-row ``aux_target`` column survives into the collator ONLY because
+        # the SFT path sets remove_unused_columns=False; HF would otherwise strip
+        # any column not in the model's forward signature. Flipping that flag would
+        # surface as an opaque "batch without 'aux_target'" error far from the
+        # toggle, so assert it here where the cause is obvious.
+        if self.args.remove_unused_columns is not False:
+            raise ValueError(
+                "AuxHeadTrainer requires TrainingArguments.remove_unused_columns=False "
+                "so the per-row 'aux_target' column survives into the data collator and "
+                f"compute_loss; got remove_unused_columns={self.args.remove_unused_columns!r}. "
+                "Do not flip this when aux_head is enabled."
+            )
+
         # Place the head on the base model's device (dtype stays the head's own,
         # so a bf16 base can feed an fp32 head; AuxHead.forward casts the input).
         try:
@@ -63,6 +77,31 @@ class AuxHeadTrainer(Trainer):
             self._freeze_base_keep_head()
 
         self._log_trainable_param_accounting()
+
+    def train(self, resume_from_checkpoint=None, *args: Any, **kwargs: Any):  # type: ignore[override]
+        """Fail loud on resume — Phase A does not support ``resume_from_checkpoint``.
+
+        The head is held OUTSIDE ``self.model`` and persisted ONLY as a post-train
+        sidecar (``save_aux_head``). HF's per-step checkpoints serialize
+        ``self.model`` + ``optimizer.pt`` + ``scheduler.pt`` but NOT the head module,
+        so resuming would reconstruct the head fresh (random) in ``run()`` while
+        reloading STALE head-optimizer momentum onto it — silently corrupting the
+        head. Until the head is hooked into checkpoint save/load (out of Phase-A
+        scope), refuse to resume rather than train a corrupted head.
+
+        The guard lives on the trainer (not only at the call site) so it protects
+        every caller, and it is observed HERE because ``resume_from_checkpoint``
+        arrives as a ``train()`` argument, not a ``TrainingArguments`` field.
+        """
+        if resume_from_checkpoint:
+            raise RuntimeError(
+                "AuxHeadTrainer does not support resume_from_checkpoint: the aux_head is "
+                "not captured by HF per-step checkpoints (it is sidecar-saved after "
+                "train() only), so resuming would reinitialize the head while reapplying "
+                "stale head-optimizer state. Phase A does not support resume — restart "
+                "training from scratch or clear resume_from_checkpoint."
+            )
+        return super().train(resume_from_checkpoint, *args, **kwargs)
 
     def _freeze_base_keep_head(self) -> None:
         """Freeze every base/LoRA parameter so ONLY the head accumulates gradient.

--- a/Trainers/sft/src/aux_head_trainer.py
+++ b/Trainers/sft/src/aux_head_trainer.py
@@ -1,0 +1,150 @@
+"""
+Trainer subclass that trains an auxiliary scalar readout head (Phase A).
+
+Location: Trainers/sft/src/aux_head_trainer.py
+
+Summary
+-------
+``AuxHeadTrainer`` subclasses the stock ``transformers.Trainer`` used by the SFT
+path. It freezes the base (and any LoRA) so only the appended :class:`AuxHead`
+trains, enables hidden states inside ``compute_loss``, reduces the configured
+layer at the configured token position, and supervises the head with a
+proper-scoring loss against the per-row ``aux_target`` carried by the collator.
+
+How it is used
+--------------
+``train_sft.run`` constructs this in place of ``Trainer`` only when
+``config.aux_head.enabled`` is true; otherwise the off-path is byte-identical to
+the stock trainer. After ``train()`` the caller saves the head via
+``aux_head.save_aux_head``.
+
+Phase A vs Phase B
+------------------
+Phase A loss IS the head loss alone (no LM term). The base + LoRA are frozen and
+the optimizer is built over the head's parameters only. The single Phase-B seam
+(``loss = outputs.loss + lm_loss_weight * head_loss``) is marked with a one-line
+comment in ``compute_loss``; flipping ``freeze_base``/``lm_loss_weight`` is the
+only change Phase B needs here.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import torch
+from transformers import Trainer
+
+from aux_head import AuxHead, compute_aux_head_loss, reduce_hidden_states
+
+
+class AuxHeadTrainer(Trainer):
+    """Stock ``Trainer`` that trains only an :class:`AuxHead` over a frozen base.
+
+    Args (beyond the stock ``Trainer`` kwargs):
+        aux_head: the head module to train.
+        aux_head_config: the resolved ``AuxHeadConfig`` (layer, token_position,
+            target_field, loss, freeze_base, lm_loss_weight, head_lr).
+    """
+
+    def __init__(self, *args: Any, aux_head: AuxHead, aux_head_config: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.aux_head = aux_head
+        self.aux_head_config = aux_head_config
+
+        # Place the head on the base model's device (dtype stays the head's own,
+        # so a bf16 base can feed an fp32 head; AuxHead.forward casts the input).
+        try:
+            ref = next(self.model.parameters())
+            self.aux_head = self.aux_head.to(device=ref.device)
+        except StopIteration:
+            pass
+
+        if getattr(aux_head_config, "freeze_base", True):
+            self._freeze_base_keep_head()
+
+        self._log_trainable_param_accounting()
+
+    def _freeze_base_keep_head(self) -> None:
+        """Freeze every base/LoRA parameter so ONLY the head accumulates gradient.
+
+        Mirrors the embedding ``frozen_head`` precedent's requires_grad mechanics:
+        freeze all of ``self.model``; the head (held separately, not a submodule
+        of ``model``) stays trainable.
+        """
+        for param in self.model.parameters():
+            param.requires_grad = False
+        for param in self.aux_head.parameters():
+            param.requires_grad = True
+
+    def _log_trainable_param_accounting(self) -> None:
+        """Log trainable-param counts (mirror model_loader accounting) for audit."""
+        base_trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
+        head_trainable = sum(p.numel() for p in self.aux_head.parameters() if p.requires_grad)
+        if getattr(self.aux_head_config, "freeze_base", True) and base_trainable != 0:
+            # Loud: Phase A must train the head ONLY.
+            print(
+                f"[aux_head][WARN] freeze_base=true but base reports {base_trainable} trainable "
+                f"params (expected 0). Only the head should train in Phase A."
+            )
+        print(
+            f"[aux_head] trainable params -> head: {head_trainable:,} | base: {base_trainable:,} "
+            f"(freeze_base={getattr(self.aux_head_config, 'freeze_base', True)})"
+        )
+
+    def create_optimizer(self, model=None):  # type: ignore[override]
+        """Build the optimizer over the HEAD's parameters.
+
+        The head is not a submodule of ``self.model``, so stock
+        ``create_optimizer`` (which walks ``model.parameters()``) would never see
+        it. We override to register the head's params explicitly, optionally on a
+        dedicated ``head_lr`` learning rate. Phase B (``freeze_base=false``) would
+        additionally add the unfrozen LoRA params here.
+        """
+        if self.optimizer is not None:
+            return self.optimizer
+
+        optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
+        head_lr = getattr(self.aux_head_config, "head_lr", None)
+        head_params = [p for p in self.aux_head.parameters() if p.requires_grad]
+        param_group = {"params": head_params}
+        if head_lr is not None:
+            param_group["lr"] = head_lr
+        self.optimizer = optimizer_cls([param_group], **optimizer_kwargs)
+        return self.optimizer
+
+    def compute_loss(
+        self,
+        model,
+        inputs,
+        return_outputs: bool = False,
+        num_items_in_batch: Optional[int] = None,
+    ):
+        """Phase A: loss = proper_score(head(reduced hidden state), aux_target)."""
+        cfg = self.aux_head_config
+
+        # The collator stacks the per-row target under "aux_target"; pop it so it
+        # is never passed into the language model forward.
+        aux_target = inputs.pop("aux_target", None)
+        if aux_target is None:
+            raise ValueError(
+                "AuxHeadTrainer.compute_loss received a batch without 'aux_target'. "
+                "Ensure aux_head.target_field is set and the preprocessing/collator "
+                "plumbing carried the per-row target through."
+            )
+
+        # Enable hidden states HERE (no global flag); base is frozen so this
+        # forward accrues gradient only through the head below.
+        outputs = model(**inputs, output_hidden_states=True)
+
+        hidden = outputs.hidden_states[cfg.layer]
+        reduced = reduce_hidden_states(hidden, inputs["attention_mask"], cfg.token_position)
+        pred = self.aux_head(reduced)
+
+        target = aux_target.to(pred.device)
+        head_loss = compute_aux_head_loss(pred, target, cfg.loss)
+
+        # Phase A: the head loss is the ENTIRE loss (no LM term).
+        # Phase B seam (do NOT enable here): loss = outputs.loss + cfg.lm_loss_weight * head_loss
+        loss = head_loss
+
+        return (loss, outputs) if return_outputs else loss

--- a/Trainers/sft/src/data_loader.py
+++ b/Trainers/sft/src/data_loader.py
@@ -155,6 +155,7 @@ def load_and_prepare_tokenized_dataset(
     max_seq_length: int = 2048,
     loss_mask_mode: str = ASSISTANT_ONLY,
     chat_template_kwargs: Optional[dict] = None,
+    aux_target_field: Optional[str] = None,
 ) -> Tuple[Dataset, Optional[Dataset]]:
     """
     Load and prepare dataset into explicit tokenized SFT features.
@@ -162,6 +163,9 @@ def load_and_prepare_tokenized_dataset(
     This is the repo-owned prepared-dataset path for trainers that want to
     consume ``input_ids`` / ``attention_mask`` / ``labels`` directly instead of
     relying on implicit TRL preprocessing behavior.
+
+    ``aux_target_field`` (optional) names a per-row column to carry through as an
+    ``aux_target`` feature for the auxiliary readout head. None ⇒ unchanged.
     """
     print("=" * 60)
     print("LOADING TOKENIZED DATASET FOR SFT")
@@ -211,6 +215,7 @@ def load_and_prepare_tokenized_dataset(
         num_proc=num_proc,
         include_text=False,
         chat_template_kwargs=chat_template_kwargs,
+        aux_target_field=aux_target_field,
     )
 
     eval_dataset = None

--- a/Trainers/sft/src/preprocessing.py
+++ b/Trainers/sft/src/preprocessing.py
@@ -4,6 +4,7 @@ SFT-facing wrapper over the canonical repo-owned preprocessing contract.
 
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from datasets import Dataset
@@ -76,9 +77,16 @@ def prepare_sft_dataset(
     loss_mask_mode: str = ASSISTANT_ONLY,
     backend: str = "trl_unsloth",
     chat_template_kwargs: dict[str, Any] | None = None,
+    aux_target_field: str | None = None,
 ) -> Dataset:
     del backend  # The contract is backend-agnostic; callers choose the trainer separately.
 
+    # ``remove_columns=dataset.column_names`` (below) drops every original column
+    # AFTER ``_materialize`` runs, so any per-row directive (e.g. the aux_head
+    # target) must be READ HERE and threaded into the returned dict to survive —
+    # extending only the collator is too late. When ``aux_target_field`` is None
+    # the returned dict is exactly {input_ids, attention_mask, labels}, identical
+    # to the feature-off behavior.
     def _materialize(example: dict[str, Any]) -> dict[str, Any]:
         normalized = normalize_sft_example(example)
         prepared = materialize_sft_features(
@@ -88,17 +96,45 @@ def prepare_sft_dataset(
             loss_mask_mode=loss_mask_mode,
             chat_template_kwargs=chat_template_kwargs,
         )
-        return {
+        materialized = {
             "input_ids": prepared.input_ids,
             "attention_mask": prepared.attention_mask,
             "labels": prepared.labels,
         }
+        if aux_target_field is not None:
+            materialized["aux_target"] = _read_aux_target(example, aux_target_field)
+        return materialized
 
     return dataset.map(
         _materialize,
         remove_columns=dataset.column_names,
         desc="Preparing tokenized SFT examples",
     )
+
+
+def _read_aux_target(example: dict[str, Any], aux_target_field: str) -> float:
+    """Read + validate a per-row aux_head target. Loud on missing/NaN (never default).
+
+    Mirrors the subspan precedent's loud-fail discipline: every row must carry a
+    finite target when the feature is enabled — there is no silent substitution.
+    """
+    raw_value = example.get(aux_target_field, None)
+    if raw_value is None:
+        raise ValueError(
+            f"aux_head is enabled with target_field={aux_target_field!r} but a row is "
+            f"missing it (or it is null). Every training row must carry a finite target."
+        )
+    try:
+        target_value = float(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"aux_head target_field={aux_target_field!r} value {raw_value!r} is not numeric."
+        ) from exc
+    if not math.isfinite(target_value):
+        raise ValueError(
+            f"aux_head target_field={aux_target_field!r} value {raw_value!r} is not finite (NaN/inf)."
+        )
+    return target_value
 
 
 def load_and_prepare_sft_dataset(
@@ -110,6 +146,7 @@ def load_and_prepare_sft_dataset(
     num_proc: int = 1,
     include_text: bool = False,
     chat_template_kwargs: dict[str, Any] | None = None,
+    aux_target_field: str | None = None,
 ) -> Dataset:
     del num_proc
     del include_text
@@ -119,4 +156,5 @@ def load_and_prepare_sft_dataset(
         max_seq_length=max_seq_length,
         loss_mask_mode=loss_mask_mode,
         chat_template_kwargs=chat_template_kwargs,
+        aux_target_field=aux_target_field,
     )

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -226,26 +226,6 @@ def validate_model_compatibility(config) -> None:
     print(border + "\n")
 
 
-
-def _resolve_hidden_size(model) -> int:
-    """Resolve the base model's hidden size for the aux_head input dim.
-
-    The model returned by the PEFT/Unsloth wrap usually proxies ``.config`` to the
-    base, but not always — fall back to the base model's config, then to the input
-    embedding width.
-    """
-    config_obj = getattr(model, "config", None)
-    hidden_size = getattr(config_obj, "hidden_size", None)
-    if hidden_size is None:
-        base = getattr(model, "base_model", None)
-        base_config = getattr(base, "config", None)
-        hidden_size = getattr(base_config, "hidden_size", None)
-    if hidden_size is None:
-        embeddings = model.get_input_embeddings()
-        hidden_size = getattr(embeddings, "embedding_dim", None) or embeddings.weight.shape[1]
-    return int(hidden_size)
-
-
 def collate_prepared_sft_batch(features: list[dict[str, Any]], tokenizer) -> dict[str, torch.Tensor]:
     """Pad explicit tokenized SFT rows into a trainer-ready batch."""
     if not features:
@@ -1032,10 +1012,10 @@ def run(args: argparse.Namespace):
     # stock Trainer construction is byte-identical to current behavior.
     aux_head_module = None
     if aux_head_enabled:
-        from src.aux_head import AuxHead
+        from src.aux_head import AuxHead, resolve_hidden_size
         from src.aux_head_trainer import AuxHeadTrainer
 
-        input_dim = _resolve_hidden_size(model)
+        input_dim = resolve_hidden_size(model)
         aux_head_module = AuxHead(
             input_dim=input_dim,
             head_type=aux_head_cfg.head_type,

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -227,6 +227,25 @@ def validate_model_compatibility(config) -> None:
 
 
 
+def _resolve_hidden_size(model) -> int:
+    """Resolve the base model's hidden size for the aux_head input dim.
+
+    The model returned by the PEFT/Unsloth wrap usually proxies ``.config`` to the
+    base, but not always — fall back to the base model's config, then to the input
+    embedding width.
+    """
+    config_obj = getattr(model, "config", None)
+    hidden_size = getattr(config_obj, "hidden_size", None)
+    if hidden_size is None:
+        base = getattr(model, "base_model", None)
+        base_config = getattr(base, "config", None)
+        hidden_size = getattr(base_config, "hidden_size", None)
+    if hidden_size is None:
+        embeddings = model.get_input_embeddings()
+        hidden_size = getattr(embeddings, "embedding_dim", None) or embeddings.weight.shape[1]
+    return int(hidden_size)
+
+
 def collate_prepared_sft_batch(features: list[dict[str, Any]], tokenizer) -> dict[str, torch.Tensor]:
     """Pad explicit tokenized SFT rows into a trainer-ready batch."""
     if not features:
@@ -254,11 +273,21 @@ def collate_prepared_sft_batch(features: list[dict[str, Any]], tokenizer) -> dic
         attention_mask.append(feature_attention_mask)
         labels.append(feature_labels)
 
-    return {
+    batch = {
         "input_ids": torch.tensor(input_ids, dtype=torch.long),
         "attention_mask": torch.tensor(attention_mask, dtype=torch.long),
         "labels": torch.tensor(labels, dtype=torch.long),
     }
+
+    # aux_head: when preprocessing carried a per-row target through (feature
+    # enabled), stack it into a float `aux_target` tensor. Absent ⇒ the batch is
+    # byte-identical to the feature-off path.
+    if "aux_target" in features[0]:
+        batch["aux_target"] = torch.tensor(
+            [float(feature["aux_target"]) for feature in features], dtype=torch.float32
+        )
+
+    return batch
 
 
 def build_training_lineage(
@@ -812,6 +841,12 @@ def run(args: argparse.Namespace):
         "packing": False,
     }
 
+    # aux_head: carry the configured per-row target column through preprocessing
+    # only when the feature is enabled; None ⇒ dataset prep is byte-identical.
+    aux_head_cfg = getattr(config, "aux_head", None)
+    aux_head_enabled = bool(aux_head_cfg is not None and aux_head_cfg.enabled)
+    aux_target_field = aux_head_cfg.target_field if aux_head_enabled else None
+
     # Materialize trainer-ready tokenized rows in-repo so cloud runs do not
     # depend on implicit TRL/Unsloth dataset preparation behavior.
     train_dataset, eval_dataset = load_and_prepare_tokenized_dataset(
@@ -826,6 +861,7 @@ def run(args: argparse.Namespace):
         max_seq_length=config.training.max_seq_length,
         loss_mask_mode=loss_mask_mode,
         chat_template_kwargs=config.training.chat_template_kwargs,
+        aux_target_field=aux_target_field,
     )
     run_metadata["train_size"] = len(train_dataset)
     run_metadata["eval_size"] = len(eval_dataset) if eval_dataset else None
@@ -992,7 +1028,32 @@ def run(args: argparse.Namespace):
         "callbacks": callbacks,
         "data_collator": lambda features: collate_prepared_sft_batch(features, tokenizer),
     }
-    trainer = Trainer(**trainer_kwargs)
+    # aux_head: swap in the readout-head trainer only when enabled; otherwise the
+    # stock Trainer construction is byte-identical to current behavior.
+    aux_head_module = None
+    if aux_head_enabled:
+        from src.aux_head import AuxHead
+        from src.aux_head_trainer import AuxHeadTrainer
+
+        input_dim = _resolve_hidden_size(model)
+        aux_head_module = AuxHead(
+            input_dim=input_dim,
+            head_type=aux_head_cfg.head_type,
+            hidden_dims=aux_head_cfg.hidden_dims,
+            out_activation=aux_head_cfg.out_activation,
+        )
+        print(
+            f"[aux_head] enabled: layer={aux_head_cfg.layer}, token_position={aux_head_cfg.token_position}, "
+            f"target_field={aux_head_cfg.target_field!r}, loss={aux_head_cfg.loss}, head_type={aux_head_cfg.head_type}, "
+            f"input_dim={input_dim}"
+        )
+        trainer = AuxHeadTrainer(
+            aux_head=aux_head_module,
+            aux_head_config=aux_head_cfg,
+            **trainer_kwargs,
+        )
+    else:
+        trainer = Trainer(**trainer_kwargs)
 
     # Remove PrinterCallback to stop the {'loss': ...} dict spam
     # Our LiveDashboardCallback or MetricsTableCallback handles display instead
@@ -1087,6 +1148,21 @@ def run(args: argparse.Namespace):
     # Save final model
     print(f"\nSaving final model to: {final_model_path}")
     trainer.save_model(str(final_model_path))
+
+    # aux_head: trainer.save_model does NOT serialize the separately-held head, so
+    # persist it as a portable sidecar (weights + resolved config) alongside the
+    # final model. Only runs when the feature is enabled.
+    if aux_head_module is not None:
+        from src.aux_head import save_aux_head
+
+        save_aux_head(
+            aux_head_module,
+            final_model_path,
+            layer=aux_head_cfg.layer,
+            token_position=aux_head_cfg.token_position,
+            loss=aux_head_cfg.loss,
+        )
+        print(f"[aux_head] saved sidecar (aux_head.safetensors + aux_head_config.json) to: {final_model_path}")
 
     print(f"\n[OK] Training complete!")
     print(f"  Model saved to: {final_model_path}")

--- a/tests/trainers/sft/test_aux_head.py
+++ b/tests/trainers/sft/test_aux_head.py
@@ -1,0 +1,235 @@
+"""Unit + component smoke tests for the auxiliary scalar readout head.
+
+Location: tests/trainers/sft/test_aux_head.py
+
+Covers AuxHead shapes/dtype/range for linear & mlp, the token-position reduction,
+the proper-scoring loss, the sidecar save/load roundtrip, the inference hook, and
+a component-level training smoke (only the head's params move; loss decreases).
+The full Trainer.train() integration (and the AUROC-vs-oracle bar) is TEST-phase.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors.torch")
+
+import aux_head as aux_head_mod  # noqa: E402
+from aux_head import (  # noqa: E402
+    AuxHead,
+    compute_aux_head_loss,
+    infer_aux_scalar,
+    load_aux_head,
+    reduce_hidden_states,
+    save_aux_head,
+)
+
+
+# ---------------------------------------------------------------------------
+# AuxHead module: shapes, dtype, [0,1] range, linear & mlp
+# ---------------------------------------------------------------------------
+
+def test_linear_head_emits_batch_scalar_in_unit_interval():
+    head = AuxHead(input_dim=16, head_type="linear")
+    out = head(torch.randn(5, 16))
+    assert out.shape == (5,)
+    assert torch.all(out >= 0.0) and torch.all(out <= 1.0)
+
+
+def test_mlp_head_emits_batch_scalar_in_unit_interval():
+    head = AuxHead(input_dim=16, head_type="mlp", hidden_dims=(8, 4))
+    out = head(torch.randn(3, 16))
+    assert out.shape == (3,)
+    assert torch.all(out >= 0.0) and torch.all(out <= 1.0)
+
+
+def test_head_casts_pulled_hidden_state_to_head_dtype():
+    head = AuxHead(input_dim=8, head_type="linear")  # fp32 params by default
+    out = head(torch.randn(4, 8, dtype=torch.float16))
+    assert out.dtype == torch.float32
+    assert out.shape == (4,)
+
+
+def test_identity_activation_returns_raw_logits():
+    head = AuxHead(input_dim=8, head_type="linear", out_activation="identity")
+    out = head(torch.randn(4, 8) * 100.0)
+    # Without sigmoid, values are not constrained to [0, 1].
+    assert out.shape == (4,)
+    assert (out.min() < 0.0) or (out.max() > 1.0)
+
+
+def test_invalid_head_type_and_activation_raise():
+    with pytest.raises(ValueError):
+        AuxHead(input_dim=8, head_type="quadratic")
+    with pytest.raises(ValueError):
+        AuxHead(input_dim=8, out_activation="softmax")
+    with pytest.raises(ValueError):
+        AuxHead(input_dim=0)
+
+
+# ---------------------------------------------------------------------------
+# reduce_hidden_states: last / mean / int, right-pad aware
+# ---------------------------------------------------------------------------
+
+def test_reduce_last_picks_last_non_pad_token_under_right_padding():
+    # batch=2, seq=4, hidden=3. Row 0 has 2 real tokens, row 1 has 4.
+    hidden = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+    attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 1]])
+    reduced = reduce_hidden_states(hidden, attention_mask, "last")
+    assert reduced.shape == (2, 3)
+    # Row 0: last real token is index 1; Row 1: index 3.
+    assert torch.equal(reduced[0], hidden[0, 1])
+    assert torch.equal(reduced[1], hidden[1, 3])
+
+
+def test_reduce_mean_is_masked_mean_over_real_tokens():
+    hidden = torch.ones(1, 4, 2)
+    hidden[0, 2:] = 5.0  # padded positions carry junk
+    attention_mask = torch.tensor([[1, 1, 0, 0]])
+    reduced = reduce_hidden_states(hidden, attention_mask, "mean")
+    # Only the two real (value=1.0) tokens count.
+    assert torch.allclose(reduced, torch.ones(1, 2))
+
+
+def test_reduce_int_index_selects_that_position():
+    hidden = torch.arange(1 * 4 * 2, dtype=torch.float32).reshape(1, 4, 2)
+    attention_mask = torch.ones(1, 4)
+    reduced = reduce_hidden_states(hidden, attention_mask, 0)
+    assert torch.equal(reduced[0], hidden[0, 0])
+
+
+def test_reduce_rejects_bad_inputs():
+    with pytest.raises(ValueError):
+        reduce_hidden_states(torch.randn(2, 3), torch.ones(2, 3), "last")  # not 3D
+    with pytest.raises(ValueError):
+        reduce_hidden_states(torch.randn(1, 4, 2), torch.ones(1, 4), "median")
+    with pytest.raises(ValueError):
+        reduce_hidden_states(torch.randn(1, 4, 2), torch.ones(1, 4), 99)
+
+
+# ---------------------------------------------------------------------------
+# Loss
+# ---------------------------------------------------------------------------
+
+def test_bce_and_brier_losses_are_nonnegative_and_match_known_values():
+    pred = torch.tensor([0.5, 0.5])
+    target = torch.tensor([1.0, 0.0])
+    brier = compute_aux_head_loss(pred, target, "brier")
+    assert torch.allclose(brier, torch.tensor(0.25))
+    bce = compute_aux_head_loss(pred, target, "bce")
+    assert bce.item() > 0.0
+
+
+def test_loss_rejects_unknown_type():
+    with pytest.raises(ValueError):
+        compute_aux_head_loss(torch.tensor([0.5]), torch.tensor([1.0]), "hinge")
+
+
+# ---------------------------------------------------------------------------
+# Save / load sidecar roundtrip
+# ---------------------------------------------------------------------------
+
+def test_save_load_roundtrip_preserves_weights_and_config(tmp_path):
+    head = AuxHead(input_dim=12, head_type="mlp", hidden_dims=(6,))
+    save_aux_head(head, tmp_path, layer=35, token_position="last", loss="bce")
+
+    assert (tmp_path / "aux_head.safetensors").exists()
+    assert (tmp_path / "aux_head_config.json").exists()
+
+    reloaded = load_aux_head(tmp_path)
+    assert reloaded.input_dim == 12
+    assert reloaded.head_type == "mlp"
+    assert reloaded.hidden_dims == (6,)
+
+    x = torch.randn(4, 12)
+    assert torch.allclose(head(x), reloaded(x), atol=1e-6)
+
+    resolved = aux_head_mod.read_aux_head_resolved_config(tmp_path)
+    assert resolved["layer"] == 35
+    assert resolved["token_position"] == "last"
+    assert resolved["loss"] == "bce"
+
+
+def test_load_missing_sidecar_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_aux_head(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Inference hook
+# ---------------------------------------------------------------------------
+
+class _FakeOutputs:
+    def __init__(self, hidden_states):
+        self.hidden_states = hidden_states
+
+
+class _FakeBase(torch.nn.Module):
+    """Minimal stand-in: emits per-layer hidden states from a learned embedding."""
+
+    def __init__(self, vocab=20, hidden=8, layers=3):
+        super().__init__()
+        self.embed = torch.nn.Embedding(vocab, hidden)
+        self.num_layers = layers
+
+    def forward(self, input_ids, attention_mask=None, output_hidden_states=False):
+        h = self.embed(input_ids)
+        hidden_states = tuple(h * (i + 1) for i in range(self.num_layers))
+        return _FakeOutputs(hidden_states)
+
+
+def test_infer_aux_scalar_returns_per_row_scalar_in_unit_interval():
+    base = _FakeBase(hidden=8)
+    head = AuxHead(input_dim=8, head_type="linear")
+    input_ids = torch.randint(0, 20, (3, 5))
+    attention_mask = torch.ones(3, 5, dtype=torch.long)
+    scores = infer_aux_scalar(
+        base, head, input_ids=input_ids, attention_mask=attention_mask, layer=2, token_position="last"
+    )
+    assert scores.shape == (3,)
+    assert torch.all(scores >= 0.0) and torch.all(scores <= 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Component-level training smoke: only the head moves; loss decreases
+# ---------------------------------------------------------------------------
+
+def test_only_head_trains_and_loss_decreases():
+    torch.manual_seed(0)
+    # A "frozen base" stand-in: parameters that must NOT receive gradient.
+    frozen_base = torch.nn.Linear(8, 8)
+    for p in frozen_base.parameters():
+        p.requires_grad = False
+
+    head = AuxHead(input_dim=8, head_type="linear")
+    optimizer = torch.optim.Adam([p for p in head.parameters() if p.requires_grad], lr=0.1)
+
+    # Fixed separable batch.
+    hidden = torch.randn(32, 8)
+    target = (hidden.sum(dim=1) > 0).float()
+
+    first_loss = None
+    last_loss = None
+    for _ in range(50):
+        optimizer.zero_grad()
+        with torch.no_grad():
+            features = frozen_base(hidden)  # frozen base produces features
+        pred = head(features)
+        loss = compute_aux_head_loss(pred, target, "bce")
+        loss.backward()
+        optimizer.step()
+        if first_loss is None:
+            first_loss = loss.item()
+        last_loss = loss.item()
+
+    assert last_loss < first_loss  # the head learned
+    # The frozen base never accumulated gradient.
+    assert all(p.grad is None for p in frozen_base.parameters())
+    assert all(not p.requires_grad for p in frozen_base.parameters())

--- a/tests/trainers/sft/test_aux_head.py
+++ b/tests/trainers/sft/test_aux_head.py
@@ -28,8 +28,10 @@ from aux_head import (  # noqa: E402
     infer_aux_scalar,
     load_aux_head,
     reduce_hidden_states,
+    resolve_hidden_size,
     save_aux_head,
 )
+from types import SimpleNamespace  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -233,3 +235,54 @@ def test_only_head_trains_and_loss_decreases():
     # The frozen base never accumulated gradient.
     assert all(p.grad is None for p in frozen_base.parameters())
     assert all(not p.requires_grad for p in frozen_base.parameters())
+
+
+# ---------------------------------------------------------------------------
+# resolve_hidden_size: all three fallback branches (sizes the head input_dim)
+# ---------------------------------------------------------------------------
+
+def test_resolve_hidden_size_reads_top_level_config():
+    # Branch 1: the (PEFT/Unsloth-proxied) model exposes .config.hidden_size.
+    model = SimpleNamespace(config=SimpleNamespace(hidden_size=128))
+    assert resolve_hidden_size(model) == 128
+
+
+def test_resolve_hidden_size_falls_back_to_base_model_config():
+    # Branch 2: top-level .config has no hidden_size; the base model's does.
+    model = SimpleNamespace(
+        config=SimpleNamespace(),  # no hidden_size attribute
+        base_model=SimpleNamespace(config=SimpleNamespace(hidden_size=256)),
+    )
+    assert resolve_hidden_size(model) == 256
+
+
+def test_resolve_hidden_size_falls_back_to_input_embedding_width():
+    # Branch 3: neither config exposes hidden_size; read the embedding width.
+    embedding = torch.nn.Embedding(10, 64)
+
+    model = SimpleNamespace(
+        config=SimpleNamespace(),
+        base_model=SimpleNamespace(config=SimpleNamespace()),
+        get_input_embeddings=lambda: embedding,
+    )
+    assert resolve_hidden_size(model) == 64
+
+
+def test_resolve_hidden_size_embedding_width_from_weight_shape():
+    # Branch 3 variant: embedding lacks .embedding_dim → fall through to weight.shape[1].
+    weight = torch.zeros(10, 48)
+    embedding = SimpleNamespace(embedding_dim=None, weight=weight)
+
+    model = SimpleNamespace(
+        config=SimpleNamespace(),
+        base_model=SimpleNamespace(config=SimpleNamespace()),
+        get_input_embeddings=lambda: embedding,
+    )
+    assert resolve_hidden_size(model) == 48
+
+
+def test_resolve_hidden_size_returns_int():
+    # The head's nn.Linear needs a real int, not a tensor/0-d value.
+    model = SimpleNamespace(config=SimpleNamespace(hidden_size=32))
+    result = resolve_hidden_size(model)
+    assert isinstance(result, int) and result == 32

--- a/tests/trainers/sft/test_aux_head_config.py
+++ b/tests/trainers/sft/test_aux_head_config.py
@@ -1,0 +1,79 @@
+"""Tests for AuxHeadConfig loading + the Config field wiring.
+
+Location: tests/trainers/sft/test_aux_head_config.py
+
+Guards the silent-drop gotcha: the aux_head block is only honored because
+AuxHeadConfig is a real dataclass field on Config (dict_to_dataclass drops
+unknown keys). Also verifies absent ⇒ off and the loud layer-required check.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "configs"))
+
+import config_loader  # noqa: E402
+from config_loader import AuxHeadConfig, Config, load_aux_head_config  # noqa: E402
+
+
+def test_absent_block_yields_disabled_default():
+    cfg = load_aux_head_config({})
+    assert isinstance(cfg, AuxHeadConfig)
+    assert cfg.enabled is False
+    assert cfg.layer is None
+    assert cfg.target_field == "target"
+    assert cfg.loss == "bce"
+    assert cfg.head_type == "linear"
+    assert cfg.freeze_base is True
+    assert cfg.lm_loss_weight == 0.0
+
+
+def test_enabled_block_is_parsed_fieldwise():
+    cfg = load_aux_head_config(
+        {
+            "enabled": True,
+            "layer": 35,
+            "token_position": "mean",
+            "target_field": "score",
+            "loss": "brier",
+            "head_type": "mlp",
+            "hidden_dims": [64, 16],
+            "out_activation": "identity",
+            "freeze_base": True,
+            "lm_loss_weight": 0.0,
+            "head_lr": 1e-3,
+        }
+    )
+    assert cfg.enabled is True
+    assert cfg.layer == 35
+    assert cfg.token_position == "mean"
+    assert cfg.target_field == "score"
+    assert cfg.loss == "brier"
+    assert cfg.head_type == "mlp"
+    assert cfg.hidden_dims == [64, 16]
+    assert cfg.out_activation == "identity"
+    assert cfg.head_lr == 1e-3
+
+
+def test_enabled_without_layer_fails_loud():
+    with pytest.raises(ValueError, match="requires aux_head.layer"):
+        load_aux_head_config({"enabled": True})
+
+
+def test_config_has_real_aux_head_field_so_block_is_not_silently_dropped():
+    # The whole point: aux_head must be a declared field on Config, otherwise
+    # dict_to_dataclass-style loading would silently ignore the YAML block.
+    field_names = {f.name for f in Config.__dataclass_fields__.values()}
+    assert "aux_head" in field_names
+    assert Config.__dataclass_fields__["aux_head"].type is AuxHeadConfig
+
+
+def test_default_constructed_config_field_is_disabled():
+    # default_factory must give every existing config an inert, disabled head.
+    default = AuxHeadConfig()
+    assert default.enabled is False

--- a/tests/trainers/sft/test_aux_head_integration.py
+++ b/tests/trainers/sft/test_aux_head_integration.py
@@ -1,0 +1,203 @@
+"""Real ``Trainer.train()`` integration smoke for the aux_head feature.
+
+Location: tests/trainers/sft/test_aux_head_integration.py
+
+The other aux_head tests cover the module, the loss, the config, the
+preprocessing hop, and assert the ``train_sft.py`` wiring at the source level
+(that file imports unsloth at module load, so it cannot be imported here). This
+file closes the remaining gap: it drives the **actual** ``transformers.Trainer``
+training loop through ``AuxHeadTrainer`` on a tiny real ``LlamaForCausalLM``,
+on CPU, with no unsloth — exercising the live ``compute_loss`` override,
+``create_optimizer`` (head-only param group), base freezing, and the
+save/reload/inference roundtrip end to end.
+
+transformers-5.5 removed the ``no_cuda`` TrainingArguments kwarg; CPU training is
+selected with ``use_cpu=True`` here.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "configs"))
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("safetensors.torch")
+
+from transformers import LlamaConfig, LlamaForCausalLM, TrainingArguments  # noqa: E402
+
+from aux_head import AuxHead, infer_aux_scalar, load_aux_head, save_aux_head  # noqa: E402
+from aux_head_trainer import AuxHeadTrainer  # noqa: E402
+from config_loader import AuxHeadConfig  # noqa: E402
+
+
+HIDDEN = 16
+N_LAYERS = 3
+VOCAB = 32
+SEQ = 6
+READ_LAYER = 2  # a mid hidden_states index (0 = embeddings, so 1..N_LAYERS are blocks)
+
+
+def _tiny_causal_lm() -> LlamaForCausalLM:
+    cfg = LlamaConfig(
+        vocab_size=VOCAB,
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=N_LAYERS,
+        num_attention_heads=2,
+        max_position_embeddings=SEQ + 2,
+    )
+    torch.manual_seed(0)
+    return LlamaForCausalLM(cfg)
+
+
+class _RowDataset(torch.utils.data.Dataset):
+    """A handful of right-padded rows carrying a per-row ``aux_target``."""
+
+    def __init__(self, n: int = 8):
+        torch.manual_seed(1)
+        self.rows = []
+        for i in range(n):
+            real = 3 + (i % 3)  # 3..5 real tokens, then right-pad to SEQ
+            ids = [int(torch.randint(1, VOCAB, (1,))) for _ in range(real)] + [0] * (SEQ - real)
+            mask = [1] * real + [0] * (SEQ - real)
+            self.rows.append(
+                {
+                    "input_ids": ids,
+                    "attention_mask": mask,
+                    "labels": ids,
+                    # Separable-ish soft target in [0, 1].
+                    "aux_target": 1.0 if i % 2 == 0 else 0.0,
+                }
+            )
+
+    def __len__(self):
+        return len(self.rows)
+
+    def __getitem__(self, idx):
+        return self.rows[idx]
+
+
+def _collate(features):
+    """Minimal collator: stack the pre-padded rows into tensors.
+
+    The production collator ``collate_prepared_sft_batch`` (which also pads) is
+    asserted separately at the source level; importing it here would pull unsloth.
+    The contract under test is the trainer, not the padding.
+    """
+    return {
+        "input_ids": torch.tensor([f["input_ids"] for f in features], dtype=torch.long),
+        "attention_mask": torch.tensor([f["attention_mask"] for f in features], dtype=torch.long),
+        "labels": torch.tensor([f["labels"] for f in features], dtype=torch.long),
+        "aux_target": torch.tensor([float(f["aux_target"]) for f in features], dtype=torch.float32),
+    }
+
+
+def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="last"):
+    model = _tiny_causal_lm()
+    head = AuxHead(input_dim=HIDDEN, head_type="linear")
+    cfg = AuxHeadConfig(
+        enabled=True,
+        layer=READ_LAYER,
+        token_position=token_position,
+        target_field="aux_target",
+        loss=loss,
+        head_type="linear",
+        freeze_base=freeze_base,
+        lm_loss_weight=0.0,
+    )
+    args = TrainingArguments(
+        output_dir=str(tmp_path / "out"),
+        use_cpu=True,  # transformers-5.5: replaces the removed no_cuda kwarg
+        remove_unused_columns=False,  # keep aux_target on the rows (mirrors train_sft)
+        per_device_train_batch_size=4,
+        max_steps=5,
+        learning_rate=0.1,
+        logging_steps=1,
+        save_strategy="no",
+        report_to="none",
+        seed=0,
+    )
+    trainer = AuxHeadTrainer(
+        model=model,
+        args=args,
+        data_collator=_collate,
+        train_dataset=_RowDataset(),
+        aux_head=head,
+        aux_head_config=cfg,
+    )
+    return trainer, model, head
+
+
+def test_construction_freezes_base_and_leaves_only_head_trainable(tmp_path):
+    trainer, model, head = _make_trainer(tmp_path)
+    base_trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    head_trainable = sum(p.numel() for p in head.parameters() if p.requires_grad)
+    assert base_trainable == 0  # Phase A: base fully frozen
+    assert head_trainable == (HIDDEN + 1)  # linear head: weight + bias
+
+
+def test_optimizer_covers_head_params_only(tmp_path):
+    trainer, model, head = _make_trainer(tmp_path)
+    optimizer = trainer.create_optimizer()
+    opt_param_count = sum(p.numel() for group in optimizer.param_groups for p in group["params"])
+    assert opt_param_count == sum(p.numel() for p in head.parameters())
+
+
+def test_real_trainer_train_runs_and_updates_only_the_head(tmp_path):
+    trainer, model, head = _make_trainer(tmp_path)
+    head_before = [p.detach().clone() for p in head.parameters()]
+    base_before = [p.detach().clone() for p in model.parameters()]
+
+    result = trainer.train()
+
+    assert result.training_loss is not None
+    assert result.training_loss == pytest.approx(result.training_loss)  # finite (not NaN)
+
+    # The head moved (it trained); the frozen base did not.
+    head_moved = any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))
+    base_moved = any(not torch.equal(b, a) for b, a in zip(base_before, model.parameters()))
+    assert head_moved
+    assert not base_moved
+
+
+def test_brier_loss_path_also_trains(tmp_path):
+    # The other proper-scoring loss must drive a real training step too.
+    trainer, model, head = _make_trainer(tmp_path, loss="brier")
+    head_before = [p.detach().clone() for p in head.parameters()]
+    trainer.train()
+    assert any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))
+
+
+def test_trained_head_saves_reloads_and_infers_in_unit_interval(tmp_path):
+    trainer, model, head = _make_trainer(tmp_path)
+    trainer.train()
+
+    sidecar = tmp_path / "sidecar"
+    save_aux_head(head, sidecar, layer=READ_LAYER, token_position="last", loss="bce")
+    reloaded = load_aux_head(sidecar, base_model=model)
+
+    input_ids = torch.randint(1, VOCAB, (3, SEQ))
+    attention_mask = torch.ones(3, SEQ, dtype=torch.long)
+    scores = infer_aux_scalar(
+        model, reloaded, input_ids=input_ids, attention_mask=attention_mask,
+        layer=READ_LAYER, token_position="last",
+    )
+    assert scores.shape == (3,)
+    assert torch.all(scores >= 0.0) and torch.all(scores <= 1.0)
+
+
+def test_missing_aux_target_in_batch_fails_loud(tmp_path):
+    # If the collator/plumbing ever drops aux_target, compute_loss must shout,
+    # never silently train on a default.
+    trainer, model, head = _make_trainer(tmp_path)
+    batch = _collate([_RowDataset()[0], _RowDataset()[1]])
+    batch.pop("aux_target")
+    with pytest.raises(ValueError, match="aux_target"):
+        trainer.compute_loss(model, batch)

--- a/tests/trainers/sft/test_aux_head_integration.py
+++ b/tests/trainers/sft/test_aux_head_integration.py
@@ -99,7 +99,7 @@ def _collate(features):
     }
 
 
-def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="last"):
+def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="last", remove_unused_columns=False):
     model = _tiny_causal_lm()
     head = AuxHead(input_dim=HIDDEN, head_type="linear")
     cfg = AuxHeadConfig(
@@ -115,7 +115,7 @@ def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="las
     args = TrainingArguments(
         output_dir=str(tmp_path / "out"),
         use_cpu=True,  # transformers-5.5: replaces the removed no_cuda kwarg
-        remove_unused_columns=False,  # keep aux_target on the rows (mirrors train_sft)
+        remove_unused_columns=remove_unused_columns,  # keep aux_target on the rows (mirrors train_sft)
         per_device_train_batch_size=4,
         max_steps=5,
         learning_rate=0.1,
@@ -201,3 +201,22 @@ def test_missing_aux_target_in_batch_fails_loud(tmp_path):
     batch.pop("aux_target")
     with pytest.raises(ValueError, match="aux_target"):
         trainer.compute_loss(model, batch)
+
+
+def test_construction_rejects_remove_unused_columns_true(tmp_path):
+    # The per-row aux_target column survives ONLY because remove_unused_columns is
+    # False. Flipping it must fail loud at construction (naming the coupling), not
+    # surface as an opaque "missing aux_target" error mid-training.
+    with pytest.raises(ValueError, match="remove_unused_columns"):
+        _make_trainer(tmp_path, remove_unused_columns=True)
+
+
+def test_train_refuses_resume_from_checkpoint(tmp_path):
+    # The head is sidecar-saved post-train and is NOT in HF per-step checkpoints,
+    # so resume would reinitialize it while reloading stale optimizer state.
+    # The guard must refuse loudly rather than train a corrupted head.
+    trainer, model, head = _make_trainer(tmp_path)
+    with pytest.raises(RuntimeError, match="resume_from_checkpoint"):
+        trainer.train(resume_from_checkpoint=str(tmp_path / "out" / "checkpoint-1"))
+    with pytest.raises(RuntimeError, match="resume_from_checkpoint"):
+        trainer.train(resume_from_checkpoint=True)

--- a/tests/trainers/sft/test_aux_head_preprocessing.py
+++ b/tests/trainers/sft/test_aux_head_preprocessing.py
@@ -1,0 +1,115 @@
+"""Tests for the aux_target preprocessing hop (R1 two-hop fix, part a).
+
+Location: tests/trainers/sft/test_aux_head_preprocessing.py
+
+The collator alone is insufficient: prepare_sft_dataset.map(remove_columns=...)
+drops the target column before the collator runs, so the per-row target must be
+READ inside _materialize. These tests verify the target survives, that a missing
+target fails loud, and that the feature-off path is byte-identical (no extra
+column).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
+
+preprocessing = pytest.importorskip("preprocessing")
+
+
+class _FakeTokenizer:
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        rendered = "\n".join(f"{message['role']}::{message['content']}" for message in messages)
+        if add_generation_prompt:
+            rendered += "\nassistant::"
+        return rendered
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(char) % 97 for char in text]
+
+
+def _row(target=None):
+    row = {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "there"},
+        ]
+    }
+    if target is not None:
+        row["score"] = target
+    return row
+
+
+def test_feature_off_is_byte_identical_no_extra_column():
+    dataset = Dataset.from_list([_row(0.7), _row(0.2)])
+    prepared = preprocessing.prepare_sft_dataset(
+        dataset,
+        tokenizer=_FakeTokenizer(),
+        max_seq_length=64,
+        loss_mask_mode="assistant_only",
+        # aux_target_field defaults to None ⇒ off
+    )
+    assert prepared.column_names == ["input_ids", "attention_mask", "labels"]
+
+
+def test_enabled_carries_target_through_remove_columns():
+    dataset = Dataset.from_list([_row(0.7), _row(0.2)])
+    prepared = preprocessing.prepare_sft_dataset(
+        dataset,
+        tokenizer=_FakeTokenizer(),
+        max_seq_length=64,
+        loss_mask_mode="assistant_only",
+        aux_target_field="score",
+    )
+    assert "aux_target" in prepared.column_names
+    assert prepared[0]["aux_target"] == pytest.approx(0.7)
+    assert prepared[1]["aux_target"] == pytest.approx(0.2)
+
+
+def test_missing_target_fails_loud():
+    dataset = Dataset.from_list([_row(0.7), _row(target=None)])
+    with pytest.raises(ValueError, match="missing it"):
+        preprocessing.prepare_sft_dataset(
+            dataset,
+            tokenizer=_FakeTokenizer(),
+            max_seq_length=64,
+            loss_mask_mode="assistant_only",
+            aux_target_field="score",
+        )
+
+
+def test_non_numeric_target_fails_loud():
+    dataset = Dataset.from_list([_row("not-a-number")])
+    with pytest.raises(ValueError, match="not numeric"):
+        preprocessing.prepare_sft_dataset(
+            dataset,
+            tokenizer=_FakeTokenizer(),
+            max_seq_length=64,
+            loss_mask_mode="assistant_only",
+            aux_target_field="score",
+        )
+
+
+def test_nan_target_fails_loud():
+    dataset = Dataset.from_list([_row(float("nan"))])
+    with pytest.raises(ValueError, match="not finite"):
+        preprocessing.prepare_sft_dataset(
+            dataset,
+            tokenizer=_FakeTokenizer(),
+            max_seq_length=64,
+            loss_mask_mode="assistant_only",
+            aux_target_field="score",
+        )
+
+
+def test_read_aux_target_helper_validates_directly():
+    assert preprocessing._read_aux_target({"score": 1}, "score") == pytest.approx(1.0)
+    with pytest.raises(ValueError):
+        preprocessing._read_aux_target({}, "score")

--- a/tests/trainers/sft/test_aux_head_trainer_source.py
+++ b/tests/trainers/sft/test_aux_head_trainer_source.py
@@ -54,10 +54,14 @@ def test_sidecar_save_runs_only_when_head_present():
     assert "save_aux_head(" in source
 
 
-def test_hidden_size_resolver_has_peft_fallback():
+def test_hidden_size_resolver_imported_from_aux_head():
+    # The resolver moved into the unsloth-free aux_head module so its fallback
+    # branches are unit-testable; train_sft.py now imports + calls it.
     source = _train_sft_source()
-    assert "def _resolve_hidden_size(model)" in source
-    assert "base_model" in source
+    assert "from src.aux_head import AuxHead, resolve_hidden_size" in source
+    assert "input_dim = resolve_hidden_size(model)" in source
+    # The inline definition is gone (logic lives in aux_head.py now).
+    assert "def _resolve_hidden_size(model)" not in source
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +80,8 @@ def test_aux_head_trainer_overrides_present():
     assert "compute_loss" in cls.__dict__
     assert "create_optimizer" in cls.__dict__
     assert "_freeze_base_keep_head" in cls.__dict__
+    # Resume guard (Phase A does not support resume_from_checkpoint).
+    assert "train" in cls.__dict__
 
 
 def test_aux_head_trainer_source_marks_phase_b_seam_and_no_lm_term():

--- a/tests/trainers/sft/test_aux_head_trainer_source.py
+++ b/tests/trainers/sft/test_aux_head_trainer_source.py
@@ -1,0 +1,87 @@
+"""Wire-in + trainer-override tests for the aux_head feature.
+
+Location: tests/trainers/sft/test_aux_head_trainer_source.py
+
+train_sft.py imports unsloth at module load, so its wiring is asserted at the
+source level (the repo's established pattern, cf. test_train_sft_source.py).
+AuxHeadTrainer itself is unsloth-free, so its overrides are asserted by import.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SFT_DIR = ROOT / "Trainers" / "sft"
+
+
+# ---------------------------------------------------------------------------
+# Source-level: train_sft.py wiring (byte-identical-off + two-hop + sidecar)
+# ---------------------------------------------------------------------------
+
+def _train_sft_source() -> str:
+    return (SFT_DIR / "train_sft.py").read_text(encoding="utf-8")
+
+
+def test_collator_stacks_aux_target_only_when_present():
+    source = _train_sft_source()
+    # Guarded so the feature-off batch is byte-identical.
+    assert 'if "aux_target" in features[0]:' in source
+    assert '"aux_target"' in source
+
+
+def test_dataset_call_threads_aux_target_field():
+    source = _train_sft_source()
+    assert "aux_target_field=aux_target_field" in source
+    # Only set when enabled ⇒ None on the off-path.
+    assert "aux_target_field = aux_head_cfg.target_field if aux_head_enabled else None" in source
+
+
+def test_trainer_swap_is_gated_on_enabled():
+    source = _train_sft_source()
+    assert "if aux_head_enabled:" in source
+    assert "AuxHeadTrainer(" in source
+    # Off-path still constructs the stock Trainer unchanged.
+    assert "trainer = Trainer(**trainer_kwargs)" in source
+
+
+def test_sidecar_save_runs_only_when_head_present():
+    source = _train_sft_source()
+    assert "if aux_head_module is not None:" in source
+    assert "save_aux_head(" in source
+
+
+def test_hidden_size_resolver_has_peft_fallback():
+    source = _train_sft_source()
+    assert "def _resolve_hidden_size(model)" in source
+    assert "base_model" in source
+
+
+# ---------------------------------------------------------------------------
+# Import-level: AuxHeadTrainer overrides (transformers, no unsloth)
+# ---------------------------------------------------------------------------
+
+def test_aux_head_trainer_overrides_present():
+    pytest.importorskip("transformers")
+    sys.path.insert(0, str(SFT_DIR / "src"))
+    import aux_head_trainer  # noqa: E402
+    from transformers import Trainer
+
+    cls = aux_head_trainer.AuxHeadTrainer
+    assert issubclass(cls, Trainer)
+    # Real overrides (defined on the subclass, not merely inherited).
+    assert "compute_loss" in cls.__dict__
+    assert "create_optimizer" in cls.__dict__
+    assert "_freeze_base_keep_head" in cls.__dict__
+
+
+def test_aux_head_trainer_source_marks_phase_b_seam_and_no_lm_term():
+    source = (SFT_DIR / "src" / "aux_head_trainer.py").read_text(encoding="utf-8")
+    # Phase A: head loss is the entire loss.
+    assert "loss = head_loss" in source
+    # Phase B seam left as a one-line comment, NOT enabled.
+    assert "lm_loss_weight" in source
+    assert "output_hidden_states=True" in source


### PR DESCRIPTION
## Summary

Adds an optional, config-driven **auxiliary scalar readout head** (`aux_head`) to the SFT trainer. A small head reads a configured hidden-layer activation at a configured token position and is supervised by a proper-scoring loss (`bce`|`brier`) against a per-row target in `[0,1]`, with the base model **frozen** (only the head trains, no LM loss term). This is **Phase A** (frozen base); Phase B (joint multi-task) is left a config flag away and is not implemented here.

Generic engine work — no domain/application vocabulary in code, configs, or test names.

## What's included

- **`AuxHead`** `nn.Module` (`linear`|`mlp`); `reduce_hidden_states` (`last`|`mean`|`int`); proper-scoring loss in fp32; sidecar save/load (`aux_head.safetensors` + `aux_head_config.json`) + inference hook.
- **`AuxHeadTrainer(Trainer)`**: freezes base, overrides `create_optimizer` to a head-only param group, `compute_loss = proper_score(head(reduced hidden_states[layer]), aux_target)`.
- **`AuxHeadConfig`** as a real dataclass field on `Config` (+ loader) — avoids `dict_to_dataclass` silently dropping unknown YAML keys.
- **Two-hop `aux_target` plumbing**: read in `_materialize` before `remove_columns`, stacked in the collator; loud-fail on missing/non-finite target. `remove_unused_columns=False` is the load-bearing setting that lets `aux_target` survive into the batch.
- Skill reference + abstract example config.

## Testing

- Full aux suite **39 passed** (33 component + 6 real `Trainer.train()` CPU integration tests; `use_cpu=True`, unsloth-free).
- **Local-lane validation**: productized `AuxHead` reproduces the offline probe ceiling on identical hidden-state vectors / leakage-free 5-fold OOF — `bce`=0.9851 (default loss, in the 0.98–0.997 bar). Oracle baseline reproduced at 0.9967.
- **Feature-off byte-identical**: with the `aux_head` block absent or `enabled=false`, the SFT path is unchanged.

## Scope notes

- Submodule PR only — the parent-repo submodule-pointer bump is a separate later commit, **not** part of this PR.
- Known non-blocking follow-up (tracked separately): add config-load validation rejecting `out_activation=identity` paired with a probability-domain loss (closes the `identity+brier` silent-MSE footgun; `identity+bce` already fails loud), plus a skill note on `brier`'s weaker near-saturation convergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)