### PR TITLE
feat(sft): prompt_completion render mode + CLI aux_head coherence guard

### DIFF
--- a/.agents/skills/fine-tuning/reference/sft-training.md
+++ b/.agents/skills/fine-tuning/reference/sft-training.md
@@ -141,11 +141,60 @@ Two Phase-B knobs:
   before the head, so a linear head trains at a normal LR on unnormalized
   activations instead of saturating.
 
+### `prompt_render` (a `training` knob, paired with `end_of_prompt`)
+
+`token_position: end_of_prompt` is only faithful when the row was tokenized so the
+prompt ends exactly at the generation anchor. The default render
+(`training.prompt_render: full_conversation`) renders the whole conversation and
+derives the assistant-only mask by a prefix match — but many chat templates render
+the assistant scaffold differently with vs. without `add_generation_prompt` (e.g.
+one fewer newline), so the masked boundary token is NOT the generation anchor and
+the head reads an off-anchor representation.
+
+Set `training.prompt_render: prompt_completion` for a faithful boundary: the row's
+`input_ids` are built from the `add_generation_prompt=True` prompt render followed
+by the raw completion plus the tokenizer's derived terminal (`eos_token_id`), with
+the prompt segment masked to `-100`. The prompt then ends exactly at the
+generation anchor, so the existing `end_of_prompt` read is faithful.
+
+```yaml
+training:
+  prompt_render: prompt_completion   # full_conversation (default) | prompt_completion
+```
+
+`prompt_render` lives on the `training` config (it replaces the SFT masking
+region, so it is not an `aux_head` field), but it is grouped with the aux_head
+knobs for launching (see below). It defaults to `full_conversation`, so every
+existing recipe is byte-identical. When `aux_head.enabled` and
+`token_position: end_of_prompt` are set while `prompt_render` is still
+`full_conversation`, the trainer prints a one-line WARNING (not an error — the
+combo is legitimate for single-turn / inference-shaped rows whose two renders
+coincide).
+
 Complete runnable examples live at
 `Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
 `Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
 default — choosing the hidden-state index is a deliberate per-run decision, so an
 enabled block without it fails fast.
+
+### Launching aux_head (local-run recipe + direct CLI)
+
+The `aux_head` block flows through **both** launch paths:
+
+- **Direct trainer** (`cd Trainers/sft && python train_sft.py ...`): every field
+  has a CLI flag — `--aux-head-enabled` / `--no-aux-head-enabled`,
+  `--aux-head-layer`, `--aux-head-token-position`, `--aux-head-target-field`,
+  `--aux-head-loss`, `--aux-head-head-type`, `--aux-head-out-activation`,
+  `--aux-head-input-norm`, `--aux-head-freeze-base` / `--no-aux-head-freeze-base`,
+  `--aux-head-lm-loss-weight`, `--aux-head-head-lr`, and `--aux-head-prompt-render`
+  (which sets `training.prompt_render`). An unset flag never overrides the loaded
+  config; a CLI value takes precedence over the YAML/preset config.
+- **local-run recipe** (`python tuner.py local-run --job-config <recipe>.yaml`):
+  put an `aux_head:` block (and, when using `end_of_prompt`, a
+  `training.prompt_render: prompt_completion`) in the recipe; the runner forwards
+  every field to the trainer's `--aux-head-*` flags automatically. Recipes with no
+  `aux_head` block and no `training.prompt_render` emit zero new flags, so they
+  stay byte-identical. aux_head forwarding is SFT-only.
 
 ---
 

--- a/.claude/skills/fine-tuning/reference/sft-training.md
+++ b/.claude/skills/fine-tuning/reference/sft-training.md
@@ -141,11 +141,60 @@ Two Phase-B knobs:
   before the head, so a linear head trains at a normal LR on unnormalized
   activations instead of saturating.
 
+### `prompt_render` (a `training` knob, paired with `end_of_prompt`)
+
+`token_position: end_of_prompt` is only faithful when the row was tokenized so the
+prompt ends exactly at the generation anchor. The default render
+(`training.prompt_render: full_conversation`) renders the whole conversation and
+derives the assistant-only mask by a prefix match — but many chat templates render
+the assistant scaffold differently with vs. without `add_generation_prompt` (e.g.
+one fewer newline), so the masked boundary token is NOT the generation anchor and
+the head reads an off-anchor representation.
+
+Set `training.prompt_render: prompt_completion` for a faithful boundary: the row's
+`input_ids` are built from the `add_generation_prompt=True` prompt render followed
+by the raw completion plus the tokenizer's derived terminal (`eos_token_id`), with
+the prompt segment masked to `-100`. The prompt then ends exactly at the
+generation anchor, so the existing `end_of_prompt` read is faithful.
+
+```yaml
+training:
+  prompt_render: prompt_completion   # full_conversation (default) | prompt_completion
+```
+
+`prompt_render` lives on the `training` config (it replaces the SFT masking
+region, so it is not an `aux_head` field), but it is grouped with the aux_head
+knobs for launching (see below). It defaults to `full_conversation`, so every
+existing recipe is byte-identical. When `aux_head.enabled` and
+`token_position: end_of_prompt` are set while `prompt_render` is still
+`full_conversation`, the trainer prints a one-line WARNING (not an error — the
+combo is legitimate for single-turn / inference-shaped rows whose two renders
+coincide).
+
 Complete runnable examples live at
 `Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
 `Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
 default — choosing the hidden-state index is a deliberate per-run decision, so an
 enabled block without it fails fast.
+
+### Launching aux_head (local-run recipe + direct CLI)
+
+The `aux_head` block flows through **both** launch paths:
+
+- **Direct trainer** (`cd Trainers/sft && python train_sft.py ...`): every field
+  has a CLI flag — `--aux-head-enabled` / `--no-aux-head-enabled`,
+  `--aux-head-layer`, `--aux-head-token-position`, `--aux-head-target-field`,
+  `--aux-head-loss`, `--aux-head-head-type`, `--aux-head-out-activation`,
+  `--aux-head-input-norm`, `--aux-head-freeze-base` / `--no-aux-head-freeze-base`,
+  `--aux-head-lm-loss-weight`, `--aux-head-head-lr`, and `--aux-head-prompt-render`
+  (which sets `training.prompt_render`). An unset flag never overrides the loaded
+  config; a CLI value takes precedence over the YAML/preset config.
+- **local-run recipe** (`python tuner.py local-run --job-config <recipe>.yaml`):
+  put an `aux_head:` block (and, when using `end_of_prompt`, a
+  `training.prompt_render: prompt_completion`) in the recipe; the runner forwards
+  every field to the trainer's `--aux-head-*` flags automatically. Recipes with no
+  `aux_head` block and no `training.prompt_render` emit zero new flags, so they
+  stay byte-identical. aux_head forwarding is SFT-only.
 
 ---
 

--- a/.skills/fine-tuning/reference/sft-training.md
+++ b/.skills/fine-tuning/reference/sft-training.md
@@ -141,11 +141,60 @@ Two Phase-B knobs:
   before the head, so a linear head trains at a normal LR on unnormalized
   activations instead of saturating.
 
+### `prompt_render` (a `training` knob, paired with `end_of_prompt`)
+
+`token_position: end_of_prompt` is only faithful when the row was tokenized so the
+prompt ends exactly at the generation anchor. The default render
+(`training.prompt_render: full_conversation`) renders the whole conversation and
+derives the assistant-only mask by a prefix match — but many chat templates render
+the assistant scaffold differently with vs. without `add_generation_prompt` (e.g.
+one fewer newline), so the masked boundary token is NOT the generation anchor and
+the head reads an off-anchor representation.
+
+Set `training.prompt_render: prompt_completion` for a faithful boundary: the row's
+`input_ids` are built from the `add_generation_prompt=True` prompt render followed
+by the raw completion plus the tokenizer's derived terminal (`eos_token_id`), with
+the prompt segment masked to `-100`. The prompt then ends exactly at the
+generation anchor, so the existing `end_of_prompt` read is faithful.
+
+```yaml
+training:
+  prompt_render: prompt_completion   # full_conversation (default) | prompt_completion
+```
+
+`prompt_render` lives on the `training` config (it replaces the SFT masking
+region, so it is not an `aux_head` field), but it is grouped with the aux_head
+knobs for launching (see below). It defaults to `full_conversation`, so every
+existing recipe is byte-identical. When `aux_head.enabled` and
+`token_position: end_of_prompt` are set while `prompt_render` is still
+`full_conversation`, the trainer prints a one-line WARNING (not an error — the
+combo is legitimate for single-turn / inference-shaped rows whose two renders
+coincide).
+
 Complete runnable examples live at
 `Trainers/sft/configs/aux_head_example.yaml` (Phase A) and
 `Trainers/sft/configs/aux_head_phase_b_example.yaml` (Phase B). `layer` has no
 default — choosing the hidden-state index is a deliberate per-run decision, so an
 enabled block without it fails fast.
