### PR TITLE
feat(sft): aux_head Phase B — joint co-training over unfrozen base

### DIFF
--- a/.agents/skills/fine-tuning/reference/sft-training.md
+++ b/.agents/skills/fine-tuning/reference/sft-training.md
@@ -90,37 +90,62 @@ When `completion_only_loss: true` (default):
 
 ### Auxiliary Readout Head (`aux_head`, optional)
 An optional auxiliary scalar readout head that learns to predict a per-row
-target from a frozen base model's hidden state (Phase A: the base/LoRA is
-frozen and only the small head trains; the LM loss is not used). The feature is
-**off by default** — when the `aux_head` block is absent or `enabled: false`,
-the SFT path is byte-identical to a standard run.
+target from a base model's hidden state. It runs in two modes:
+
+- **Phase A** (`freeze_base: true`, `lm_loss_weight: 0`): the base/LoRA is frozen
+  and only the small head trains; the LM loss is not used.
+- **Phase B** (`freeze_base: false`, `lm_loss_weight > 0`): the base stays
+  unfrozen (the LoRA params PEFT left trainable are added to the optimizer as a
+  second group at the trainer LR) and the head co-trains jointly with the LM
+  loss — total loss is `lm_loss + lm_loss_weight * head_loss`.
+
+The feature is **off by default** — when the `aux_head` block is absent or
+`enabled: false`, the SFT path is byte-identical to a standard run. The Phase-A
+path (frozen base, no LM term, `input_norm: none`) is itself byte-identical
+whether or not the Phase-B code is present, because both branches gate on the
+config values.
 
 When enabled, every training row must carry a finite numeric target under the
 column named by `target_field`; a missing, null, non-numeric, or non-finite
 value fails loudly (there is no silent default). After training, the head is
 written next to the model as a sidecar (`aux_head.safetensors` +
 `aux_head_config.json`) so it can be reloaded for inference independently of the
-base weights.
+base weights. The sidecar persists `input_norm`, so a head trained with
+normalization reloads and infers identically.
 
 ```yaml
 aux_head:
   enabled: true            # absent / false => feature fully off
   layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
-  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  token_position: last     # "last" (last non-pad) | "mean" | int | "end_of_prompt"
   target_field: target     # per-row dataset column carrying the scalar target
   loss: bce                # "bce" | "brier" (MSE on probability)
   head_type: linear        # "linear" | "mlp"
   hidden_dims: []          # hidden widths when head_type: mlp
   out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
-  freeze_base: true        # Phase A = true
-  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  input_norm: none         # "none" (off; default) | "layernorm" (so the head trains at a normal LR)
+  freeze_base: true        # Phase A = true; Phase B = false (co-train the unfrozen base)
+  lm_loss_weight: 0.0      # Phase A = 0.0; Phase B > 0 (weight on the head loss in the joint sum)
   head_lr: null            # optional dedicated head LR; defaults to trainer LR
 ```
 
-A complete runnable example lives at
-`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
-the hidden-state index is a deliberate per-run decision, so an enabled block
-without it fails fast.
+Two Phase-B knobs:
+
+- **`token_position: end_of_prompt`** reads the last *prompt* token (the position
+  right before generation) instead of the last completion token. At train time
+  the prompt/completion boundary is recovered from the label mask (prompt tokens
+  are masked to `-100`); a row with no prompt span (completion-first or empty
+  completion) falls back to the last real token. At inference the input is
+  prompt-only, so `end_of_prompt` and `last` coincide.
+- **`input_norm: layernorm`** applies a `LayerNorm` to the pulled hidden state
+  before the head, so a linear head trains at a normal LR on unnormalized
+  activations instead of saturating.
+
+Complete runnable examples live at
+`Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
+`Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
+default — choosing the hidden-state index is a deliberate per-run decision, so an
+enabled block without it fails fast.
 
 ---
 
@@ -193,7 +218,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
-- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head, head-only over a frozen base (Phase A) or co-trained with the LM loss over an unfrozen base (Phase B); disabled by default
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/.claude/skills/fine-tuning/reference/sft-training.md
+++ b/.claude/skills/fine-tuning/reference/sft-training.md
@@ -90,37 +90,62 @@ When `completion_only_loss: true` (default):
 
 ### Auxiliary Readout Head (`aux_head`, optional)
 An optional auxiliary scalar readout head that learns to predict a per-row
-target from a frozen base model's hidden state (Phase A: the base/LoRA is
-frozen and only the small head trains; the LM loss is not used). The feature is
-**off by default** — when the `aux_head` block is absent or `enabled: false`,
-the SFT path is byte-identical to a standard run.
+target from a base model's hidden state. It runs in two modes:
+
+- **Phase A** (`freeze_base: true`, `lm_loss_weight: 0`): the base/LoRA is frozen
+  and only the small head trains; the LM loss is not used.
+- **Phase B** (`freeze_base: false`, `lm_loss_weight > 0`): the base stays
+  unfrozen (the LoRA params PEFT left trainable are added to the optimizer as a
+  second group at the trainer LR) and the head co-trains jointly with the LM
+  loss — total loss is `lm_loss + lm_loss_weight * head_loss`.
+
+The feature is **off by default** — when the `aux_head` block is absent or
+`enabled: false`, the SFT path is byte-identical to a standard run. The Phase-A
+path (frozen base, no LM term, `input_norm: none`) is itself byte-identical
+whether or not the Phase-B code is present, because both branches gate on the
+config values.
 
 When enabled, every training row must carry a finite numeric target under the
 column named by `target_field`; a missing, null, non-numeric, or non-finite
 value fails loudly (there is no silent default). After training, the head is
 written next to the model as a sidecar (`aux_head.safetensors` +
 `aux_head_config.json`) so it can be reloaded for inference independently of the
-base weights.
+base weights. The sidecar persists `input_norm`, so a head trained with
+normalization reloads and infers identically.
 
 ```yaml
 aux_head:
   enabled: true            # absent / false => feature fully off
   layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
-  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  token_position: last     # "last" (last non-pad) | "mean" | int | "end_of_prompt"
   target_field: target     # per-row dataset column carrying the scalar target
   loss: bce                # "bce" | "brier" (MSE on probability)
   head_type: linear        # "linear" | "mlp"
   hidden_dims: []          # hidden widths when head_type: mlp
   out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
-  freeze_base: true        # Phase A = true
-  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  input_norm: none         # "none" (off; default) | "layernorm" (so the head trains at a normal LR)
+  freeze_base: true        # Phase A = true; Phase B = false (co-train the unfrozen base)
+  lm_loss_weight: 0.0      # Phase A = 0.0; Phase B > 0 (weight on the head loss in the joint sum)
   head_lr: null            # optional dedicated head LR; defaults to trainer LR
 ```
 
-A complete runnable example lives at
-`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
-the hidden-state index is a deliberate per-run decision, so an enabled block
-without it fails fast.
+Two Phase-B knobs:
+
+- **`token_position: end_of_prompt`** reads the last *prompt* token (the position
+  right before generation) instead of the last completion token. At train time
+  the prompt/completion boundary is recovered from the label mask (prompt tokens
+  are masked to `-100`); a row with no prompt span (completion-first or empty
+  completion) falls back to the last real token. At inference the input is
+  prompt-only, so `end_of_prompt` and `last` coincide.
+- **`input_norm: layernorm`** applies a `LayerNorm` to the pulled hidden state
+  before the head, so a linear head trains at a normal LR on unnormalized
+  activations instead of saturating.
+
+Complete runnable examples live at
+`Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
+`Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
+default — choosing the hidden-state index is a deliberate per-run decision, so an
+enabled block without it fails fast.
 
 ---
 
@@ -193,7 +218,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
-- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head, head-only over a frozen base (Phase A) or co-trained with the LM loss over an unfrozen base (Phase B); disabled by default
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/.skills/fine-tuning/reference/sft-training.md
+++ b/.skills/fine-tuning/reference/sft-training.md
@@ -90,37 +90,62 @@ When `completion_only_loss: true` (default):
 
 ### Auxiliary Readout Head (`aux_head`, optional)
 An optional auxiliary scalar readout head that learns to predict a per-row