+
+### Launching aux_head (local-run recipe + direct CLI)
+
+The `aux_head` block flows through **both** launch paths:
+
+- **Direct trainer** (`cd Trainers/sft && python train_sft.py ...`): every field
+  has a CLI flag — `--aux-head-enabled` / `--no-aux-head-enabled`,
+  `--aux-head-layer`, `--aux-head-token-position`, `--aux-head-target-field`,
+  `--aux-head-loss`, `--aux-head-head-type`, `--aux-head-out-activation`,
+  `--aux-head-input-norm`, `--aux-head-freeze-base` / `--no-aux-head-freeze-base`,
+  `--aux-head-lm-loss-weight`, `--aux-head-head-lr`, and `--aux-head-prompt-render`
+  (which sets `training.prompt_render`). An unset flag never overrides the loaded
+  config; a CLI value takes precedence over the YAML/preset config.
+- **local-run recipe** (`python tuner.py local-run --job-config <recipe>.yaml`):
+  put an `aux_head:` block (and, when using `end_of_prompt`, a
+  `training.prompt_render: prompt_completion`) in the recipe; the runner forwards
+  every field to the trainer's `--aux-head-*` flags automatically. Recipes with no
+  `aux_head` block and no `training.prompt_render` emit zero new flags, so they
+  stay byte-identical. aux_head forwarding is SFT-only.
 
 ---
 

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -302,6 +302,7 @@ def validate_aux_head_coherence(
     lm_loss_weight: float,
     out_activation: str,
     loss: str,
+    layer: Optional[int],
 ) -> None:
     """Raise if an enabled aux_head config is internally incoherent.
 
@@ -314,11 +315,26 @@ def validate_aux_head_coherence(
       so without this shared call a CLI-assembled config would reach training
       unvalidated).
 
-    A disabled head (``enabled=False``) is always coherent — the fields are
-    inert — so this is a no-op in that case.
+    Guards (all gated on ``enabled``): ``layer`` must be set; ``freeze_base`` and
+    ``lm_loss_weight`` must describe the same phase; and a probability-scoring
+    ``loss`` requires a probability ``out_activation``. A disabled head
+    (``enabled=False``) is always coherent — the fields are inert — so this is a
+    no-op in that case.
     """
     if not enabled:
         return
+
+    # Presence guard: an enabled head must name the hidden_states index it reads.
+    # There is no silent default (other users read a different layer than ours),
+    # so a config whose layer never reached the YAML/flags fails loudly HERE
+    # rather than crashing late and cryptically at hidden_states[None]. Shared by
+    # both lanes — the flag-only runner lane never calls load_aux_head_config, so
+    # without this check that lane would skip the presence guard entirely.
+    if layer is None:
+        raise ValueError(
+            "aux_head.enabled=true requires aux_head.layer to be set explicitly "
+            "(no silent default — choose the hidden_states index to read)."
+        )
 
     # Coherence guard: freeze_base and lm_loss_weight must describe the SAME phase.
     # Valid: (freeze_base=true, lm_loss_weight=0) trains the head alone over a
@@ -365,26 +381,24 @@ def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
 
     enabled = aux_data.get('enabled', False)
     layer = aux_data.get('layer', None)
-    if enabled and layer is None:
-        raise ValueError(
-            "aux_head.enabled=true requires aux_head.layer to be set explicitly "
-            "(no silent default — choose the hidden_states index to read)."
-        )
-
     freeze_base = aux_data.get('freeze_base', True)
     lm_loss_weight = aux_data.get('lm_loss_weight', 0.0)
     loss = aux_data.get('loss', 'bce')
     out_activation = aux_data.get('out_activation', 'sigmoid')
 
-    # Coherence guards (phase agreement + probability-loss/out_activation match)
-    # are shared with the CLI-override path in train_sft.run; a single
-    # implementation keeps the YAML lane and the CLI lane raising identically.
+    # Coherence guards (layer presence + phase agreement + probability-loss/
+    # out_activation match) are shared with the CLI-override path in
+    # train_sft.run; a single implementation keeps the YAML lane and the CLI lane
+    # raising identically. The layer-presence check lives in the shared validator
+    # too (not inline here) so the flag-only runner lane — which never calls this
+    # function — gets the same early, descriptive raise.
     validate_aux_head_coherence(
         enabled=enabled,
         freeze_base=freeze_base,
         lm_loss_weight=lm_loss_weight,
         out_activation=out_activation,
         loss=loss,
+        layer=layer,
     )
 
     return AuxHeadConfig(

--- a/Trainers/sft/configs/config_loader.py
+++ b/Trainers/sft/configs/config_loader.py
@@ -85,6 +85,16 @@ class SFTTrainingConfig:
     # models). None ⇒ no kwargs ⇒ default rendering for every existing config.
     chat_template_kwargs: Optional[Dict[str, Any]] = None
     max_steps: Optional[int] = None
+    # Render/masking strategy for SFT preprocessing.
+    #   "full_conversation" (default) — render the whole conversation with
+    #       add_generation_prompt=False and derive the assistant-only mask by a
+    #       prefix match. Byte-identical to historical behavior.
+    #   "prompt_completion" — build input_ids from the add_generation_prompt=True
+    #       prompt render followed by the raw completion + derived terminal, with
+    #       the prompt segment masked to -100. Lives here (not on AuxHeadConfig)
+    #       because it REPLACES the assistant_only masking region rather than
+    #       configuring the head; see shared.sft_preprocessing.materialize_sft_example.
+    prompt_render: str = "full_conversation"
 
 
 @dataclass
@@ -286,6 +296,63 @@ def load_evolutionary_config(evo_data: Dict[str, Any]) -> EvolutionaryConfig:
     )
 
 
+def validate_aux_head_coherence(
+    enabled: bool,
+    freeze_base: bool,
+    lm_loss_weight: float,
+    out_activation: str,
+    loss: str,
+) -> None:
+    """Raise if an enabled aux_head config is internally incoherent.
+
+    Shared by both config paths so a config assembled from CLI flags is
+    validated identically to one loaded from YAML:
+
+    - ``load_aux_head_config`` (the YAML-load path), and
+    - ``train_sft.run`` after the ``--aux-head-*`` CLI overrides mutate
+      ``config.aux_head`` (those overrides run AFTER ``load_aux_head_config``,
+      so without this shared call a CLI-assembled config would reach training
+      unvalidated).
+
+    A disabled head (``enabled=False``) is always coherent — the fields are
+    inert — so this is a no-op in that case.
+    """
+    if not enabled:
+        return
+
+    # Coherence guard: freeze_base and lm_loss_weight must describe the SAME phase.
+    # Valid: (freeze_base=true, lm_loss_weight=0) trains the head alone over a
+    # frozen base, or (freeze_base=false, lm_loss_weight>0) co-trains the base
+    # jointly with a weighted LM term. The (false, 0) corner co-trains the base on
+    # the head loss alone with no LM term anchoring it — the base drifts freely.
+    # The (true, >0) corner adds an LM term that receives no gradient (the base is
+    # frozen) — wasted compute and a misleading loss curve. Reject both loudly
+    # rather than launch a silently incoherent run.
+    phase_coherent = (freeze_base and lm_loss_weight == 0) or (
+        not freeze_base and lm_loss_weight > 0
+    )
+    if not phase_coherent:
+        raise ValueError(
+            "aux_head.freeze_base and aux_head.lm_loss_weight must agree on the "
+            "phase: use (freeze_base=true, lm_loss_weight=0) or "
+            "(freeze_base=false, lm_loss_weight>0). Got "
+            f"freeze_base={freeze_base}, lm_loss_weight={lm_loss_weight} — an "
+            "incoherent combination that would train a misconfigured run."
+        )
+
+    # Coherence guard: an "identity" out_activation returns the raw value, not a
+    # probability in [0, 1], so pairing it with a probability-scoring loss
+    # (bce/brier, which expect a probability) silently mis-scores — bce on
+    # out-of-range inputs, or brier as MSE-on-logits (a non-proper score). Require
+    # a sigmoid output for these losses.
+    if out_activation == 'identity' and loss in ('bce', 'brier'):
+        raise ValueError(
+            "aux_head.out_activation='identity' is incompatible with "
+            f"aux_head.loss={loss!r}: bce and brier expect a probability in "
+            "[0, 1]. Use out_activation='sigmoid' for these losses."
+        )
+
+
 def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
     """Load aux_head config from a YAML dict (mirrors load_evolutionary_config).
 
@@ -309,37 +376,16 @@ def load_aux_head_config(aux_data: Dict[str, Any]) -> AuxHeadConfig:
     loss = aux_data.get('loss', 'bce')
     out_activation = aux_data.get('out_activation', 'sigmoid')
 
-    # Coherence guard: freeze_base and lm_loss_weight must describe the SAME phase.
-    # Valid: (freeze_base=true, lm_loss_weight=0) trains the head alone over a
-    # frozen base, or (freeze_base=false, lm_loss_weight>0) co-trains the base
-    # jointly with a weighted LM term. The (false, 0) corner co-trains the base on
-    # the head loss alone with no LM term anchoring it — the base drifts freely.
-    # The (true, >0) corner adds an LM term that receives no gradient (the base is
-    # frozen) — wasted compute and a misleading loss curve. Reject both loudly
-    # rather than launch a silently incoherent run.
-    phase_coherent = (freeze_base and lm_loss_weight == 0) or (
-        not freeze_base and lm_loss_weight > 0
+    # Coherence guards (phase agreement + probability-loss/out_activation match)
+    # are shared with the CLI-override path in train_sft.run; a single
+    # implementation keeps the YAML lane and the CLI lane raising identically.
+    validate_aux_head_coherence(
+        enabled=enabled,
+        freeze_base=freeze_base,
+        lm_loss_weight=lm_loss_weight,
+        out_activation=out_activation,
+        loss=loss,
     )
-    if enabled and not phase_coherent:
-        raise ValueError(
-            "aux_head.freeze_base and aux_head.lm_loss_weight must agree on the "
-            "phase: use (freeze_base=true, lm_loss_weight=0) or "
-            "(freeze_base=false, lm_loss_weight>0). Got "
-            f"freeze_base={freeze_base}, lm_loss_weight={lm_loss_weight} — an "
-            "incoherent combination that would train a misconfigured run."
-        )
-
-    # Coherence guard: an "identity" out_activation returns the raw value, not a
-    # probability in [0, 1], so pairing it with a probability-scoring loss
-    # (bce/brier, which expect a probability) silently mis-scores — bce on
-    # out-of-range inputs, or brier as MSE-on-logits (a non-proper score). Require
-    # a sigmoid output for these losses.
-    if enabled and out_activation == 'identity' and loss in ('bce', 'brier'):
-        raise ValueError(
-            "aux_head.out_activation='identity' is incompatible with "
-            f"aux_head.loss={loss!r}: bce and brier expect a probability in "
-            "[0, 1]. Use out_activation='sigmoid' for these losses."
-        )
 
     return AuxHeadConfig(
         enabled=enabled,

--- a/Trainers/sft/src/data_loader.py
+++ b/Trainers/sft/src/data_loader.py
@@ -156,6 +156,7 @@ def load_and_prepare_tokenized_dataset(
     loss_mask_mode: str = ASSISTANT_ONLY,
     chat_template_kwargs: Optional[dict] = None,
     aux_target_field: Optional[str] = None,
+    prompt_render: str = "full_conversation",
 ) -> Tuple[Dataset, Optional[Dataset]]:
     """
     Load and prepare dataset into explicit tokenized SFT features.
@@ -168,7 +169,7 @@ def load_and_prepare_tokenized_dataset(
     ``aux_target`` feature for the auxiliary readout head. None ⇒ unchanged.
     """
     print("=" * 60)
-    print("LOADING TOKENIZED DATASET FOR SFT")
+    print("LOADING ENCODED DATASET FOR SFT")
     print("=" * 60)
 
     if tokenizer is None:
@@ -206,7 +207,7 @@ def load_and_prepare_tokenized_dataset(
         print(f"Filtered: {original_size} → {filtered_count} examples")
         print(f"Removed: {original_size - filtered_count} undesirable examples")
 
-    print("\nPreparing explicit tokenized SFT features...")
+    print("\nPreparing explicit encoded SFT features...")
     train_dataset = load_and_prepare_sft_dataset(
         dataset=raw_datasets,
         tokenizer=tokenizer,
@@ -216,6 +217,7 @@ def load_and_prepare_tokenized_dataset(
         include_text=False,
         chat_template_kwargs=chat_template_kwargs,
         aux_target_field=aux_target_field,
+        prompt_render=prompt_render,
     )
 
     eval_dataset = None
@@ -277,10 +279,10 @@ def print_dataset_samples(dataset: Dataset, num_samples: int = 3):
             print(f"Format: Text")
             print(f"Content: {example['text'][:200]}...")
         elif "input_ids" in example and "labels" in example:
-            print("Format: Tokenized SFT")
-            print(f"Input IDs: {len(example['input_ids'])} tokens")
+            print("Format: Encoded SFT")
+            print(f"Input IDs: {len(example['input_ids'])} ids")
             supervised = sum(1 for label in example["labels"] if label != -100)
-            print(f"Supervised tokens: {supervised}")
+            print(f"Supervised positions: {supervised}")
             if "loss_mask_mode" in example:
                 print(f"Loss mask mode: {example['loss_mask_mode']}")
         else:

--- a/Trainers/sft/src/preprocessing.py
+++ b/Trainers/sft/src/preprocessing.py
@@ -54,6 +54,7 @@ def materialize_sft_features(
     loss_mask_mode: str = ASSISTANT_ONLY,
     tool_call_mode: str = "render_text",
     chat_template_kwargs: dict[str, Any] | None = None,
+    prompt_render: str = "full_conversation",
 ) -> PreparedSFTExample:
     if tool_call_mode != "render_text":
         raise ValueError(f"Unsupported tool_call_mode: {tool_call_mode}")
@@ -66,6 +67,7 @@ def materialize_sft_features(
         max_seq_length=max_seq_length,
         assistant_only_loss=assistant_only_loss,
         chat_template_kwargs=chat_template_kwargs,
+        prompt_render=prompt_render,
     )
 
 
@@ -78,6 +80,7 @@ def prepare_sft_dataset(
     backend: str = "trl_unsloth",
     chat_template_kwargs: dict[str, Any] | None = None,
     aux_target_field: str | None = None,
+    prompt_render: str = "full_conversation",
 ) -> Dataset:
     del backend  # The contract is backend-agnostic; callers choose the trainer separately.
 
@@ -95,6 +98,7 @@ def prepare_sft_dataset(
             max_seq_length=max_seq_length,
             loss_mask_mode=loss_mask_mode,
             chat_template_kwargs=chat_template_kwargs,
+            prompt_render=prompt_render,
         )
         materialized = {
             "input_ids": prepared.input_ids,
@@ -147,6 +151,7 @@ def load_and_prepare_sft_dataset(
     include_text: bool = False,
     chat_template_kwargs: dict[str, Any] | None = None,
     aux_target_field: str | None = None,
+    prompt_render: str = "full_conversation",
 ) -> Dataset:
     del num_proc
     del include_text
@@ -157,4 +162,5 @@ def load_and_prepare_sft_dataset(
         loss_mask_mode=loss_mask_mode,
         chat_template_kwargs=chat_template_kwargs,
         aux_target_field=aux_target_field,
+        prompt_render=prompt_render,
     )

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -703,16 +703,20 @@ def run(args: argparse.Namespace):
         config.training.prompt_render = args.aux_head_prompt_render
     # Coherence parity with the YAML lane: the --aux-head-* overrides above mutate
     # config.aux_head after load_aux_head_config ran, so a config assembled purely
-    # from CLI flags (e.g. --aux-head-enabled --no-aux-head-freeze-base, which
-    # reaches the freeze_base=false + lm_loss_weight=0 corner via the dataclass
-    # defaults) would otherwise reach training unvalidated. Same shared guard,
-    # same raise. Distinct from the prompt_render WARN below — both must hold.
+    # from CLI flags would otherwise reach training unvalidated — e.g.
+    # --aux-head-enabled --no-aux-head-freeze-base (the freeze_base=false +
+    # lm_loss_weight=0 corner via dataclass defaults), or --aux-head-enabled with
+    # no --aux-head-layer (layer=None, which would crash late at hidden_states[None]
+    # on the flag-only runner lane that never calls load_aux_head_config). Same
+    # shared guard, same raise. Distinct from the prompt_render WARN below — both
+    # must hold.
     validate_aux_head_coherence(
         enabled=config.aux_head.enabled,
         freeze_base=config.aux_head.freeze_base,
         lm_loss_weight=config.aux_head.lm_loss_weight,
         out_activation=config.aux_head.out_activation,
         loss=config.aux_head.loss,
+        layer=config.aux_head.layer,
     )
     if args.lora_r is not None:
         config.lora.r = args.lora_r

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -43,6 +43,7 @@ from configs.config_loader import (
     get_13b_config,
     get_20b_config,
     load_config,
+    validate_aux_head_coherence,
 )
 from src.data_loader import load_and_prepare_tokenized_dataset, print_dataset_samples
 from src.model_loader import (
@@ -473,6 +474,47 @@ def parse_args(argv=None):
         help="Disable 4-bit model loading",
     )
 
+    # aux_head CLI knobs (local-run lane). Every flag defaults to None so an unset
+    # flag never overrides the loaded config — a CLI-provided value takes
+    # precedence over the YAML/preset config, and absence is byte-identical to
+    # config-only. Scalar/str/numeric knobs set AuxHeadConfig fields; the two
+    # booleans (enabled, freeze_base) use the tri-state --flag/--no-flag pattern
+    # (mirroring --load-in-4bit) so False is expressible without making absence
+    # mean False. --aux-head-prompt-render is grouped here for user intent but
+    # sets config.training.prompt_render — the render mode lives on
+    # SFTTrainingConfig, not AuxHeadConfig (it replaces the masking region).
+    parser.set_defaults(aux_head_enabled=None, aux_head_freeze_base=None)
+    parser.add_argument("--aux-head-enabled", action="store_true", dest="aux_head_enabled",
+                        help="Enable the auxiliary scalar readout head (AuxHeadConfig.enabled=true).")
+    parser.add_argument("--no-aux-head-enabled", action="store_false", dest="aux_head_enabled",
+                        help="Disable the auxiliary scalar readout head (AuxHeadConfig.enabled=false).")
+    parser.add_argument("--aux-head-layer", type=int, default=None,
+                        help="Hidden-states index the head reads (AuxHeadConfig.layer).")
+    parser.add_argument("--aux-head-token-position", type=str, default=None,
+                        help="Token position the head reduces over "
+                             "(AuxHeadConfig.token_position; e.g. last | mean | end_of_prompt).")
+    parser.add_argument("--aux-head-target-field", type=str, default=None,
+                        help="Per-row dataset column carrying the head target (AuxHeadConfig.target_field).")
+    parser.add_argument("--aux-head-loss", type=str, default=None,
+                        help="Head loss (AuxHeadConfig.loss; e.g. bce | brier).")
+    parser.add_argument("--aux-head-head-type", type=str, default=None,
+                        help="Head architecture (AuxHeadConfig.head_type; e.g. linear | mlp).")
+    parser.add_argument("--aux-head-out-activation", type=str, default=None,
+                        help="Head output activation (AuxHeadConfig.out_activation; e.g. sigmoid | identity).")
+    parser.add_argument("--aux-head-input-norm", type=str, default=None,
+                        help="Head input normalization (AuxHeadConfig.input_norm; e.g. none | layernorm).")
+    parser.add_argument("--aux-head-freeze-base", action="store_true", dest="aux_head_freeze_base",
+                        help="Freeze the base model (AuxHeadConfig.freeze_base=true).")
+    parser.add_argument("--no-aux-head-freeze-base", action="store_false", dest="aux_head_freeze_base",
+                        help="Unfreeze the base model for joint co-training (AuxHeadConfig.freeze_base=false).")
+    parser.add_argument("--aux-head-lm-loss-weight", type=float, default=None,
+                        help="Weight on the LM loss term in joint training (AuxHeadConfig.lm_loss_weight).")
+    parser.add_argument("--aux-head-head-lr", type=float, default=None,
+                        help="Optional explicit head learning rate (AuxHeadConfig.head_lr).")
+    parser.add_argument("--aux-head-prompt-render", type=str, default=None,
+                        help="SFT render/masking strategy "
+                             "(config.training.prompt_render; full_conversation | prompt_completion).")
+
     # Dataset parameters
     parser.add_argument("--dataset-name", type=str,
                        help="HuggingFace dataset name")
@@ -626,6 +668,52 @@ def run(args: argparse.Namespace):
                 f"(got {type(parsed_chat_template_kwargs).__name__})."
             )
         config.training.chat_template_kwargs = parsed_chat_template_kwargs
+    # aux_head CLI overrides (local-run lane). config.aux_head always exists
+    # (Config carries a default AuxHeadConfig), so each is a direct field set
+    # guarded by is not None — an unset flag preserves the loaded config exactly.
+    # NOTE: these overrides run AFTER load_aux_head_config, so the YAML-load
+    # coherence guards have already passed; the shared validate_aux_head_coherence
+    # call below re-runs them on the final (post-override) config to keep the CLI
+    # lane at parity with the YAML lane.
+    # prompt_render is grouped with the aux knobs for user intent but targets
+    # config.training (the render mode is a preprocessing strategy, not a head field).
+    if args.aux_head_enabled is not None:
+        config.aux_head.enabled = args.aux_head_enabled
+    if args.aux_head_layer is not None:
+        config.aux_head.layer = args.aux_head_layer
+    if args.aux_head_token_position is not None:
+        config.aux_head.token_position = args.aux_head_token_position
+    if args.aux_head_target_field is not None:
+        config.aux_head.target_field = args.aux_head_target_field
+    if args.aux_head_loss is not None:
+        config.aux_head.loss = args.aux_head_loss
+    if args.aux_head_head_type is not None:
+        config.aux_head.head_type = args.aux_head_head_type
+    if args.aux_head_out_activation is not None:
+        config.aux_head.out_activation = args.aux_head_out_activation
+    if args.aux_head_input_norm is not None:
+        config.aux_head.input_norm = args.aux_head_input_norm
+    if args.aux_head_freeze_base is not None:
+        config.aux_head.freeze_base = args.aux_head_freeze_base
+    if args.aux_head_lm_loss_weight is not None:
+        config.aux_head.lm_loss_weight = args.aux_head_lm_loss_weight
+    if args.aux_head_head_lr is not None:
+        config.aux_head.head_lr = args.aux_head_head_lr
+    if args.aux_head_prompt_render is not None:
+        config.training.prompt_render = args.aux_head_prompt_render
+    # Coherence parity with the YAML lane: the --aux-head-* overrides above mutate
+    # config.aux_head after load_aux_head_config ran, so a config assembled purely
+    # from CLI flags (e.g. --aux-head-enabled --no-aux-head-freeze-base, which
+    # reaches the freeze_base=false + lm_loss_weight=0 corner via the dataclass
+    # defaults) would otherwise reach training unvalidated. Same shared guard,
+    # same raise. Distinct from the prompt_render WARN below — both must hold.
+    validate_aux_head_coherence(
+        enabled=config.aux_head.enabled,
+        freeze_base=config.aux_head.freeze_base,
+        lm_loss_weight=config.aux_head.lm_loss_weight,
+        out_activation=config.aux_head.out_activation,
+        loss=config.aux_head.loss,
+    )
     if args.lora_r is not None:
         config.lora.r = args.lora_r
     if args.lora_alpha is not None:
@@ -827,6 +915,25 @@ def run(args: argparse.Namespace):
     aux_head_enabled = bool(aux_head_cfg is not None and aux_head_cfg.enabled)
     aux_target_field = aux_head_cfg.target_field if aux_head_enabled else None
 
+    # Faithfulness guard: token_position="end_of_prompt" reads the generation-anchor
+    # token only when the row was rendered prompt/completion-style. On a
+    # full_conversation row the boundary token is NOT the generation anchor (the
+    # assistant scaffold renders differently with vs. without add_generation_prompt),
+    # so the head reads an off-anchor representation. WARN (not error): the combo is
+    # legitimate for single-turn / inference-shaped rows whose two renders coincide.
+    if (
+        aux_head_enabled
+        and aux_head_cfg.token_position == "end_of_prompt"
+        and config.training.prompt_render == "full_conversation"
+    ):
+        print(
+            "\nWARNING: aux_head token_position='end_of_prompt' with "
+            "prompt_render='full_conversation' — the head may read an off-anchor "
+            "token because the assistant scaffold renders differently with vs. "
+            "without add_generation_prompt. Set training.prompt_render="
+            "'prompt_completion' for a faithful boundary.\n"
+        )
+
     # Materialize trainer-ready tokenized rows in-repo so cloud runs do not
     # depend on implicit TRL/Unsloth dataset preparation behavior.
     train_dataset, eval_dataset = load_and_prepare_tokenized_dataset(
@@ -842,6 +949,7 @@ def run(args: argparse.Namespace):
         loss_mask_mode=loss_mask_mode,
         chat_template_kwargs=config.training.chat_template_kwargs,
         aux_target_field=aux_target_field,
+        prompt_render=config.training.prompt_render,
     )
     run_metadata["train_size"] = len(train_dataset)
     run_metadata["eval_size"] = len(eval_dataset) if eval_dataset else None

--- a/shared/sft_preprocessing.py
+++ b/shared/sft_preprocessing.py
@@ -166,6 +166,7 @@ def materialize_sft_example(
     assistant_only_loss: bool,
     source_hash: str | None = None,
     chat_template_kwargs: dict[str, Any] | None = None,
+    prompt_render: str = "full_conversation",
 ) -> PreparedSFTExample:
     # chat_template_kwargs is forwarded verbatim into apply_chat_template (e.g.
     # {"enable_thinking": False} for thinking-capable models). Default None ⇒ empty
@@ -183,6 +184,70 @@ def materialize_sft_example(
     # Unwrap Processor → Tokenizer for multimodal models (Gemma 4, Qwen-VL, etc.)
     # Processors have apply_chat_template but lack encode(); the inner .tokenizer does.
     _encoder = getattr(tokenizer, "tokenizer", tokenizer)
+
+    # prompt_render selects the render/masking strategy. The default
+    # "full_conversation" path (below) renders the whole conversation with
+    # add_generation_prompt=False and derives the assistant-only mask by a prefix
+    # match. That prefix match breaks whenever a template renders the assistant
+    # scaffold differently with vs. without add_generation_prompt (e.g. one fewer
+    # newline around the header), so the masked boundary is not the generation
+    # anchor. The "prompt_completion" branch instead builds input_ids from the
+    # add_generation_prompt=True prompt render — so the prompt ends EXACTLY at the
+    # generation anchor — followed by the raw completion plus a derived terminal,
+    # masking the prompt segment to -100. It is gated strictly behind the
+    # non-default flag AND an assistant final turn, so every existing caller is
+    # byte-identical. template_kwargs are forwarded into the prompt-half render
+    # identically to the full-conversation render, so no new divergence axis is
+    # introduced; the completion half is encoded raw (no chat template).
+    if prompt_render == "prompt_completion" and messages[-1].get("role") == "assistant":
+        prompt_str = tokenizer.apply_chat_template(
+            messages[:-1],
+            tokenize=False,
+            add_generation_prompt=True,
+            **template_kwargs,
+        )
+        prompt_ids = _encoder.encode(prompt_str, add_special_tokens=False)
+
+        completion_text = messages[-1].get("content")
+        if not isinstance(completion_text, str):
+            raise ValueError(
+                "prompt_render='prompt_completion' requires the final assistant "
+                "message content to be a string after sanitization, got "
+                f"{type(completion_text).__name__}."
+            )
+        # Terminal is DERIVED from the tokenizer (never a hardcoded literal) so the
+        # completion closes with the model's own end-of-turn id. Read from the
+        # encoder whose vocabulary produced the ids, falling back to the outer
+        # tokenizer (Processor wrappers proxy this); loud if neither defines it.
+        terminal_id = getattr(_encoder, "eos_token_id", None)
+        if terminal_id is None:
+            terminal_id = getattr(tokenizer, "eos_token_id", None)
+        if terminal_id is None:
+            raise ValueError(
+                "prompt_render='prompt_completion' requires the tokenizer to define "
+                "eos_token_id (the completion terminal is derived from it, never "
+                "hardcoded)."
+            )
+        completion_ids = (
+            _encoder.encode(completion_text, add_special_tokens=False) + [terminal_id]
+        )
+
+        full_ids = prompt_ids + completion_ids
+        truncation_applied = len(full_ids) > max_seq_length
+        input_ids = list(full_ids[:max_seq_length])
+        attention_mask = [1] * len(input_ids)
+        # Mask the prompt segment; every completion token (incl. the terminal)
+        # carries a real label. Right-trim mirrors the full-conversation contract.
+        labels = ([-100] * len(prompt_ids) + completion_ids)[:max_seq_length]
+        return PreparedSFTExample(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            example_format=example_format,
+            loss_mask_mode="assistant_only",
+            truncation_applied=truncation_applied,
+            source_hash=source_hash,
+        )
 
     full_str = tokenizer.apply_chat_template(
         messages,

--- a/tests/cli/test_local_run_handler.py
+++ b/tests/cli/test_local_run_handler.py
@@ -39,7 +39,7 @@ def test_local_run_sft_config_compiles_repo_relative_dataset(tmp_path):
     assert plan["host_artifact_path"].name == "unit"
 
 
-def _compile_local_command(tmp_path, *, method, trainer, training, lora=None):
+def _compile_local_command(tmp_path, *, method, trainer, training, lora=None, aux_head=None):
     """Compile a local-docker recipe and return the built trainer command list."""
     dataset = tmp_path / "data.jsonl"
     dataset.write_text('{"conversations":[]}\n', encoding="utf-8")
@@ -59,6 +59,8 @@ def _compile_local_command(tmp_path, *, method, trainer, training, lora=None):
     }
     if lora is not None:
         recipe["lora"] = lora
+    if aux_head is not None:
+        recipe["aux_head"] = aux_head
     config.write_text(yaml.safe_dump(recipe), encoding="utf-8")
     handler = LocalRunHandler(args=Namespace(json=True, job_config=str(config)))
     plan = handler._compile(config, handler._load_yaml(config))
@@ -261,3 +263,81 @@ def test_local_run_dpo_omits_chat_template_kwargs(tmp_path):
         training={"max_steps": 1, "beta": 0.05, "chat_template_kwargs": {"enable_thinking": False}},
     )
     assert "--chat-template-kwargs" not in command
+
+
+def test_local_run_sft_omits_aux_head_flags_when_absent(tmp_path):
+    # Byte-identical for recipes with no aux_head block and no training.prompt_render:
+    # zero --aux-head-* flags emitted (the whole point of the gated forwarding).
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1},
+    )
+    assert not any(arg.startswith("--aux-head-") for arg in command)
+    assert "--no-aux-head-enabled" not in command
+
+
+def test_local_run_sft_forwards_aux_head_block(tmp_path):
+    # An aux_head block forwards field-by-field; enabled/freeze_base use the
+    # tri-state --flag/--no-flag form; prompt_render rides training, not aux_head.
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "prompt_render": "prompt_completion"},
+        aux_head={
+            "enabled": True,
+            "layer": 35,
+            "token_position": "end_of_prompt",
+            "target_field": "score",
+            "loss": "bce",
+            "head_type": "linear",
+            "out_activation": "sigmoid",
+            "input_norm": "layernorm",
+            "freeze_base": False,
+            "lm_loss_weight": 1.0,
+            "head_lr": 0.005,
+        },
+    )
+    assert "--aux-head-enabled" in command
+    assert "--no-aux-head-freeze-base" in command
+    assert command[command.index("--aux-head-layer") + 1] == "35"
+    assert command[command.index("--aux-head-token-position") + 1] == "end_of_prompt"
+    assert command[command.index("--aux-head-target-field") + 1] == "score"
+    assert command[command.index("--aux-head-loss") + 1] == "bce"
+    assert command[command.index("--aux-head-head-type") + 1] == "linear"
+    assert command[command.index("--aux-head-out-activation") + 1] == "sigmoid"
+    assert command[command.index("--aux-head-input-norm") + 1] == "layernorm"
+    assert command[command.index("--aux-head-lm-loss-weight") + 1] == "1.0"
+    assert command[command.index("--aux-head-head-lr") + 1] == "0.005"
+    assert command[command.index("--aux-head-prompt-render") + 1] == "prompt_completion"
+
+
+def test_local_run_sft_forwards_falsy_aux_head_values(tmp_path):
+    # A set-but-falsy lm_loss_weight (0.0) and an explicit enabled: false must
+    # still forward (provenance: the trainer must run the recipe's exact values).
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1},
+        aux_head={"enabled": False, "lm_loss_weight": 0.0},
+    )
+    assert "--no-aux-head-enabled" in command
+    assert command[command.index("--aux-head-lm-loss-weight") + 1] == "0.0"
+
+
+def test_local_run_sft_forwards_prompt_render_without_aux_head_block(tmp_path):
+    # prompt_render is a training-config knob, forwarded independently of the
+    # aux_head block (a plain SFT recipe may want the faithful render).
+    command = _compile_local_command(
+        tmp_path, method="sft", trainer="Trainers/sft/train_sft.py",
+        training={"max_steps": 1, "prompt_render": "prompt_completion"},
+    )
+    assert command[command.index("--aux-head-prompt-render") + 1] == "prompt_completion"
+
+
+def test_local_run_dpo_omits_aux_head_flags(tmp_path):
+    # aux_head forwarding is sft-only: a stray aux_head block in a dpo recipe must
+    # not be forwarded (the dpo trainer exposes no --aux-head-* flags).
+    command = _compile_local_command(
+        tmp_path, method="dpo", trainer="Trainers/dpo/train_dpo.py",
+        training={"max_steps": 1, "beta": 0.05, "prompt_render": "prompt_completion"},
+        aux_head={"enabled": True, "layer": 35},
+    )
+    assert not any(arg.startswith("--aux-head-") for arg in command)

--- a/tests/trainers/sft/test_aux_head_config.py
+++ b/tests/trainers/sft/test_aux_head_config.py
@@ -18,7 +18,12 @@ ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "configs"))
 
 import config_loader  # noqa: E402
-from config_loader import AuxHeadConfig, Config, load_aux_head_config  # noqa: E402
+from config_loader import (  # noqa: E402
+    AuxHeadConfig,
+    Config,
+    load_aux_head_config,
+    validate_aux_head_coherence,
+)
 
 
 def test_absent_block_yields_disabled_default():
@@ -131,6 +136,73 @@ def test_coherent_phase_configs_still_load():
         {"enabled": True, "layer": 35, "freeze_base": False, "lm_loss_weight": 1.0}
     )
     assert phase_b.freeze_base is False and phase_b.lm_loss_weight == 1.0
+
+
+# --- validate_aux_head_coherence: direct unit tests -------------------------
+# The same guard is reused by both the YAML-load path (load_aux_head_config,
+# exercised above) and the CLI-override path (train_sft.run). These tests pin
+# the shared function directly so the CLI lane is covered without importing
+# train_sft (which imports unsloth and cannot load in-process).
+
+
+@pytest.mark.parametrize(
+    "freeze_base, lm_loss_weight",
+    [
+        (False, 0.0),  # co-train base on head loss alone, no LM anchor
+        (True, 1.0),   # weighted LM term with no gradient (base frozen)
+    ],
+)
+def test_validate_coherence_rejects_incoherent_phase(freeze_base, lm_loss_weight):
+    with pytest.raises(ValueError, match="must agree on the phase"):
+        validate_aux_head_coherence(
+            enabled=True,
+            freeze_base=freeze_base,
+            lm_loss_weight=lm_loss_weight,
+            out_activation="sigmoid",
+            loss="bce",
+        )
+
+
+@pytest.mark.parametrize(
+    "freeze_base, lm_loss_weight",
+    [
+        (True, 0.0),   # frozen base, head-only — Phase A
+        (False, 1.0),  # unfrozen base, weighted LM term — Phase B
+    ],
+)
+def test_validate_coherence_accepts_coherent_phase(freeze_base, lm_loss_weight):
+    # No raise on either valid phase combination.
+    validate_aux_head_coherence(
+        enabled=True,
+        freeze_base=freeze_base,
+        lm_loss_weight=lm_loss_weight,
+        out_activation="sigmoid",
+        loss="bce",
+    )
+
+
+@pytest.mark.parametrize("loss", ["bce", "brier"])
+def test_validate_coherence_rejects_identity_with_probability_loss(loss):
+    with pytest.raises(ValueError, match="out_activation='identity' is incompatible"):
+        validate_aux_head_coherence(
+            enabled=True,
+            freeze_base=True,
+            lm_loss_weight=0.0,
+            out_activation="identity",
+            loss=loss,
+        )
+
+
+def test_validate_coherence_is_noop_when_disabled():
+    # A disabled head has inert fields — even an otherwise-incoherent combination
+    # must not raise (mirrors the enabled-gated YAML-load behavior).
+    validate_aux_head_coherence(
+        enabled=False,
+        freeze_base=False,
+        lm_loss_weight=0.0,
+        out_activation="identity",
+        loss="bce",
+    )
 
 
 def test_config_has_real_aux_head_field_so_block_is_not_silently_dropped():

--- a/tests/trainers/sft/test_aux_head_config.py
+++ b/tests/trainers/sft/test_aux_head_config.py
@@ -160,6 +160,7 @@ def test_validate_coherence_rejects_incoherent_phase(freeze_base, lm_loss_weight
             lm_loss_weight=lm_loss_weight,
             out_activation="sigmoid",
             loss="bce",
+            layer=35,
         )
 
 
@@ -178,6 +179,7 @@ def test_validate_coherence_accepts_coherent_phase(freeze_base, lm_loss_weight):
         lm_loss_weight=lm_loss_weight,
         out_activation="sigmoid",
         loss="bce",
+        layer=35,
     )
 
 
@@ -190,18 +192,51 @@ def test_validate_coherence_rejects_identity_with_probability_loss(loss):
             lm_loss_weight=0.0,
             out_activation="identity",
             loss=loss,
+            layer=35,
         )
 
 
 def test_validate_coherence_is_noop_when_disabled():
     # A disabled head has inert fields — even an otherwise-incoherent combination
-    # must not raise (mirrors the enabled-gated YAML-load behavior).
+    # (incl. a missing layer) must not raise (mirrors the enabled-gated
+    # YAML-load behavior).
     validate_aux_head_coherence(
         enabled=False,
         freeze_base=False,
         lm_loss_weight=0.0,
         out_activation="identity",
         loss="bce",
+        layer=None,
+    )
+
+
+@pytest.mark.parametrize("loss", ["bce", "brier"])
+def test_validate_coherence_rejects_missing_layer_when_enabled(loss):
+    # A-M1 parity: an enabled head with no layer must raise EARLY + DESCRIPTIVE
+    # on BOTH lanes. The flag-only runner lane never calls load_aux_head_config,
+    # so this presence guard must live in the shared validator (not inline in the
+    # loader) or that lane would crash late at hidden_states[None].
+    with pytest.raises(ValueError, match="requires aux_head.layer to be set"):
+        validate_aux_head_coherence(
+            enabled=True,
+            freeze_base=True,
+            lm_loss_weight=0.0,
+            out_activation="sigmoid",
+            loss=loss,
+            layer=None,
+        )
+
+
+def test_validate_coherence_accepts_layer_when_enabled():
+    # The presence guard passes once a layer is named (no raise on an otherwise
+    # coherent enabled head).
+    validate_aux_head_coherence(
+        enabled=True,
+        freeze_base=True,
+        lm_loss_weight=0.0,
+        out_activation="sigmoid",
+        loss="bce",
+        layer=0,
     )
 
 

--- a/tests/trainers/sft/test_aux_head_integration.py
+++ b/tests/trainers/sft/test_aux_head_integration.py
@@ -23,6 +23,7 @@ from pathlib import Path
 import pytest
 
 ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
 sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "configs"))
 
@@ -328,6 +329,118 @@ def test_gradient_flows_into_base_from_head_alone_under_checkpointing(tmp_path):
     assert pre_read_param.grad is not None
     assert torch.count_nonzero(pre_read_param.grad) > 0
 
+    head_param = next(head.parameters())
+    assert head_param.grad is not None
+    assert torch.count_nonzero(head_param.grad) > 0
+
+
+class _MinimalRenderTokenizer:
+    """Tiny tokenizer that renders rows short enough for the tiny model's position
+    budget while still exercising the prompt_completion render path end to end.
+
+    The generation-prompt render appends a single ``G`` anchor; encode maps chars
+    into ``[3, VOCAB)`` so ids never collide with pad (0) or the eos terminal (2).
+    """
+
+    eos_token_id = 2
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        body = "".join(str(m["content"]) for m in messages)
+        if add_generation_prompt:
+            body += "G"
+        return body
+
+    def encode(self, text, add_special_tokens=False):
+        return [3 + (ord(char) % (VOCAB - 3)) for char in text]
+
+
+def test_joint_step_trains_through_prompt_completion_rendered_rows(tmp_path):
+    # §3.4: a joint step (freeze_base=false, lm_loss_weight>0) over rows produced
+    # by the prompt_completion render mode runs end to end and produces BOTH head
+    # and base gradients, with token_position="end_of_prompt" reading the faithful
+    # boundary the new render guarantees (prompt_end_indices recovers it from the
+    # leading -100 run, undisturbed by trailing pad). Extends the §2.5 path to the
+    # new render mode (acceptance #4).
+    from shared.sft_preprocessing import materialize_sft_example
+
+    tokenizer = _MinimalRenderTokenizer()
+    raw = []
+    for i in range(8):
+        prepared = materialize_sft_example(
+            tokenizer=tokenizer,
+            record={
+                "messages": [
+                    {"role": "user", "content": "q"},
+                    {"role": "assistant", "content": "a" if i % 2 == 0 else "b"},
+                ]
+            },
+            max_seq_length=SEQ,
+            assistant_only_loss=True,
+            prompt_render="prompt_completion",
+        )
+        raw.append((prepared, 1.0 if i % 2 == 0 else 0.0))
+
+    # Every render must carry a masked prompt prefix AND at least one real label,
+    # otherwise end_of_prompt degenerates to "last" and the test is vacuous.
+    for prepared, _ in raw:
+        assert -100 in prepared.labels
+        assert any(label != -100 for label in prepared.labels)
+
+    max_len = max(len(prepared.input_ids) for prepared, _ in raw)
+    rows = []
+    for prepared, target in raw:
+        pad = max_len - len(prepared.input_ids)
+        rows.append(
+            {
+                "input_ids": prepared.input_ids + [0] * pad,
+                "attention_mask": prepared.attention_mask + [0] * pad,
+                "labels": prepared.labels + [-100] * pad,
+                "aux_target": target,
+            }
+        )
+
+    model = _tiny_causal_lm()
+    head = AuxHead(input_dim=HIDDEN, head_type="linear")
+    cfg = AuxHeadConfig(
+        enabled=True,
+        layer=READ_LAYER,
+        token_position="end_of_prompt",
+        target_field="aux_target",
+        loss="bce",
+        head_type="linear",
+        freeze_base=False,
+        lm_loss_weight=1.0,
+    )
+    args = TrainingArguments(
+        output_dir=str(tmp_path / "out"),
+        use_cpu=True,
+        remove_unused_columns=False,
+        per_device_train_batch_size=4,
+        max_steps=1,
+        learning_rate=0.1,
+        logging_steps=1,
+        save_strategy="no",
+        report_to="none",
+        seed=0,
+    )
+    trainer = AuxHeadTrainer(
+        model=model,
+        args=args,
+        data_collator=_collate,
+        train_dataset=_RowDataset(),
+        aux_head=head,
+        aux_head_config=cfg,
+    )
+
+    batch = _collate(rows[:4])
+    loss, outputs = trainer.compute_loss(model, batch, return_outputs=True)
+    model.zero_grad(set_to_none=True)
+    loss.backward()
+
+    # Joint loss (LM + head) must reach BOTH a pre-read base param and the head.
+    pre_read_param = model.model.layers[0].self_attn.q_proj.weight
+    assert pre_read_param.grad is not None
+    assert torch.count_nonzero(pre_read_param.grad) > 0
     head_param = next(head.parameters())
     assert head_param.grad is not None
     assert torch.count_nonzero(head_param.grad) > 0

--- a/tests/trainers/sft/test_aux_head_prompt_completion_render.py
+++ b/tests/trainers/sft/test_aux_head_prompt_completion_render.py
@@ -1,0 +1,232 @@
+"""Tests for the prompt_completion render mode in SFT preprocessing.
+
+Location: tests/trainers/sft/test_aux_head_prompt_completion_render.py
+
+The default "full_conversation" render masks the assistant-only region by a
+prefix match against the add_generation_prompt=True prompt render. When a chat
+template renders the assistant scaffold differently with vs. without
+add_generation_prompt (e.g. one fewer newline), that masked boundary is NOT the
+generation-anchor token. The "prompt_completion" mode builds input_ids from the
+add_generation_prompt=True prompt render directly, so the boundary token is the
+generation anchor exactly.
+
+These tests use a tokenizer that deliberately DIVERGES between the two render
+modes (mirroring the Qwen3 scaffold divergence) to prove:
+  * the prompt_completion boundary token IS the generation anchor (faithful),
+  * the full_conversation boundary token is NOT (the bug the mode fixes),
+  * the prompt segment is fully masked and every completion token (incl. the
+    derived terminal) carries a real label,
+  * the terminal is derived from the tokenizer (loud when undefined),
+  * the default mode is byte-identical to the historical full_conversation path,
+  * the mode threads through the prepare_sft_dataset wrapper hop.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from datasets import Dataset
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "Trainers" / "sft" / "src"))
+
+from shared.sft_preprocessing import materialize_sft_example  # noqa: E402
+
+preprocessing = pytest.importorskip("preprocessing")
+
+
+class _DivergingTokenizer:
+    """Renders the assistant scaffold differently in the two render modes.
+
+    add_generation_prompt=True ends the prompt with a double-newline generation
+    anchor (``<assistant>\\n\\n``); the full-conversation render (the assistant
+    turn with add_generation_prompt=False) emits ``<assistant>{content}`` with no
+    such scaffold, so the two renders diverge right at the boundary — exactly the
+    structural divergence that breaks the prefix-match mask on real templates.
+    """
+
+    eos_token_id = 999
+
+    def apply_chat_template(self, messages, tokenize=False, add_generation_prompt=False):
+        assert tokenize is False
+        body = "".join(f"<{m['role']}>{m['content']}" for m in messages)
+        if add_generation_prompt:
+            body += "<assistant>\n\n"
+        return body
+
+    def encode(self, text, add_special_tokens=False):
+        assert add_special_tokens is False
+        return [ord(char) for char in text]
+
+
+class _NoEosTokenizer(_DivergingTokenizer):
+    eos_token_id = None
+
+
+def _row():
+    return {
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "there"},
+        ]
+    }
+
+
+def _materialize(tokenizer, *, prompt_render, max_seq_length=128):
+    return materialize_sft_example(
+        tokenizer=tokenizer,
+        record=_row(),
+        max_seq_length=max_seq_length,
+        assistant_only_loss=True,
+        prompt_render=prompt_render,
+    )
+
+
+def test_prompt_completion_boundary_is_the_generation_anchor():
+    tokenizer = _DivergingTokenizer()
+    prompt_str = tokenizer.apply_chat_template(
+        _row()["messages"][:-1], tokenize=False, add_generation_prompt=True
+    )
+    prompt_ids = tokenizer.encode(prompt_str, add_special_tokens=False)
+
+    prepared = _materialize(tokenizer, prompt_render="prompt_completion")
+
+    # The input_ids prefix is byte-for-byte the generation-prompt render, so the
+    # boundary token (index len(prompt)-1) IS the generation anchor's last token.
+    assert prepared.input_ids[: len(prompt_ids)] == prompt_ids
+    assert prepared.input_ids[len(prompt_ids) - 1] == prompt_ids[-1]
+
+
+def test_full_conversation_boundary_is_not_the_generation_anchor():
+    # Contrast: on the same diverging template, the default render masks a prefix
+    # that ends BEFORE the generation anchor, so its boundary token differs from
+    # the prompt_completion (faithful) boundary token. This is the defect that
+    # motivated the new mode — asserted here so a template change that silently
+    # collapses the divergence is caught.
+    tokenizer = _DivergingTokenizer()
+    prompt_str = tokenizer.apply_chat_template(
+        _row()["messages"][:-1], tokenize=False, add_generation_prompt=True
+    )
+    anchor_last = tokenizer.encode(prompt_str, add_special_tokens=False)[-1]
+
+    full = _materialize(tokenizer, prompt_render="full_conversation")
+    masked_len = sum(1 for label in full.labels if label == -100)
+    full_boundary = full.input_ids[masked_len - 1]
+
+    assert full_boundary != anchor_last
+
+
+def test_prompt_completion_masks_prompt_and_labels_completion():
+    tokenizer = _DivergingTokenizer()
+    prompt_str = tokenizer.apply_chat_template(
+        _row()["messages"][:-1], tokenize=False, add_generation_prompt=True
+    )
+    prompt_ids = tokenizer.encode(prompt_str, add_special_tokens=False)
+    completion_ids = tokenizer.encode("there", add_special_tokens=False) + [tokenizer.eos_token_id]
+
+    prepared = _materialize(tokenizer, prompt_render="prompt_completion")
+
+    # Every prompt token masked; every completion token (incl. the terminal) kept.
+    assert prepared.labels[: len(prompt_ids)] == [-100] * len(prompt_ids)
+    assert prepared.labels[len(prompt_ids) :] == completion_ids
+    assert prepared.input_ids[len(prompt_ids) :] == completion_ids
+    assert prepared.attention_mask == [1] * len(prepared.input_ids)
+    assert prepared.loss_mask_mode == "assistant_only"
+
+
+def test_prompt_completion_terminal_is_derived_eos():
+    tokenizer = _DivergingTokenizer()
+    prepared = _materialize(tokenizer, prompt_render="prompt_completion")
+    assert prepared.input_ids[-1] == tokenizer.eos_token_id
+    assert prepared.labels[-1] == tokenizer.eos_token_id
+
+
+def test_prompt_completion_requires_eos_token_id():
+    with pytest.raises(ValueError, match="eos_token_id"):
+        _materialize(_NoEosTokenizer(), prompt_render="prompt_completion")
+
+
+def test_prompt_completion_truncates_to_max_seq_length():
+    tokenizer = _DivergingTokenizer()
+    prepared = _materialize(tokenizer, prompt_render="prompt_completion", max_seq_length=4)
+    assert len(prepared.input_ids) == 4
+    assert len(prepared.labels) == 4
+    assert len(prepared.attention_mask) == 4
+    assert prepared.truncation_applied is True
+
+
+def test_default_mode_is_byte_identical_to_full_conversation():
+    # The new parameter defaults to "full_conversation"; an explicit pass and the
+    # default must produce identical output, and neither may touch the historical
+    # contract (input_ids/labels/attention_mask/loss_mask_mode).
+    tokenizer = _DivergingTokenizer()
+    explicit = _materialize(tokenizer, prompt_render="full_conversation")
+    default = materialize_sft_example(
+        tokenizer=_DivergingTokenizer(),
+        record=_row(),
+        max_seq_length=128,
+        assistant_only_loss=True,
+    )
+    assert explicit.to_dict() == default.to_dict()
+
+
+def test_non_assistant_final_turn_falls_through_to_full_conversation():
+    # The branch is gated on an assistant final turn; a prompt-only (user-final)
+    # row under prompt_completion must fall through to the default render, not
+    # raise. Mirrors the inference-shaped-row carve-out.
+    tokenizer = _DivergingTokenizer()
+    record = {"messages": [{"role": "user", "content": "hello"}]}
+    prepared = materialize_sft_example(
+        tokenizer=tokenizer,
+        record=record,
+        max_seq_length=128,
+        assistant_only_loss=True,
+        prompt_render="prompt_completion",
+    )
+    # Full-conversation fallthrough: no assistant turn ⇒ full_sequence mask mode.
+    assert prepared.loss_mask_mode == "full_sequence"
+
+
+def test_prompt_render_threads_through_prepare_sft_dataset():
+    # The wrapper hop must forward prompt_render to the seam: a prompt_completion
+    # dataset row terminates with the derived eos, which the full_conversation
+    # render never appends.
+    dataset = Dataset.from_list([_row(), _row()])
+    prepared = preprocessing.prepare_sft_dataset(
+        dataset,
+        tokenizer=_DivergingTokenizer(),
+        max_seq_length=128,
+        loss_mask_mode="assistant_only",
+        prompt_render="prompt_completion",
+    )
+    assert prepared[0]["input_ids"][-1] == _DivergingTokenizer.eos_token_id
+    assert prepared[0]["labels"][-1] == _DivergingTokenizer.eos_token_id
+
+
+def test_aux_target_threads_through_under_prompt_completion_render():
+    # The aux_target is read one layer up in prepare_sft_dataset (before the
+    # original columns are dropped), independent of the render mode. This pins
+    # that the prompt_completion render and the aux_target threading coexist: the
+    # row carries its per-row target AND terminates with the derived eos.
+    rows = [
+        {**_row(), "target": 0.25},
+        {**_row(), "target": 0.75},
+    ]
+    dataset = Dataset.from_list(rows)
+    prepared = preprocessing.prepare_sft_dataset(
+        dataset,
+        tokenizer=_DivergingTokenizer(),
+        max_seq_length=128,
+        loss_mask_mode="assistant_only",
+        aux_target_field="target",
+        prompt_render="prompt_completion",
+    )
+    # aux_target survives the column drop and matches each row's value.
+    assert prepared[0]["aux_target"] == pytest.approx(0.25)
+    assert prepared[1]["aux_target"] == pytest.approx(0.75)
+    # And the render mode still applied (derived-eos terminal on the same rows).
+    assert prepared[0]["input_ids"][-1] == _DivergingTokenizer.eos_token_id
+    assert prepared[0]["labels"][-1] == _DivergingTokenizer.eos_token_id