-target from a frozen base model's hidden state (Phase A: the base/LoRA is
-frozen and only the small head trains; the LM loss is not used). The feature is
-**off by default** — when the `aux_head` block is absent or `enabled: false`,
-the SFT path is byte-identical to a standard run.
+target from a base model's hidden state. It runs in two modes:
+
+- **Phase A** (`freeze_base: true`, `lm_loss_weight: 0`): the base/LoRA is frozen
+  and only the small head trains; the LM loss is not used.
+- **Phase B** (`freeze_base: false`, `lm_loss_weight > 0`): the base stays
+  unfrozen (the LoRA params PEFT left trainable are added to the optimizer as a
+  second group at the trainer LR) and the head co-trains jointly with the LM
+  loss — total loss is `lm_loss + lm_loss_weight * head_loss`.
+
+The feature is **off by default** — when the `aux_head` block is absent or
+`enabled: false`, the SFT path is byte-identical to a standard run. The Phase-A
+path (frozen base, no LM term, `input_norm: none`) is itself byte-identical
+whether or not the Phase-B code is present, because both branches gate on the
+config values.
 
 When enabled, every training row must carry a finite numeric target under the
 column named by `target_field`; a missing, null, non-numeric, or non-finite
 value fails loudly (there is no silent default). After training, the head is
 written next to the model as a sidecar (`aux_head.safetensors` +
 `aux_head_config.json`) so it can be reloaded for inference independently of the
-base weights.
+base weights. The sidecar persists `input_norm`, so a head trained with
+normalization reloads and infers identically.
 
 ```yaml
 aux_head:
   enabled: true            # absent / false => feature fully off
   layer: 35                # required when enabled: which hidden_states index to read (0 = embeddings)
-  token_position: last     # "last" (last non-pad) | "mean" | integer index
+  token_position: last     # "last" (last non-pad) | "mean" | int | "end_of_prompt"
   target_field: target     # per-row dataset column carrying the scalar target
   loss: bce                # "bce" | "brier" (MSE on probability)
   head_type: linear        # "linear" | "mlp"
   hidden_dims: []          # hidden widths when head_type: mlp
   out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity"
-  freeze_base: true        # Phase A = true
-  lm_loss_weight: 0.0      # Phase A = 0.0 (no LM term)
+  input_norm: none         # "none" (off; default) | "layernorm" (so the head trains at a normal LR)
+  freeze_base: true        # Phase A = true; Phase B = false (co-train the unfrozen base)
+  lm_loss_weight: 0.0      # Phase A = 0.0; Phase B > 0 (weight on the head loss in the joint sum)
   head_lr: null            # optional dedicated head LR; defaults to trainer LR
 ```
 
-A complete runnable example lives at
-`Trainers/sft/configs/aux_head_example.yaml`. `layer` has no default — choosing
-the hidden-state index is a deliberate per-run decision, so an enabled block
-without it fails fast.
+Two Phase-B knobs:
+
+- **`token_position: end_of_prompt`** reads the last *prompt* token (the position
+  right before generation) instead of the last completion token. At train time
+  the prompt/completion boundary is recovered from the label mask (prompt tokens
+  are masked to `-100`); a row with no prompt span (completion-first or empty
+  completion) falls back to the last real token. At inference the input is
+  prompt-only, so `end_of_prompt` and `last` coincide.
+- **`input_norm: layernorm`** applies a `LayerNorm` to the pulled hidden state
+  before the head, so a linear head trains at a normal LR on unnormalized
+  activations instead of saturating.
+
+Complete runnable examples live at
+`Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
+`Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
+default — choosing the hidden-state index is a deliberate per-run decision, so an
+enabled block without it fails fast.
 
 ---
 
@@ -193,7 +218,7 @@ Key sections:
 - `training` — batch size, LR, epochs, packing, etc.
 - `dataset` — source, filtering, split
 - `evolutionary` — experimental gradient evolution (disabled by default)
-- `aux_head` — optional auxiliary scalar readout head over a frozen base (disabled by default)
+- `aux_head` — optional auxiliary scalar readout head, head-only over a frozen base (Phase A) or co-trained with the LM loss over an unfrozen base (Phase B); disabled by default
 
 For cloud runs, evolutionary SFT is now expressible through `run-experiment` specs or `cloud-pipeline --train-evolutionary-*` overrides. Keep the first run short and capped by `max_steps`; the wrapper adds real per-step overhead.
 

--- a/Trainers/sft/configs/aux_head_phase_b_example.yaml
+++ b/Trainers/sft/configs/aux_head_phase_b_example.yaml
@@ -1,0 +1,105 @@
+# ============================================================================
+# Example SFT config with an auxiliary scalar readout head (aux_head), Phase B.
+#
+# Phase B co-trains the head JOINTLY with the language-model loss over an
+# UNFROZEN base: the total loss is `outputs.loss + lm_loss_weight * head_loss`,
+# the base's trainable (LoRA) params stay trainable and are added to the
+# optimizer alongside the head, and the head reads the end-of-prompt token with
+# optional input normalization so it trains at a normal LR.
+#
+# The difference from the Phase-A example is the aux_head block (freeze_base,
+# lm_loss_weight, token_position, input_norm) plus a lower base learning rate.
+# With `aux_head` absent or enabled=false, training is byte-identical to a
+# normal SFT run; with freeze_base=true + lm_loss_weight=0 + input_norm=none it
+# is byte-identical to the Phase-A path.
+#
+# The base model, dataset, and target column below are placeholders — point them
+# at your own. The dataset must carry a per-row float in [0,1] (or a 0/1 label)
+# under `aux_head.target_field`; producing that column is the dataset's job.
+# ============================================================================
+
+model:
+  model_name: "unsloth/Qwen3-4B"
+  max_seq_length: 2048
+  dtype: null
+  load_in_4bit: false
+
+lora:
+  r: 64
+  lora_alpha: 128
+  lora_dropout: 0
+  bias: "none"
+  target_modules:
+    - "q_proj"
+    - "k_proj"
+    - "v_proj"
+    - "o_proj"
+  use_gradient_checkpointing: "unsloth"   # the single GC knob for this unsloth base
+  random_state: 3407
+  use_rslora: false
+  use_dora: false
+
+training:
+  output_dir: "./aux_head_phase_b_output"
+  per_device_train_batch_size: 8
+  gradient_accumulation_steps: 4
+  learning_rate: 1e-4            # base co-training LR (lower than Phase-A head-only)
+  max_grad_norm: 1.0
+  lr_scheduler_type: "linear"
+  max_seq_length: 2048
+  packing: false
+  completion_only_loss: true
+  assistant_only_loss: false
+  # The base co-trains in Phase B, so gradient checkpointing now pays off. Use
+  # exactly ONE GC mechanism: the unsloth base is already wrapped by
+  # lora.use_gradient_checkpointing="unsloth" above, so leave HF's own
+  # gradient_checkpointing off to avoid double-wrapping the same modules.
+  gradient_checkpointing: false
+  optim: "adamw_8bit"
+  fp16: false
+  bf16: true
+  num_train_epochs: 1
+  warmup_ratio: 0.02
+  logging_steps: 5
+  save_steps: 50
+  save_total_limit: 3
+  dataloader_num_workers: 0
+  dataloader_pin_memory: true
+  group_by_length: false
+  eval_strategy: "no"
+  eval_steps: 50
+
+dataset:
+  dataset_name: null
+  dataset_file: null
+  # Point this at a local JSONL whose rows carry the target column below.
+  local_file: "../../Datasets/your_dataset_with_target.jsonl"
+  num_proc: 1
+  test_size: 0.1
+  split_dataset: false
+  filter_desirable: false
+
+wandb:
+  enabled: false
+  project: null
+  run_name: null
+  entity: null
+
+seed: 42
+
+# ============================================================================
+# Auxiliary scalar readout head (Phase B: unfrozen base, joint LM + head loss).
+# ============================================================================
+aux_head:
+  enabled: true            # absent/false ⇒ feature fully off (backward compatible)
+  layer: 35                # which hidden_states index to read (0 = embeddings); required when enabled
+  token_position: end_of_prompt  # "last" | "mean" | int | "end_of_prompt" (last prompt token)
+  target_field: target     # per-row dataset column carrying the target float/label
+  loss: bce                # "bce" (binary/soft in [0,1]) | "brier" (MSE on prob)
+  head_type: linear        # "linear" | "mlp"
+  hidden_dims: []          # widths for the "mlp" head; ignored for "linear"
+  out_activation: sigmoid  # "sigmoid" (prob in [0,1]) | "identity" (raw logit)
+  input_norm: layernorm    # "none" (off) | "layernorm" (so the head trains at a normal LR)
+  freeze_base: false       # Phase B = false (co-train the unfrozen base)
+  lm_loss_weight: 1.0      # Phase B > 0: total loss = lm_loss + lm_loss_weight * head_loss
+  head_lr: null            # optional dedicated head LR; defaults to trainer LR if null

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -304,17 +304,54 @@ def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
             "(no silent default — choose the hidden_states index to read)."
         )
 
+    freeze_base = aux_data.get('freeze_base', True)
+    lm_loss_weight = aux_data.get('lm_loss_weight', 0.0)
+    loss = aux_data.get('loss', 'bce')
+    out_activation = aux_data.get('out_activation', 'sigmoid')
+
+    # Coherence guard: freeze_base and lm_loss_weight must describe the SAME phase.
+    # Valid: (freeze_base=true, lm_loss_weight=0) trains the head alone over a
+    # frozen base, or (freeze_base=false, lm_loss_weight>0) co-trains the base
+    # jointly with a weighted LM term. The (false, 0) corner co-trains the base on
+    # the head loss alone with no LM term anchoring it — the base drifts freely.
+    # The (true, >0) corner adds an LM term that receives no gradient (the base is
+    # frozen) — wasted compute and a misleading loss curve. Reject both loudly
+    # rather than launch a silently incoherent run.
+    phase_coherent = (freeze_base and lm_loss_weight == 0) or (
+        not freeze_base and lm_loss_weight > 0
+    )
+    if enabled and not phase_coherent:
+        raise ValueError(
+            "aux_head.freeze_base and aux_head.lm_loss_weight must agree on the "
+            "phase: use (freeze_base=true, lm_loss_weight=0) or "
+            "(freeze_base=false, lm_loss_weight>0). Got "
+            f"freeze_base={freeze_base}, lm_loss_weight={lm_loss_weight} — an "
+            "incoherent combination that would train a misconfigured run."
+        )
+
+    # Coherence guard: an "identity" out_activation returns the raw value, not a
+    # probability in [0, 1], so pairing it with a probability-scoring loss
+    # (bce/brier, which expect a probability) silently mis-scores — bce on
+    # out-of-range inputs, or brier as MSE-on-logits (a non-proper score). Require
+    # a sigmoid output for these losses.
+    if enabled and out_activation == 'identity' and loss in ('bce', 'brier'):
+        raise ValueError(
+            "aux_head.out_activation='identity' is incompatible with "
+            f"aux_head.loss={loss!r}: bce and brier expect a probability in "
+            "[0, 1]. Use out_activation='sigmoid' for these losses."
+        )
+
     return AuxHeadConfig(
         enabled=enabled,
         layer=layer,
         token_position=aux_data.get('token_position', 'last'),
         target_field=aux_data.get('target_field', 'target'),
-        loss=aux_data.get('loss', 'bce'),
+        loss=loss,
         head_type=aux_data.get('head_type', 'linear'),
         hidden_dims=list(aux_data.get('hidden_dims', []) or []),
-        out_activation=aux_data.get('out_activation', 'sigmoid'),
-        freeze_base=aux_data.get('freeze_base', True),
-        lm_loss_weight=aux_data.get('lm_loss_weight', 0.0),
+        out_activation=out_activation,
+        freeze_base=freeze_base,
+        lm_loss_weight=lm_loss_weight,
         head_lr=aux_data.get('head_lr', None),
         input_norm=aux_data.get('input_norm', 'none'),
     )

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -166,6 +166,7 @@ class AuxHeadConfig:
     freeze_base: bool = True             # Phase A = true (Phase B flips this)
     lm_loss_weight: float = 0.0          # Phase A = 0.0 (no LM term; Phase B > 0)
     head_lr: Optional[float] = None      # optional; defaults to trainer LR if None
+    input_norm: str = "none"             # "none" (default; off) | "layernorm"
 
 
 @dataclass
@@ -315,6 +316,7 @@ def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
         freeze_base=aux_data.get('freeze_base', True),
         lm_loss_weight=aux_data.get('lm_loss_weight', 0.0),
         head_lr=aux_data.get('head_lr', None),
+        input_norm=aux_data.get('input_norm', 'none'),
     )
 
 

--- a/Trainers/sft/src/aux_head.py
+++ b/Trainers/sft/src/aux_head.py
@@ -41,6 +41,7 @@ from torch import nn
 VALID_HEAD_TYPES = ("linear", "mlp")
 VALID_LOSSES = ("bce", "brier")
 VALID_OUT_ACTIVATIONS = ("sigmoid", "identity")
+VALID_INPUT_NORMS = ("none", "layernorm")
 
 
 class AuxHead(nn.Module):
@@ -54,11 +55,16 @@ class AuxHead(nn.Module):
         hidden_dims: Hidden widths for the ``mlp`` head. Ignored for ``linear``.
         out_activation: ``"sigmoid"`` (default) squashes the logit into ``[0, 1]``;
             ``"identity"`` returns the raw logit (callers that want logits).
+        input_norm: ``"none"`` (default; off — Phase-A byte-identical, adds no
+            submodule/params) or ``"layernorm"`` (a ``nn.LayerNorm(input_dim)``
+            applied to the pulled hidden state before the net, so the head trains
+            at a normal LR on unnormalized activations instead of saturating).
 
     forward(hidden) -> Tensor:
         ``hidden`` has shape ``[batch, input_dim]`` (already reduced over the
         sequence). The pulled hidden state is cast to the head's parameter dtype