--- a/tests/trainers/sft/test_chat_template_kwargs_passthrough.py
+++ b/tests/trainers/sft/test_chat_template_kwargs_passthrough.py
@@ -117,6 +117,31 @@ def test_default_none_forwards_no_kwargs_byte_identical():
         assert call["kwargs"] == {}
 
 
+def test_prompt_completion_forwards_kwargs_to_single_prompt_render():
+    # In prompt_completion mode the prompt is rendered ONCE
+    # (add_generation_prompt=True) and the completion is encoded raw (no template),
+    # so there is exactly one apply_chat_template call and it must carry the
+    # forwarded kwargs — the new branch must not introduce a kwargs-divergent
+    # render relative to the full_conversation path.
+    class _RecordingTokenizerWithEos(_RecordingTokenizer):
+        eos_token_id = 7
+
+    tokenizer = _RecordingTokenizerWithEos()
+
+    materialize_sft_example(
+        tokenizer=tokenizer,
+        record=_EXAMPLE,
+        max_seq_length=128,
+        assistant_only_loss=True,
+        chat_template_kwargs={"enable_thinking": False},
+        prompt_render="prompt_completion",
+    )
+
+    assert len(tokenizer.calls) == 1
+    assert tokenizer.calls[0]["add_generation_prompt"] is True
+    assert tokenizer.calls[0]["kwargs"] == {"enable_thinking": False}
+
+
 def test_preprocessing_wrappers_thread_chat_template_kwargs():
     """The SFT-facing wrappers forward the kwarg down to materialize."""
     tokenizer = _RecordingTokenizer()

--- a/tests/trainers/sft/test_train_sft_source.py
+++ b/tests/trainers/sft/test_train_sft_source.py
@@ -64,3 +64,105 @@ def test_train_sft_honors_config_level_max_steps() -> None:
     assert "config.training.max_steps = args.max_steps" in source
     assert 'effective_max_steps = getattr(config.training, "max_steps", None) or -1' in source
     assert '"max_steps": effective_max_steps' in source
+
+
+def test_train_sft_exposes_aux_head_cli_flags() -> None:
+    # train_sft imports unsloth at module load, so verify the local-run lane's
+    # aux_head argparse surface at the source level. All 12 flags must exist so
+    # the recipe handler can forward an aux_head block end-to-end.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+
+    for flag in (
+        '"--aux-head-enabled"',
+        '"--no-aux-head-enabled"',
+        '"--aux-head-layer"',
+        '"--aux-head-token-position"',
+        '"--aux-head-target-field"',
+        '"--aux-head-loss"',
+        '"--aux-head-head-type"',
+        '"--aux-head-out-activation"',
+        '"--aux-head-input-norm"',
+        '"--aux-head-freeze-base"',
+        '"--no-aux-head-freeze-base"',
+        '"--aux-head-lm-loss-weight"',
+        '"--aux-head-head-lr"',
+        '"--aux-head-prompt-render"',
+    ):
+        assert flag in source, f"SFT trainer missing aux_head flag: {flag}"
+    # Tri-state booleans default to None so absence never collapses to False.
+    assert "aux_head_enabled=None" in source
+    assert "aux_head_freeze_base=None" in source
+
+
+def test_train_sft_aux_head_overrides_use_is_not_none() -> None:
+    # Each aux_head override must be is-not-None guarded so an unset flag preserves
+    # the loaded config (and a falsy-but-set value like lm_loss_weight=0.0 still
+    # forwards). prompt_render is grouped with the aux knobs but targets training.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+
+    for guard in (
+        "if args.aux_head_enabled is not None:",
+        "if args.aux_head_layer is not None:",
+        "if args.aux_head_token_position is not None:",
+        "if args.aux_head_target_field is not None:",
+        "if args.aux_head_loss is not None:",
+        "if args.aux_head_head_type is not None:",
+        "if args.aux_head_out_activation is not None:",
+        "if args.aux_head_input_norm is not None:",
+        "if args.aux_head_freeze_base is not None:",
+        "if args.aux_head_lm_loss_weight is not None:",
+        "if args.aux_head_head_lr is not None:",
+        "if args.aux_head_prompt_render is not None:",
+    ):
+        assert guard in source, f"SFT trainer missing aux_head override guard: {guard}"
+    assert "config.aux_head.enabled = args.aux_head_enabled" in source
+    assert "config.training.prompt_render = args.aux_head_prompt_render" in source
+
+
+def test_train_sft_threads_prompt_render_and_warns_on_off_anchor_combo() -> None:
+    # prompt_render must reach the dataset-prep call, and the off-anchor combo
+    # (end_of_prompt + full_conversation) must WARN (not error) since it is
+    # legitimate for single-turn / inference-shaped rows.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+    config_source = (
+        REPO_ROOT / "Trainers" / "sft" / "configs" / "config_loader.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'prompt_render: str = "full_conversation"' in config_source
+    assert "prompt_render=config.training.prompt_render" in source
+    assert 'aux_head_cfg.token_position == "end_of_prompt"' in source
+    assert 'config.training.prompt_render == "full_conversation"' in source
+    assert "WARNING: aux_head token_position='end_of_prompt'" in source
+
+
+def test_train_sft_revalidates_aux_head_coherence_after_cli_overrides() -> None:
+    # Finding A remediation: the --aux-head-* overrides mutate config.aux_head
+    # AFTER load_aux_head_config has run, so the YAML-load coherence guards would
+    # otherwise be bypassed by a pure-CLI config. train_sft must re-run the shared
+    # validate_aux_head_coherence on the post-override config. Asserted at source
+    # level because train_sft imports unsloth and cannot load in-process.
+    source = (REPO_ROOT / "Trainers" / "sft" / "train_sft.py").read_text(encoding="utf-8")
+
+    # Imported from the shared config module (single implementation, no dup guard).
+    assert "validate_aux_head_coherence" in source
+    assert "validate_aux_head_coherence(" in source
+    # The call reads the post-override config (not argparse fields).
+    assert "enabled=config.aux_head.enabled" in source
+    assert "freeze_base=config.aux_head.freeze_base" in source
+    assert "lm_loss_weight=config.aux_head.lm_loss_weight" in source
+    assert "out_activation=config.aux_head.out_activation" in source
+    assert "loss=config.aux_head.loss" in source
+
+    # Ordering: the guard must run AFTER the last aux_head CLI override so it sees
+    # the final config. The prompt_render override is the last line of the block.
+    last_override_idx = source.index(
+        "config.training.prompt_render = args.aux_head_prompt_render"
+    )
+    guard_call_idx = source.index("validate_aux_head_coherence(\n        enabled=")
+    assert guard_call_idx > last_override_idx, (
+        "coherence guard must be called after the aux_head CLI-override block"
+    )
+
+    # The B-M1 ERROR guard is DISTINCT from the prompt_render WARN guard — both
+    # must coexist; the remediation must not merge or remove the WARN.
+    assert "WARNING: aux_head token_position='end_of_prompt'" in source