-        first, so a bf16/fp16 base can feed an fp32 head safely. Returns a
+        first (so a bf16/fp16 base can feed an fp32 head safely), then optionally
+        normalized (``input_norm="layernorm"``), then projected. Returns a
         ``[batch]`` tensor; with ``out_activation="sigmoid"`` every element lies
         in ``[0, 1]``.
     """
@@ -69,6 +75,7 @@ class AuxHead(nn.Module):
         head_type: str = "linear",
         hidden_dims: Sequence[int] = (),
         out_activation: str = "sigmoid",
+        input_norm: str = "none",
     ) -> None:
         super().__init__()
         if input_dim <= 0:
@@ -79,11 +86,21 @@ class AuxHead(nn.Module):
             raise ValueError(
                 f"Unknown out_activation {out_activation!r}; expected one of {VALID_OUT_ACTIVATIONS}."
             )
+        if input_norm not in VALID_INPUT_NORMS:
+            raise ValueError(
+                f"Unknown input_norm {input_norm!r}; expected one of {VALID_INPUT_NORMS}."
+            )
 
         self.input_dim = int(input_dim)
         self.head_type = head_type
         self.hidden_dims = tuple(int(d) for d in hidden_dims)
         self.out_activation = out_activation
+        self.input_norm = input_norm
+
+        # ``"none"`` adds NO submodule, so the state_dict (and thus the Phase-A
+        # save/reload round-trip) is byte-identical to before this knob existed.
+        if input_norm == "layernorm":
+            self.norm: nn.Module = nn.LayerNorm(self.input_dim)
 
         if head_type == "linear":
             self.net: nn.Module = nn.Linear(self.input_dim, 1)
@@ -105,6 +122,9 @@ class AuxHead(nn.Module):
     def forward(self, hidden: torch.Tensor) -> torch.Tensor:
         # Cast the pulled hidden state to the head's dtype (bf16 base -> fp32 head).
         hidden = hidden.to(self.dtype)
+        # Optional input normalization (off by default; Phase-A byte-identical).
+        if self.input_norm == "layernorm":
+            hidden = self.norm(hidden)
         logits = self.net(hidden).squeeze(-1)  # [batch, 1] -> [batch]
         if self.out_activation == "sigmoid":
             return torch.sigmoid(logits)
@@ -134,10 +154,45 @@ def resolve_hidden_size(model: Any) -> int:
     return int(hidden_size)
 
 
+def prompt_end_indices(labels: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+    """Per-row index of the last prompt token (the position right before generation).
+
+    The SFT preprocessing masks prompt tokens to ``-100`` and leaves completion
+    tokens with real ids, so the first un-masked label marks where generation
+    starts; the token just before it is the end of the prompt.
+
+    Two rows have no preceding prompt span and resolve to the last *real* token
+    (``attention_mask.sum(1) - 1``) — i.e. ``"last"``-equivalent — rather than a
+    spurious index 0:
+
+    - **Empty completion** (every label ``-100``): the whole row is prompt, so the
+      last real token IS the end of the prompt.
+    - **Completion-first** (the first real token is a completion token): there is
+      no prompt to end, so the boundary is taken as the last real token.
+
+    Both are detected by ``first_completion == 0`` (``argmax`` returns 0 for an
+    all-masked row too), so a single guard covers them.
+
+    Args:
+        labels: ``[batch, seq]`` token labels (-100 = masked/prompt).
+        attention_mask: ``[batch, seq]`` 1/0 mask (1 = real token, right-padded).
+
+    Returns:
+        ``[batch]`` long tensor of end-of-prompt indices.
+    """
+    real = labels != -100
+    first_completion = real.int().argmax(dim=1)  # 0 for all-masked rows
+    last_real = (attention_mask.to(labels.device).long().sum(dim=1) - 1).clamp_min(0)
+    boundary = first_completion - 1
+    no_prompt = first_completion == 0  # completion-first OR empty-completion
+    return torch.where(no_prompt, last_real, boundary)
+
+
 def reduce_hidden_states(
     hidden: torch.Tensor,
     attention_mask: torch.Tensor,
     token_position: Union[str, int] = "last",
+    prompt_end_idx: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Reduce a ``[batch, seq, hidden]`` tensor to ``[batch, hidden]``.
 
@@ -148,7 +203,13 @@ def reduce_hidden_states(
         hidden: ``[batch, seq, hidden]`` hidden states for one layer.
         attention_mask: ``[batch, seq]`` 1/0 mask (1 = real token, right-padded).
         token_position: ``"last"`` (last non-pad token), ``"mean"`` (mask-weighted
-            mean over real tokens), or an int index into the sequence.
+            mean over real tokens), ``"end_of_prompt"`` (the last prompt token,
+            via ``prompt_end_idx``), or an int index into the sequence.
+        prompt_end_idx: ``[batch]`` per-row end-of-prompt indices (from
+            :func:`prompt_end_indices`). Required only for ``"end_of_prompt"`` at
+            train time; when ``None`` (e.g. prompt-only inference) ``"end_of_prompt"``
+            falls back to ``"last"`` — for a prompt-only input the last real token
+            IS the end of the prompt, so the two reductions coincide.
 
     Returns:
         ``[batch, hidden]``.
@@ -159,7 +220,12 @@ def reduce_hidden_states(
     batch_size = hidden.size(0)
     arange = torch.arange(batch_size, device=hidden.device)
 
-    if token_position == "last":
+    if token_position == "end_of_prompt" and prompt_end_idx is not None:
+        idx = prompt_end_idx.to(hidden.device).long().clamp_min(0)
+        return hidden[arange, idx]
+
+    if token_position == "last" or token_position == "end_of_prompt":
+        # "end_of_prompt" with no prompt_end_idx (inference) reduces as "last".
         lengths = attention_mask.to(hidden.device).long().sum(dim=1)
         last_idx = (lengths - 1).clamp_min(0)  # all-zero mask is impossible, but cheap insurance
         return hidden[arange, last_idx]
@@ -234,6 +300,7 @@ def save_aux_head(
         "head_type": aux_head.head_type,
         "hidden_dims": list(aux_head.hidden_dims),
         "out_activation": aux_head.out_activation,
+        "input_norm": aux_head.input_norm,
         "layer": layer,
         "token_position": token_position,
         "loss": loss,
@@ -267,6 +334,7 @@ def load_aux_head(run_dir: Union[str, Path], base_model: Optional[Any] = None) -
         head_type=resolved.get("head_type", "linear"),
         hidden_dims=tuple(resolved.get("hidden_dims", []) or []),
         out_activation=resolved.get("out_activation", "sigmoid"),
+        input_norm=resolved.get("input_norm", "none"),  # old sidecars default to off
     )
     head.load_state_dict(load_file(str(weights_path)))
 

--- a/Trainers/sft/src/aux_head_trainer.py
+++ b/Trainers/sft/src/aux_head_trainer.py
@@ -20,11 +20,13 @@ the stock trainer. After ``train()`` the caller saves the head via
 
 Phase A vs Phase B
 ------------------
-Phase A loss IS the head loss alone (no LM term). The base + LoRA are frozen and
-the optimizer is built over the head's parameters only. The single Phase-B seam
-(``loss = outputs.loss + lm_loss_weight * head_loss``) is marked with a one-line
-comment in ``compute_loss``; flipping ``freeze_base``/``lm_loss_weight`` is the
-only change Phase B needs here.
+Phase A (``freeze_base=true``, ``lm_loss_weight=0``): the base + LoRA are frozen,
+the optimizer is built over the head's parameters only, and the loss IS the head
+loss alone. Phase B (``freeze_base=false``, ``lm_loss_weight>0``): the base stays
+unfrozen (PEFT's LoRA params remain trainable), the optimizer adds those params
+as a second group, and the loss is ``outputs.loss + lm_loss_weight * head_loss``,
+co-training the base with the head. The Phase-A path is byte-identical regardless
+of the Phase-B code being present (both branches gate on the config values).
 """
 
 from __future__ import annotations
@@ -34,7 +36,12 @@ from typing import Any, Optional
 import torch
 from transformers import Trainer
 
-from aux_head import AuxHead, compute_aux_head_loss, reduce_hidden_states
+from aux_head import (
+    AuxHead,
+    compute_aux_head_loss,
+    prompt_end_indices,
+    reduce_hidden_states,
+)
 
 
 class AuxHeadTrainer(Trainer):
@@ -75,6 +82,8 @@ class AuxHeadTrainer(Trainer):
 
         if getattr(aux_head_config, "freeze_base", True):
             self._freeze_base_keep_head()
+        else:
+            self._prepare_unfrozen_base_keep_head()
 
         self._log_trainable_param_accounting()
 
@@ -115,6 +124,28 @@ class AuxHeadTrainer(Trainer):
         for param in self.aux_head.parameters():
             param.requires_grad = True
 
+    def _prepare_unfrozen_base_keep_head(self) -> None:
+        """Phase B: co-train the unfrozen base alongside the head.
+
+        Leave the base/adapter ``requires_grad`` exactly as PEFT set them (the
+        LoRA params stay trainable) — do NOT freeze. Only ensure the head's params
+        are trainable. ``create_optimizer`` then registers both the head group and
+        the base's trainable (LoRA) params.
+
+        Defensive belt for the gradient-checkpointing path: ``output_hidden_states``
+        + checkpointing + LoRA can detach the recomputed hidden state the head
+        reads. ``enable_input_require_grads`` registers a forward hook that keeps
+        the input-embedding output requiring grad, so the autograd graph reaches
+        the adapter through the recompute boundary. It is a no-op under vanilla
+        ``torch`` checkpointing and harmless otherwise; ``use_cache`` is left to
+        the framework.
+        """
+        for param in self.aux_head.parameters():
+            param.requires_grad = True
+        enable_input_require_grads = getattr(self.model, "enable_input_require_grads", None)
+        if callable(enable_input_require_grads):
+            enable_input_require_grads()
+
     def _log_trainable_param_accounting(self) -> None:
         """Log trainable-param counts (mirror model_loader accounting) for audit."""
         base_trainable = sum(p.numel() for p in self.model.parameters() if p.requires_grad)
@@ -136,8 +167,9 @@ class AuxHeadTrainer(Trainer):
         The head is not a submodule of ``self.model``, so stock
         ``create_optimizer`` (which walks ``model.parameters()``) would never see
         it. We override to register the head's params explicitly, optionally on a