--- a/tests/trainers/sft/test_train_sft_source.py
+++ b/tests/trainers/sft/test_train_sft_source.py
@@ -152,6 +152,10 @@ def test_train_sft_revalidates_aux_head_coherence_after_cli_overrides() -> None:
     assert "lm_loss_weight=config.aux_head.lm_loss_weight" in source
     assert "out_activation=config.aux_head.out_activation" in source
     assert "loss=config.aux_head.loss" in source
+    # A-M1 lane parity: the shared validator now also enforces layer-presence, so
+    # the CLI lane must thread config.aux_head.layer (set from --aux-head-layer)
+    # into the same call — otherwise the flag-only runner lane skips the check.
+    assert "layer=config.aux_head.layer" in source
 
     # Ordering: the guard must run AFTER the last aux_head CLI override so it sees
     # the final config. The prompt_render override is the last line of the block.

--- a/tuner/handlers/local_run_handler.py
+++ b/tuner/handlers/local_run_handler.py
@@ -88,6 +88,19 @@ def _append_flag(args: list[str], key: str, value: Any) -> None:
     args.extend([flag, str(value)])
 
 
+def _append_bool_flag(args: list[str], key: str, value: Any) -> None:
+    """Emit a tri-state boolean as ``--flag`` / ``--no-flag`` (None ⇒ omit).
+
+    Mirrors train_sft.py's paired store_true/store_false dest pattern (e.g.
+    --load-in-4bit / --no-load-in-4bit) so a recipe can express False explicitly
+    without absence collapsing to False. Distinct from :func:`_append_flag`, whose
+    bool path can only emit the positive ``--flag`` and silently drops False.
+    """
+    if value is None:
+        return
+    args.append(_flag_name(key) if bool(value) else _flag_name("no_" + key))
+
+
 def _validate_user_field(raw: Any) -> str:
     """Normalize the ``job.user`` YAML value.
 
@@ -716,6 +729,35 @@ class LocalRunHandler(BaseHandler):
                 command.extend(
                     ["--chat-template-kwargs", json.dumps(chat_template_kwargs)]
                 )
+
+            # aux_head block forwarding (sft-only; the dpo/kto trainers expose no
+            # --aux-head-* flags). Forwarded field-by-field ONLY when the recipe
+            # carries an aux_head block, so recipes without one emit ZERO new flags
+            # and stay byte-identical. enabled/freeze_base are tri-state booleans
+            # (--flag/--no-flag) so a recipe can set them False explicitly; the
+            # scalar/str/numeric knobs ride the _append_flag None⇒omit path (a
+            # falsy-but-set value like lm_loss_weight: 0.0 is still forwarded).
+            aux_head_cfg = cfg.get("aux_head")
+            if isinstance(aux_head_cfg, dict):
+                _append_bool_flag(command, "aux_head_enabled", aux_head_cfg.get("enabled"))
+                _append_bool_flag(command, "aux_head_freeze_base", aux_head_cfg.get("freeze_base"))
+                for field_name in (
+                    "layer",
+                    "token_position",
+                    "target_field",
+                    "loss",
+                    "head_type",
+                    "out_activation",
+                    "input_norm",
+                    "lm_loss_weight",
+                    "head_lr",
+                ):
+                    _append_flag(command, "aux_head_" + field_name, aux_head_cfg.get(field_name))
+            # prompt_render is a training-config preprocessing knob (it replaces the
+            # masking region, so it lives on training, not aux_head), forwarded via
+            # the aux-head-grouped flag independently of the aux_head block. Unset
+            # ⇒ omitted ⇒ byte-identical for every existing recipe.
+            _append_flag(command, "aux_head_prompt_render", training_cfg.get("prompt_render"))
 
         # beta forwards only for dpo/kto (sft has no --beta argparse). is not None
         # so an explicit beta: 0.0 is honored, not silently swapped for the trainer


### PR DESCRIPTION
## Summary

Two bundled deliverables on the aux_head Phase B launch path (engine handoff 0029), plus a Finding-A guard surfaced during TEST.

**Item 1 — `prompt_completion` render mode.** New opt-in render path in `materialize_sft_example` that tokenizes aux_head rows prompt/completion-style: prompt via `apply_chat_template(add_generation_prompt=True)`, real completion appended with a derived eos terminal, prompt masked to `-100`. Gated behind `SFTTrainingConfig.prompt_render = "full_conversation"` (default) | `"prompt_completion"`; the default path is byte-identical. Fixes the `end_of_prompt` faithfulness gap (full-conversation rows read cos 0.544 vs the 0.9998 reference token) **without touching aux_head token-position code** (`prompt_end_indices`/`reduce_hidden_states` unchanged).

**Item 2 — tuner local-run launch path.** 12 `--aux-head-*` argparse flags in `train_sft.py` (paired `--flag/--no-flag` tri-state bools) + aux_head-block forwarding in `tuner/handlers/local_run_handler::_build_trainer_command`; omitted entirely when absent, so existing recipes are byte-identical. Launch mechanism documented in the fine-tuning skill (+ synced mirrors).

**Finding-A coherence guard.** Extracted `validate_aux_head_coherence()` as a module-level shared function; `load_aux_head_config` delegates to it (YAML lane byte-identical) and `train_sft.run()` calls the same function **after** the `--aux-head-*` CLI-override block, raising on incoherent phase corners. Closes the CLI/YAML asymmetry where `--aux-head-enabled --no-aux-head-freeze-base` reached the silent representation-collapse corner (`freeze_base=false` + `lm_loss_weight=0`, no LM anchor). Distinct from and coexists with the `prompt_render` WARN guard.

## Testing

- 7/7 acceptance criteria GREEN (faithful boundary cos≈1.0 by construction; default byte-identical; prompt masking + `aux_target` threading; joint path).
- Finding A remediated + verify-only re-review GREEN (36 passed on the touched files).
- ~26 net-new tests (render + guard); full aux_head+SFT suite green. CPU-only.
- Generic-vocabulary discipline preserved on added lines.

## Scope notes

- **Submodule PR only** — root-repo submodule-pointer bump is a separate later commit (tracked).
- No aux_head token-position code changed; no experiment data/recipes; no security/auth surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)