-        dedicated ``head_lr`` learning rate. Phase B (``freeze_base=false``) would
-        additionally add the unfrozen LoRA params here.
+        dedicated ``head_lr`` learning rate. Phase B (``freeze_base=false``)
+        additionally adds the base's trainable (LoRA) params as a second group at
+        the trainer learning rate.
         """
         if self.optimizer is not None:
             return self.optimizer
@@ -145,10 +177,21 @@ class AuxHeadTrainer(Trainer):
         optimizer_cls, optimizer_kwargs = Trainer.get_optimizer_cls_and_kwargs(self.args)
         head_lr = getattr(self.aux_head_config, "head_lr", None)
         head_params = [p for p in self.aux_head.parameters() if p.requires_grad]
-        param_group = {"params": head_params}
+        head_group = {"params": head_params}
         if head_lr is not None:
-            param_group["lr"] = head_lr
-        self.optimizer = optimizer_cls([param_group], **optimizer_kwargs)
+            head_group["lr"] = head_lr
+        param_groups = [head_group]
+
+        # Phase B: also optimize the unfrozen base (the LoRA params PEFT left
+        # trainable). No explicit lr ⇒ this group inherits the optimizer default
+        # (the trainer learning_rate carried in optimizer_kwargs). The head group
+        # keeps its optional head_lr override.
+        if not getattr(self.aux_head_config, "freeze_base", True):
+            base_params = [p for p in self.model.parameters() if p.requires_grad]
+            if base_params:
+                param_groups.append({"params": base_params})
+
+        self.optimizer = optimizer_cls(param_groups, **optimizer_kwargs)
         return self.optimizer
 
     def compute_loss(
@@ -158,7 +201,12 @@ class AuxHeadTrainer(Trainer):
         return_outputs: bool = False,
         num_items_in_batch: Optional[int] = None,
     ):
-        """Phase A: loss = proper_score(head(reduced hidden state), aux_target)."""
+        """Head loss, optionally combined with the LM loss (Phase B).
+
+        Phase A (``lm_loss_weight == 0``): ``loss = proper_score(head, aux_target)``
+        alone. Phase B (``lm_loss_weight > 0``): ``loss = outputs.loss +
+        lm_loss_weight * head_loss``, co-training the unfrozen base with the head.
+        """
         cfg = self.aux_head_config
 
         # The collator stacks the per-row target under "aux_target"; pop it so it
@@ -171,19 +219,40 @@ class AuxHeadTrainer(Trainer):
                 "plumbing carried the per-row target through."
             )
 
-        # Enable hidden states HERE (no global flag); base is frozen so this
-        # forward accrues gradient only through the head below.
+        # For "end_of_prompt", recover the per-row prompt/completion boundary from
+        # the labels (prompt tokens are masked to -100). Computed HERE because the
+        # batch still carries "labels"; passed into the reduction below.
+        prompt_end_idx = None
+        if cfg.token_position == "end_of_prompt":
+            labels = inputs.get("labels")
+            if labels is None:
+                raise ValueError(
+                    "token_position='end_of_prompt' requires 'labels' in the batch to "
+                    "locate the prompt/completion boundary; none were present."
+                )
+            prompt_end_idx = prompt_end_indices(labels, inputs["attention_mask"])
+
+        # Enable hidden states HERE (no global flag). In Phase A the base is frozen
+        # so this forward accrues gradient only through the head; in Phase B the
+        # unfrozen base co-trains through both the head loss and the LM loss.
         outputs = model(**inputs, output_hidden_states=True)
 
         hidden = outputs.hidden_states[cfg.layer]
-        reduced = reduce_hidden_states(hidden, inputs["attention_mask"], cfg.token_position)
+        reduced = reduce_hidden_states(
+            hidden, inputs["attention_mask"], cfg.token_position, prompt_end_idx=prompt_end_idx
+        )
         pred = self.aux_head(reduced)
 
         target = aux_target.to(pred.device)
         head_loss = compute_aux_head_loss(pred, target, cfg.loss)
 
-        # Phase A: the head loss is the ENTIRE loss (no LM term).
-        # Phase B seam (do NOT enable here): loss = outputs.loss + cfg.lm_loss_weight * head_loss
-        loss = head_loss
+        # Phase A (lm_loss_weight == 0): the head loss is the ENTIRE loss, leaving
+        # the off-path byte-identical. Phase B (> 0): add the weighted LM loss
+        # (already computed because "labels" stayed in the forward).
+        lm_loss_weight = getattr(cfg, "lm_loss_weight", 0.0)
+        if lm_loss_weight > 0:
+            loss = outputs.loss + lm_loss_weight * head_loss
+        else:
+            loss = head_loss
 
         return (loss, outputs) if return_outputs else loss

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -1021,6 +1021,7 @@ def run(args: argparse.Namespace):
             head_type=aux_head_cfg.head_type,
             hidden_dims=aux_head_cfg.hidden_dims,
             out_activation=aux_head_cfg.out_activation,
+            input_norm=getattr(aux_head_cfg, "input_norm", "none"),
         )
         print(
             f"[aux_head] enabled: layer={aux_head_cfg.layer}, token_position={aux_head_cfg.token_position}, "

--- a/tests/trainers/sft/test_aux_head.py
+++ b/tests/trainers/sft/test_aux_head.py
@@ -27,6 +27,7 @@ from aux_head import (  # noqa: E402
     compute_aux_head_loss,
     infer_aux_scalar,
     load_aux_head,
+    prompt_end_indices,
     reduce_hidden_states,
     resolve_hidden_size,
     save_aux_head,
@@ -76,6 +77,32 @@ def test_invalid_head_type_and_activation_raise():
         AuxHead(input_dim=0)
 
 
+def test_input_norm_defaults_to_none_and_adds_no_submodule():
+    # Default "none" must add NO norm submodule, so the state_dict (and thus the
+    # save/reload round-trip) stays byte-identical to a head without the knob.
+    head = AuxHead(input_dim=8, head_type="linear")
+    assert head.input_norm == "none"
+    assert not hasattr(head, "norm")
+    assert not any(k.startswith("norm.") for k in head.state_dict())
+
+
+def test_input_norm_layernorm_adds_norm_and_tames_large_inputs():
+    head = AuxHead(input_dim=8, head_type="linear", input_norm="layernorm")
+    assert isinstance(head.norm, torch.nn.LayerNorm)
+    assert any(k.startswith("norm.") for k in head.state_dict())
+    # On large-magnitude inputs the LayerNorm keeps the pre-sigmoid logit finite
+    # and the output a real probability (the raw-input head would saturate).
+    out = head(torch.randn(6, 8) * 1000.0)
+    assert out.shape == (6,)
+    assert torch.all(out >= 0.0) and torch.all(out <= 1.0)
+    assert torch.all(torch.isfinite(out))
+
+
+def test_input_norm_rejects_unknown_value():
+    with pytest.raises(ValueError):
+        AuxHead(input_dim=8, input_norm="batchnorm")
+
+
 # ---------------------------------------------------------------------------
 # reduce_hidden_states: last / mean / int, right-pad aware
 # ---------------------------------------------------------------------------
@@ -114,6 +141,58 @@ def test_reduce_rejects_bad_inputs():
         reduce_hidden_states(torch.randn(1, 4, 2), torch.ones(1, 4), "median")
     with pytest.raises(ValueError):
         reduce_hidden_states(torch.randn(1, 4, 2), torch.ones(1, 4), 99)
+
+
+# ---------------------------------------------------------------------------
+# end_of_prompt: boundary derivation + reduction (training + inference)
+# ---------------------------------------------------------------------------
+
+def test_prompt_end_indices_finds_boundary_and_handles_edges():
+    # Row 0: prompt = tokens 0..1, completion starts at 2 -> boundary = 1.
+    # Row 1: completion-first (no prompt) -> last real token (index 2).
+    # Row 2: empty completion (all masked) -> last real token (index 1).
+    labels = torch.tensor([
+        [-100, -100, 5, 6],   # boundary at 1
+        [7, 8, 9, -100],      # completion-first -> last real (idx 2)
+        [-100, -100, -100, -100],  # empty completion -> last real (idx 1)
+    ])
+    attention_mask = torch.tensor([
+        [1, 1, 1, 1],
+        [1, 1, 1, 0],
+        [1, 1, 0, 0],
+    ])
+    idx = prompt_end_indices(labels, attention_mask)
+    assert idx.tolist() == [1, 2, 1]
+
+
+def test_reduce_end_of_prompt_selects_boundary_token():
+    hidden = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+    attention_mask = torch.tensor([[1, 1, 1, 1], [1, 1, 1, 0]])
+    # Row 0 boundary index 1, row 1 boundary index 0.
+    prompt_end_idx = torch.tensor([1, 0])
+    reduced = reduce_hidden_states(hidden, attention_mask, "end_of_prompt", prompt_end_idx=prompt_end_idx)
+    assert torch.equal(reduced[0], hidden[0, 1])
+    assert torch.equal(reduced[1], hidden[1, 0])
+
+
+def test_reduce_end_of_prompt_empty_completion_equals_last():
+    # Acceptance #4: an empty-completion row reduces to the SAME vector as "last".
+    hidden = torch.arange(1 * 5 * 2, dtype=torch.float32).reshape(1, 5, 2)
+    attention_mask = torch.tensor([[1, 1, 1, 0, 0]])  # 3 real tokens
+    labels = torch.tensor([[-100, -100, -100, -100, -100]])  # all prompt, no completion
+    idx = prompt_end_indices(labels, attention_mask)
+    eop = reduce_hidden_states(hidden, attention_mask, "end_of_prompt", prompt_end_idx=idx)
+    last = reduce_hidden_states(hidden, attention_mask, "last")
+    assert torch.equal(eop, last)
+
+
+def test_reduce_end_of_prompt_without_idx_falls_back_to_last():
+    # Inference path: prompt-only input, no labels/prompt_end_idx -> behaves as "last".
+    hidden = torch.arange(2 * 4 * 3, dtype=torch.float32).reshape(2, 4, 3)
+    attention_mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 1]])
+    eop = reduce_hidden_states(hidden, attention_mask, "end_of_prompt")
+    last = reduce_hidden_states(hidden, attention_mask, "last")
+    assert torch.equal(eop, last)
 
 
 # ---------------------------------------------------------------------------
@@ -157,6 +236,40 @@ def test_save_load_roundtrip_preserves_weights_and_config(tmp_path):
     assert resolved["layer"] == 35
     assert resolved["token_position"] == "last"
     assert resolved["loss"] == "bce"
+
+
+def test_save_load_roundtrip_preserves_input_norm(tmp_path):
+    # A head saved with a LayerNorm must reload with the same input_norm and infer
+    # bit-for-bit (acceptance #5: portability of the input_norm knob).
+    head = AuxHead(input_dim=12, head_type="linear", input_norm="layernorm")
+    save_aux_head(head, tmp_path, layer=10, token_position="end_of_prompt", loss="bce")
+
+    resolved = aux_head_mod.read_aux_head_resolved_config(tmp_path)
+    assert resolved["input_norm"] == "layernorm"
+    assert resolved["token_position"] == "end_of_prompt"
+
+    reloaded = load_aux_head(tmp_path)
+    assert reloaded.input_norm == "layernorm"
+    assert isinstance(reloaded.norm, torch.nn.LayerNorm)
+
+    x = torch.randn(4, 12) * 50.0
+    assert torch.allclose(head(x), reloaded(x), atol=1e-6)
+
+
+def test_load_legacy_sidecar_without_input_norm_defaults_to_none(tmp_path):
+    # Old Phase-A sidecars predate input_norm; a reload must default it to "none".
+    head = AuxHead(input_dim=8, head_type="linear")
+    save_aux_head(head, tmp_path, layer=5, token_position="last", loss="bce")
+    # Simulate a legacy sidecar: strip the input_norm key.
+    import json
+    cfg_path = tmp_path / "aux_head_config.json"
+    data = json.loads(cfg_path.read_text())
+    data.pop("input_norm", None)
+    cfg_path.write_text(json.dumps(data))
+
+    reloaded = load_aux_head(tmp_path)
+    assert reloaded.input_norm == "none"
+    assert not hasattr(reloaded, "norm")
 
 
 def test_load_missing_sidecar_raises(tmp_path):

--- a/tests/trainers/sft/test_aux_head_config.py
+++ b/tests/trainers/sft/test_aux_head_config.py
@@ -31,6 +31,7 @@ def test_absent_block_yields_disabled_default():
     assert cfg.head_type == "linear"
     assert cfg.freeze_base is True
     assert cfg.lm_loss_weight == 0.0
+    assert cfg.input_norm == "none"
 
 
 def test_enabled_block_is_parsed_fieldwise():
@@ -58,6 +59,23 @@ def test_enabled_block_is_parsed_fieldwise():
     assert cfg.hidden_dims == [64, 16]
     assert cfg.out_activation == "identity"
     assert cfg.head_lr == 1e-3
+
+
+def test_phase_b_block_is_parsed_fieldwise():
+    cfg = load_aux_head_config(
+        {
+            "enabled": True,
+            "layer": 35,
+            "token_position": "end_of_prompt",
+            "input_norm": "layernorm",
+            "freeze_base": False,
+            "lm_loss_weight": 1.0,
+        }
+    )
+    assert cfg.token_position == "end_of_prompt"
+    assert cfg.input_norm == "layernorm"
+    assert cfg.freeze_base is False
+    assert cfg.lm_loss_weight == 1.0
 
 
 def test_enabled_without_layer_fails_loud():

--- a/tests/trainers/sft/test_aux_head_config.py
+++ b/tests/trainers/sft/test_aux_head_config.py
@@ -35,6 +35,11 @@ def test_absent_block_yields_disabled_default():
 
 
 def test_enabled_block_is_parsed_fieldwise():
+    # NOTE: out_activation is "sigmoid" here (not "identity") because the loader
+    # now rejects the identity + probability-loss (brier/bce) combination as
+    # incoherent — see test_rejects_identity_out_activation_with_probability_loss.
+    # Identity is still a valid dataclass value for callers that consume raw
+    # logits; only the loader refuses to pair it with a probability-scoring loss.
     cfg = load_aux_head_config(
         {
             "enabled": True,
@@ -44,7 +49,7 @@ def test_enabled_block_is_parsed_fieldwise():
             "loss": "brier",
             "head_type": "mlp",
             "hidden_dims": [64, 16],
-            "out_activation": "identity",
+            "out_activation": "sigmoid",
             "freeze_base": True,
             "lm_loss_weight": 0.0,
             "head_lr": 1e-3,
@@ -57,7 +62,7 @@ def test_enabled_block_is_parsed_fieldwise():
     assert cfg.loss == "brier"
     assert cfg.head_type == "mlp"
     assert cfg.hidden_dims == [64, 16]
-    assert cfg.out_activation == "identity"
+    assert cfg.out_activation == "sigmoid"
     assert cfg.head_lr == 1e-3
 
 
@@ -81,6 +86,51 @@ def test_phase_b_block_is_parsed_fieldwise():
 def test_enabled_without_layer_fails_loud():
     with pytest.raises(ValueError, match="requires aux_head.layer"):
         load_aux_head_config({"enabled": True})
+
+
+@pytest.mark.parametrize(
+    "freeze_base, lm_loss_weight",
+    [
+        (False, 0.0),  # co-train base on head loss alone, no LM anchor
+        (True, 1.0),   # weighted LM term with no gradient (base frozen)
+    ],
+)
+def test_rejects_incoherent_freeze_base_lm_loss_weight(freeze_base, lm_loss_weight):
+    with pytest.raises(ValueError, match="must agree on the phase"):
+        load_aux_head_config(
+            {
+                "enabled": True,
+                "layer": 35,
+                "freeze_base": freeze_base,
+                "lm_loss_weight": lm_loss_weight,
+            }
+        )
+
+
+@pytest.mark.parametrize("loss", ["bce", "brier"])
+def test_rejects_identity_out_activation_with_probability_loss(loss):
+    with pytest.raises(ValueError, match="out_activation='identity' is incompatible"):
+        load_aux_head_config(
+            {
+                "enabled": True,
+                "layer": 35,
+                "loss": loss,
+                "out_activation": "identity",
+            }
+        )
+
+
+def test_coherent_phase_configs_still_load():
+    # Both valid phase combinations must continue to load (byte-identical valid
+    # path): frozen-base head-only and unfrozen-base joint co-training.
+    phase_a = load_aux_head_config(
+        {"enabled": True, "layer": 35, "freeze_base": True, "lm_loss_weight": 0.0}
+    )
+    assert phase_a.freeze_base is True and phase_a.lm_loss_weight == 0.0
+    phase_b = load_aux_head_config(
+        {"enabled": True, "layer": 35, "freeze_base": False, "lm_loss_weight": 1.0}
+    )
+    assert phase_b.freeze_base is False and phase_b.lm_loss_weight == 1.0
 
 
 def test_config_has_real_aux_head_field_so_block_is_not_silently_dropped():

--- a/tests/trainers/sft/test_aux_head_integration.py
+++ b/tests/trainers/sft/test_aux_head_integration.py
@@ -341,3 +341,75 @@ def test_input_norm_layernorm_trains_through_the_trainer(tmp_path):
     head_before = [p.detach().clone() for p in head.parameters()]
     trainer.train()
     assert any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))
+
+
+def test_unfrozen_base_optimizer_group_is_exactly_the_trainable_subset(tmp_path):
+    # Acceptance #3, strengthened: a FULLY-unfrozen tiny base makes "the second
+    # group contains the trainable params" trivially true. On a real run PEFT
+    # leaves only the LoRA params trainable, so here we mimic that sparsity —
+    # freeze MOST base params and leave a single one trainable — then assert the
+    # optimizer's second param group is EXACTLY that trainable subset (not the
+    # whole base), that the trainable base param MOVES after one joint step, and
+    # that a frozen base param does NOT move.
+    trainer, model, head = _make_trainer(
+        tmp_path, freeze_base=False, lm_loss_weight=1.0
+    )
+
+    # Stand-in for LoRA sparsity: only layer-0 q_proj stays trainable.
+    trainable_subset = {}
+    for name, param in model.named_parameters():
+        if "layers.0.self_attn.q_proj" in name:
+            param.requires_grad = True
+            trainable_subset[name] = param
+        else:
+            param.requires_grad = False
+    assert len(trainable_subset) >= 1  # the subset is non-empty (non-vacuous)
+
+    optimizer = trainer.create_optimizer()
+    assert len(optimizer.param_groups) == 2  # head group + base group
+
+    # Group 0 is the head; group 1 is the base's trainable params (see
+    # create_optimizer's append order). The base group must be EXACTLY the
+    # trainable subset — by object identity, so a regression that widened it to
+    # the whole base would turn this red.
+    head_group_ids = {id(p) for p in optimizer.param_groups[0]["params"]}
+    base_group_ids = {id(p) for p in optimizer.param_groups[1]["params"]}
+    assert head_group_ids == {id(p) for p in head.parameters()}
+    assert base_group_ids == {id(p) for p in trainable_subset.values()}
+
+    named = dict(model.named_parameters())
+    trainable_name = next(iter(trainable_subset))
+    # A param guaranteed to be outside the trainable subset (different layer).
+    frozen_name = "model.layers.2.mlp.down_proj.weight"
+    assert not named[frozen_name].requires_grad
+
+    trainable_before = named[trainable_name].detach().clone()
+    frozen_before = named[frozen_name].detach().clone()
+    trainer.train()
+    assert not torch.equal(trainable_before, named[trainable_name])  # subset moved
+    assert torch.equal(frozen_before, named[frozen_name])  # frozen did NOT move
+
+
+def test_unfrozen_base_belt_is_harmless_without_checkpointing(tmp_path):
+    # YELLOW disposition (accept-as-is): _prepare_unfrozen_base_keep_head calls
+    # enable_input_require_grads() on EVERY freeze_base=false construction, not
+    # only when gradient checkpointing is enabled. That belt exists for the
+    # checkpointing path (asserted load-bearing in
+    # test_gradient_flows_into_base_from_head_alone_under_checkpointing). This
+    # test brackets it from the other side: with checkpointing OFF the belt must
+    # be HARMLESS — a normal unfrozen-base joint step still trains cleanly
+    # (finite loss; base and head both move), nothing regresses.
+    trainer, model, head = _make_trainer(
+        tmp_path, freeze_base=False, lm_loss_weight=1.0
+    )
+    assert getattr(model, "is_gradient_checkpointing", False) is False  # GC off here
+
+    base_before = [p.detach().clone() for p in model.parameters()]
+    head_before = [p.detach().clone() for p in head.parameters()]
+    result = trainer.train()
+
+    assert result.training_loss == pytest.approx(result.training_loss)  # finite, not NaN
+    base_moved = any(not torch.equal(b, a) for b, a in zip(base_before, model.parameters()))
+    head_moved = any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))
+    assert base_moved
+    assert head_moved

--- a/tests/trainers/sft/test_aux_head_integration.py
+++ b/tests/trainers/sft/test_aux_head_integration.py
@@ -99,9 +99,18 @@ def _collate(features):
     }
 
 
-def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="last", remove_unused_columns=False):
+def _make_trainer(
+    tmp_path,
+    *,
+    freeze_base=True,
+    loss="bce",
+    token_position="last",
+    remove_unused_columns=False,
+    lm_loss_weight=0.0,
+    input_norm="none",
+):
     model = _tiny_causal_lm()
-    head = AuxHead(input_dim=HIDDEN, head_type="linear")
+    head = AuxHead(input_dim=HIDDEN, head_type="linear", input_norm=input_norm)
     cfg = AuxHeadConfig(
         enabled=True,
         layer=READ_LAYER,
@@ -110,7 +119,8 @@ def _make_trainer(tmp_path, *, freeze_base=True, loss="bce", token_position="las
         loss=loss,
         head_type="linear",
         freeze_base=freeze_base,
-        lm_loss_weight=0.0,
+        lm_loss_weight=lm_loss_weight,
+        input_norm=input_norm,
     )
     args = TrainingArguments(
         output_dir=str(tmp_path / "out"),
@@ -220,3 +230,114 @@ def test_train_refuses_resume_from_checkpoint(tmp_path):
         trainer.train(resume_from_checkpoint=str(tmp_path / "out" / "checkpoint-1"))
     with pytest.raises(RuntimeError, match="resume_from_checkpoint"):
         trainer.train(resume_from_checkpoint=True)
+
+
+# ---------------------------------------------------------------------------
+# Phase B: joint loss, unfrozen base, gradient flow
+# ---------------------------------------------------------------------------
+
+def test_joint_loss_equals_lm_plus_weighted_head(tmp_path):
+    # With lm_loss_weight>0 the total loss must be exactly
+    # outputs.loss + lm_loss_weight * head_loss (acceptance #2).
+    lm_loss_weight = 0.5
+    trainer, model, head = _make_trainer(
+        tmp_path, freeze_base=False, lm_loss_weight=lm_loss_weight
+    )
+    batch = _collate([_RowDataset()[i] for i in range(4)])
+    target = batch["aux_target"].clone()  # compute_loss pops aux_target
+
+    loss, outputs = trainer.compute_loss(model, batch, return_outputs=True)
+
+    # Recompute the head term from the SAME outputs the trainer used.
+    from aux_head import compute_aux_head_loss, reduce_hidden_states  # noqa: E402
+
+    reduced = reduce_hidden_states(
+        outputs.hidden_states[READ_LAYER], batch["attention_mask"], "last"
+    )
+    head_loss = compute_aux_head_loss(head(reduced), target, "bce")
+    expected = outputs.loss + lm_loss_weight * head_loss
+    assert torch.allclose(loss, expected, atol=1e-6)
+
+
+def test_phase_a_compute_loss_is_head_loss_only(tmp_path):
+    # lm_loss_weight==0 ⇒ the loss is the head loss alone (Phase-A byte-identical),
+    # even though outputs.loss (the LM CE) is finite and available.
+    trainer, model, head = _make_trainer(tmp_path, freeze_base=True, lm_loss_weight=0.0)
+    batch = _collate([_RowDataset()[i] for i in range(4)])
+    target = batch["aux_target"].clone()
+
+    loss, outputs = trainer.compute_loss(model, batch, return_outputs=True)
+
+    from aux_head import compute_aux_head_loss, reduce_hidden_states  # noqa: E402
+
+    reduced = reduce_hidden_states(
+        outputs.hidden_states[READ_LAYER], batch["attention_mask"], "last"
+    )
+    head_loss = compute_aux_head_loss(head(reduced), target, "bce")
+    assert torch.allclose(loss, head_loss, atol=1e-6)
+    assert outputs.loss is not None  # the LM loss was computed but NOT added
+
+
+def test_unfrozen_base_optimizer_includes_base_and_step_updates_both(tmp_path):
+    # freeze_base=false ⇒ a second optimizer param group covers the base's
+    # trainable params, and one joint step moves BOTH a base weight and the head
+    # (acceptance #3). The tiny Llama has no LoRA, so its trainable params stand
+    # in for the LoRA params PEFT would leave trainable on a real run.
+    trainer, model, head = _make_trainer(
+        tmp_path, freeze_base=False, lm_loss_weight=1.0
+    )
+    optimizer = trainer.create_optimizer()
+    assert len(optimizer.param_groups) == 2  # head group + base group
+
+    base_before = [p.detach().clone() for p in model.parameters()]
+    head_before = [p.detach().clone() for p in head.parameters()]
+    trainer.train()
+    base_moved = any(not torch.equal(b, a) for b, a in zip(base_before, model.parameters()))
+    head_moved = any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))
+    assert base_moved
+    assert head_moved
+
+
+def test_gradient_flows_into_base_from_head_alone_under_checkpointing(tmp_path):
+    # §2.5 ISOLATED head path (acceptance #6): freeze_base=false AND
+    # lm_loss_weight=0, so the ONLY loss is the head loss. Under gradient
+    # checkpointing (forced ON) the head's gradient must still reach a base param
+    # at/before the read layer — proving the recomputed hidden state the head
+    # reads is NOT detached from the base. This is deliberately NOT the
+    # false-green "lm_loss_weight>0 + some base grad" form (an LM-loss gradient
+    # would reach the base regardless of the head).
+    trainer, model, head = _make_trainer(
+        tmp_path, freeze_base=False, lm_loss_weight=0.0
+    )
+    model.gradient_checkpointing_enable()  # FORCE checkpointing on for this assertion
+    model.config.use_cache = False
+    model.train()
+
+    batch = _collate([_RowDataset()[i] for i in range(4)])
+    loss, outputs = trainer.compute_loss(model, batch, return_outputs=True)
+
+    # The read hidden state must remain attached to the autograd graph.
+    assert outputs.hidden_states[READ_LAYER].grad_fn is not None
+
+    model.zero_grad(set_to_none=True)
+    loss.backward()
+
+    # A base param strictly before the read layer (hidden_states[2] = output of
+    # block index 1) must receive gradient purely from the head loss.
+    pre_read_param = model.model.layers[0].self_attn.q_proj.weight
+    assert pre_read_param.grad is not None
+    assert torch.count_nonzero(pre_read_param.grad) > 0
+
+    head_param = next(head.parameters())
+    assert head_param.grad is not None
+    assert torch.count_nonzero(head_param.grad) > 0
+
+
+def test_input_norm_layernorm_trains_through_the_trainer(tmp_path):
+    # The optional input normalization must survive a real training step: the
+    # head (LayerNorm + linear) moves under a normal LR.
+    trainer, model, head = _make_trainer(tmp_path, input_norm="layernorm")
+    assert hasattr(head, "norm")
+    head_before = [p.detach().clone() for p in head.parameters()]
+    trainer.train()
+    assert any(not torch.equal(b, a) for b, a in zip(head_before, head.parameters()))

--- a/tests/trainers/sft/test_aux_head_trainer_source.py
+++ b/tests/trainers/sft/test_aux_head_trainer_source.py
@@ -84,10 +84,16 @@ def test_aux_head_trainer_overrides_present():
     assert "train" in cls.__dict__
 
 
-def test_aux_head_trainer_source_marks_phase_b_seam_and_no_lm_term():
+def test_aux_head_trainer_source_wires_live_joint_loss_seam():
     source = (SFT_DIR / "src" / "aux_head_trainer.py").read_text(encoding="utf-8")
-    # Phase A: head loss is the entire loss.
+    # Phase B: the joint-loss seam is now LIVE (it is no longer a disabled
+    # comment). The discriminator is the exact weighted-sum line, which exists
+    # ONLY when the seam is wired — guarding against the green-by-omission trap
+    # where a bare ``lm_loss_weight`` token would pass even as a comment.
+    assert "loss = outputs.loss + lm_loss_weight * head_loss" in source
+    # Gated on the weight so the lm_loss_weight==0 path stays byte-identical.
+    assert "if lm_loss_weight > 0:" in source
+    # Phase A (lm_loss_weight == 0): the head loss is still the entire loss.
     assert "loss = head_loss" in source
-    # Phase B seam left as a one-line comment, NOT enabled.
-    assert "lm_loss_weight" in source
+    # Hidden states are enabled inside compute_loss (no global flag).
     assert "output_hidden_states=True" in source


### PR DESCRIPTION
## Summary

Phase B of the generic `aux_head` engine: co-train the scalar readout head jointly with the LM loss over an **unfrozen** base. Builds on Phase A (PR #118, the frozen-base head). Implements all five build items from the handoff spec (`docs/sessions/0028`), §3 config, and §4 acceptance.

This is a **submodule PR only** — the root-repo submodule-pointer bump is a separate later commit (tracked task #30).

## Build items (§2)

1. **Joint loss** — `lm_loss_weight > 0` ⇒ `loss = outputs.loss + lm_loss_weight * head_loss`; `== 0` ⇒ `loss = head_loss` (Phase-A unchanged).
2. **Unfrozen-base path** — `freeze_base=false` leaves PEFT/LoRA `requires_grad` as set, ensures the head is trainable, and adds the base's trainable params as a 2nd optimizer group (inherits the trainer LR; head keeps optional `head_lr`).
3. **`end_of_prompt` token position** — new `prompt_end_indices(labels, attention_mask)` helper; a single `first_completion==0` guard unifies the completion-first and empty-completion edge cases (both fall back to the last real token). Inference falls back to `"last"` when no labels.
4. **Optional `input_norm`** (`"none"` | `"layernorm"`) — persisted in the sidecar config; legacy sidecars default to `"none"`. `"none"` adds no submodule (byte-identical state_dict).
5. **Gradient-flow belt + §2.5 test** — `enable_input_require_grads()` on the unfrozen path; an isolated head-path gradient test (`freeze_base=false`, `lm_loss_weight=0`, GC forced ON) proves the head's gradient reaches a pre-read base param **alone** (not the false-green `λ>0 + some base grad` form).

## Config (§3)
- `input_norm: str = "none"` added to `AuxHeadConfig` (a real dataclass field — dodges the `dict_to_dataclass` silent-drop).
- New `aux_head_phase_b_example.yaml` (single GC knob: Unsloth on, HF GC off — resolves PR #118 F3).

## Acceptance (§4) — all CPU, no GPU
All 6 criteria mapped to committed **non-false-green** assertions. Suite: **63 passed / 0 skipped** (61 Phase-A baseline + 2 new; 1 stale seam test retargeted). Phase-A path confirmed **byte-identical** three ways. Generic-vocabulary discipline clean on all added lines + the new yaml.

## Quality gates
- **Auditor**: 🟢 GREEN (verified against the actual `git diff`, not the HANDOFF prose) — all four invariants confirmed.
- **TEST**: 🟢 GREEN — criterion-3 strengthened to assert id-set **equality** of the optimizer's 2nd group; the stale source seam test was itself false-green and was retargeted to a live discriminator.

## Known downstream caveat (not blocking)
The §2.5 test exercises **vanilla** torch gradient checkpointing on a tiny no-LoRA model. **Unsloth's custom GC** + real PEFT LoRA cannot be exercised on CPU — recommend a live-GPU smoke (non-zero grad on a real LoRA param + the head) before the first real Phase-B run.

## Commits
- `ff4f0bf` — feature (5 build items + config + example + skill sync)
- `b77db8d` — tests (retarget stale seam test, strengthen criterion-3, GC-off belt regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)