### PR TITLE
[codex] Emit native distiller tool traces

### DIFF
--- a/.agents/skills/transcript-distillation/SKILL.md
+++ b/.agents/skills/transcript-distillation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transcript-distillation
-description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO/DPO/GRPO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
 allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 ---
 
@@ -75,10 +75,14 @@ Each knob is documented in `reference/config-schema.md`. Highlights:
 - **`quality_filter`** — drop ceremony tools (orchestration), trivial text
   turns, and duplicate completions. Set `require_outcomes` to keep ONLY
   verified-good sessions.
+- **`distill.render.render_mode`** — `flat` keeps today's text row shape and
+  remains the default; `native` emits source rows with structured assistant
+  `tool_calls` and `role:"tool"` results linked by stable `tool_call_id`.
 
 ## Output row schema
 
-One JSON object per line, shaped for SFT/KTO:
+One JSON object per line. In default `render_mode: flat`, rows keep the current
+text-first shape used by SFT/KTO/DPO/GRPO projections:
 
 ```json
 {
@@ -99,7 +103,15 @@ One JSON object per line, shaped for SFT/KTO:
 
 Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
 SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
-LLM-as-judge to mint KTO negatives.
+LLM-as-judge to mint KTO negatives; build DPO pairs and GRPO reward/rollout
+inputs with explicit method-specific projections.
+
+With `render_mode: native`, rows are a high-fidelity source/emit format for
+tool-use data, not a universal trainer input replacement. Assistant messages
+carry structured `tool_calls`; tool-result messages carry `role:"tool"`,
+the matching stable `tool_call_id`, and the captured output content. Prepare or
+trainer-specific dataset builders must project those native rows into the final
+SFT, KTO, DPO, static-GRPO, or env-GRPO schema they accept.
 
 ## Privacy
 

--- a/.agents/skills/transcript-distillation/configs/template.yaml
+++ b/.agents/skills/transcript-distillation/configs/template.yaml
@@ -34,6 +34,13 @@ output:
   rows_file: "rows.jsonl"
   smoke_subdir: "smoke"
 
+# ---- row rendering ----
+distill:
+  render:
+    # flat preserves the legacy completion shape. Set to native to emit
+    # OpenAI-style assistant tool_calls plus role=tool result messages.
+    render_mode: "flat"          # flat | native
+
 # ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
 sanitize:
   enabled: true

--- a/.agents/skills/transcript-distillation/reference/config-schema.md
+++ b/.agents/skills/transcript-distillation/reference/config-schema.md
@@ -32,6 +32,19 @@ The scope-key is adapter-defined: `claude_code` uses the project-slug;
 - `rows_file`: filename (default `rows.jsonl`).
 - `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
 
+## `distill.render` (map)
+- `render_mode`: `flat` or `native` (default `flat`).
+
+`flat` preserves the legacy row shape: assistant completions include serialized
+tool calls as text and tool context messages use `[tool result]`.
+
+`native` emits OpenAI-style tool messages for source/native emit workflows:
+assistant messages may include
+`tool_calls: [{id, type: "function", function: {name, arguments}}]`, and tool
+result messages use `role: tool`, `tool_call_id`, and output `content`.
+Legacy row fields such as `prompt`, `completion`, `label`, and `metadata` are
+still present. In native mode, `completion` is assistant text only.
+
 ## `sanitize` (map)
 Deterministic secret scrub, applied to every text field at emit time.
 - `enabled`: bool.

--- a/.agents/skills/transcript-distillation/scripts/adapters/base.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/base.py
@@ -11,8 +11,9 @@ parse(path) returns (events, signals).
 events: ordered list of dicts, one per logical turn:
   human turn     -> {"role": "human",     "text": str}
   assistant turn -> {"role": "assistant", "text": str,
-                     "tool_calls": [{"name": str, "input": any}]}
+                     "tool_calls": [{"id": str, "name": str, "input": any}]}
   tool result    -> {"role": "tool", "tool_error": bool,
+                     "tool_call_id": str, # matches assistant tool_calls[].id
                      "command": str,   # the command this result is answering
                      "output": str}    # the result text (for outcome detection)
 

--- a/.agents/skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from .base import Adapter, blocks_text
 
 
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"claude_{Path(path).stem}_{seq:04d}"
+
+
 def _command_of(tool_use: dict) -> str:
     inp = tool_use.get("input")
     if isinstance(inp, dict):
@@ -39,6 +43,9 @@ class ClaudeCodeAdapter(Adapter):
         events: list[dict] = []
         signals = {"pr_created": False}
         id2cmd: dict[str, str] = {}
+        pending_tool_ids: list[str] = []
+        tool_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             line = line.strip()
@@ -67,9 +74,13 @@ class ClaudeCodeAdapter(Adapter):
                         if bt == "text":
                             text += str(b.get("text", ""))
                         elif bt == "tool_use":
-                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
-                            if b.get("id"):
-                                id2cmd[b["id"]] = _command_of(b)
+                            tool_seq += 1
+                            tool_call_id = str(b.get("id") or _fallback_tool_call_id(path, tool_seq))
+                            tool_calls.append({"id": tool_call_id,
+                                               "name": b.get("name"),
+                                               "input": b.get("input") or {}})
+                            id2cmd[tool_call_id] = _command_of(b)
+                            pending_tool_ids.append(tool_call_id)
                 elif isinstance(content, str):
                     text = content
                 events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
@@ -86,8 +97,19 @@ class ClaudeCodeAdapter(Adapter):
                         if not err:  # some errors only show in the text, not the flag
                             low = out[:200].lower()
                             err = "error" in low or "traceback" in low
+                        source_id = b.get("tool_use_id")
+                        if source_id:
+                            tool_call_id = str(source_id)
+                            if tool_call_id in pending_tool_ids:
+                                pending_tool_ids.remove(tool_call_id)
+                        elif pending_tool_ids:
+                            tool_call_id = pending_tool_ids.pop(0)
+                        else:
+                            orphan_result_seq += 1
+                            tool_call_id = _fallback_tool_call_id(path, tool_seq + orphan_result_seq)
                         events.append({"role": "tool", "tool_error": err,
-                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "tool_call_id": tool_call_id,
+                                       "command": id2cmd.get(tool_call_id, ""),
                                        "output": out})
                 else:
                     events.append({"role": "human", "text": blocks_text(content)})

--- a/.agents/skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.agents/skills/transcript-distillation/scripts/adapters/codex.py
@@ -6,8 +6,13 @@ function_call_output pairs; exit status is plaintext "Process exited with code N
 """
 from __future__ import annotations
 import json
+from pathlib import Path
 
 from .base import Adapter, blocks_text
+
+
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"codex_{Path(path).stem}_{seq:04d}"
 
 
 def _command_of(arguments) -> str:
@@ -48,7 +53,9 @@ class CodexAdapter(Adapter):
     def parse(self, path: str):
         events: list[dict] = []
         signals = {"pr_created": False}
-        pending_cmd = ""
+        pending_calls: list[tuple[str, str]] = []
+        call_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             try:
@@ -71,11 +78,13 @@ class CodexAdapter(Adapter):
             elif pt in ("function_call", "custom_tool_call"):
                 args = p.get("arguments") or p.get("input") or ""
                 cmd = _command_of(args)
+                call_seq += 1
+                tool_call_id = str(p.get("call_id") or p.get("id") or _fallback_tool_call_id(path, call_seq))
                 if "gh pr create" in cmd:
                     signals["pr_created"] = True
                 events.append({"role": "assistant", "text": "",
-                               "tool_calls": [{"name": p.get("name"), "input": args}]})
-                pending_cmd = cmd
+                               "tool_calls": [{"id": tool_call_id, "name": p.get("name"), "input": args}]})
+                pending_calls.append((tool_call_id, cmd))
 
             elif pt in ("function_call_output", "custom_tool_call_output"):
                 out = p.get("output")
@@ -83,7 +92,21 @@ class CodexAdapter(Adapter):
                 low = s.lower()
                 err = ("exited with code" in low and "exited with code 0" not in low) \
                     or "traceback (most recent call last)" in low
+                source_id = p.get("call_id")
+                if source_id:
+                    tool_call_id = str(source_id)
+                    cmd = ""
+                    for idx, (pending_id, pending_cmd) in enumerate(pending_calls):
+                        if pending_id == tool_call_id:
+                            cmd = pending_cmd
+                            pending_calls.pop(idx)
+                            break
+                elif pending_calls:
+                    tool_call_id, cmd = pending_calls.pop(0)
+                else:
+                    orphan_result_seq += 1
+                    tool_call_id, cmd = _fallback_tool_call_id(path, call_seq + orphan_result_seq), ""
                 events.append({"role": "tool", "tool_error": err,
-                               "command": pending_cmd, "output": s})
-                pending_cmd = ""
+                               "tool_call_id": tool_call_id,
+                               "command": cmd, "output": s})
         return events, signals

--- a/.agents/skills/transcript-distillation/scripts/distill.py
+++ b/.agents/skills/transcript-distillation/scripts/distill.py
@@ -52,6 +52,54 @@ def render_completion(ev: dict) -> str:
     return "\n".join(parts)
 
 
+def render_native_completion(ev: dict) -> str:
+    return ev.get("text", "").strip()
+
+
+def _serialize_tool_arguments(value) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False)
+
+
+def native_message(e: dict) -> dict:
+    if e["role"] == "human":
+        return {"role": "user", "content": e.get("text", "")}
+    if e["role"] == "tool":
+        return {
+            "role": "tool",
+            "tool_call_id": str(e.get("tool_call_id") or ""),
+            "content": e.get("output", ""),
+        }
+
+    msg = {"role": "assistant", "content": e.get("text", "").strip() or None}
+    tool_calls = []
+    for idx, call in enumerate(e.get("tool_calls") or []):
+        tool_calls.append({
+            "id": str(call.get("id") or f"call_{idx:04d}"),
+            "type": "function",
+            "function": {
+                "name": str(call.get("name") or ""),
+                "arguments": _serialize_tool_arguments(call.get("input")),
+            },
+        })
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def redact_nested(value, redactor, counts):
+    if isinstance(value, str):
+        return redactor.redact(value, counts)
+    if isinstance(value, list):
+        return [redact_nested(v, redactor, counts) for v in value]
+    if isinstance(value, dict):
+        return {k: redact_nested(v, redactor, counts) for k, v in value.items()}
+    return value
+
+
 def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     low = text.strip().lower()
     if not low or len(low) > max_len:
@@ -59,8 +107,9 @@ def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     return any(low.startswith(m) for m in markers)
 
 
-def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget, render_mode="flat"):
     rows = []
+    native = render_mode == "native"
     corr_markers = lab["correction_markers"]
     intr_markers = lab["interrupt_markers"]
     max_tokens = ctx_budget.get("max_context_tokens", 8192)
@@ -70,8 +119,14 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
 
     def _content(e):
         if e["role"] == "tool":
-            return "[tool result]"
+            return e.get("output", "") if native else "[tool result]"
         return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    def _message(e):
+        if native:
+            return native_message(e)
+        role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+        return {"role": role, "content": _content(e)}
 
     for i, ev in enumerate(events):
         if ev["role"] != "assistant":
@@ -113,10 +168,10 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
         else:
             label, tier = True, "good"
 
-        completion_str = render_completion(ev)
+        completion_str = render_native_completion(ev) if native else render_completion(ev)
         budget = max_tokens - est(completion_str)
         oversize = budget < 0
-        conv_rev = [{"role": "assistant", "content": completion_str}]
+        conv_rev = [native_message(ev) if native else {"role": "assistant", "content": completion_str}]
         used = 0
         for e in reversed(events[:i]):
             if len(conv_rev) >= max_msgs:
@@ -126,8 +181,7 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
             if used + t > budget and len(conv_rev) > 1:
                 break
             used += t
-            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
-            conv_rev.append({"role": role, "content": c})
+            conv_rev.append(_message(e))
         conv = list(reversed(conv_rev))
 
         prompt = ""
@@ -233,7 +287,10 @@ def should_keep(row, q, seen, cpt):
 
     if tools:
         kept = [t for t in tools if t not in drop_tools]
-        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        current_msg = (row.get("conversations") or [{}])[-1]
+        tool_payload = comp + " " + json.dumps(current_msg.get("tool_calls") or [],
+                                               ensure_ascii=False)
+        ceremony_skill = "Skill" in tools and any(sk in tool_payload for sk in drop_skills)
         if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
             return False, "ceremony_tool"
     else:
@@ -289,6 +346,9 @@ def main():
         cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
     redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
     redaction_counts: Counter = Counter()
+    render_mode = ((cfg.get("distill") or {}).get("render") or {}).get("render_mode", "flat")
+    if render_mode not in ("flat", "native"):
+        raise SystemExit("distill.render.render_mode must be 'flat' or 'native'")
     qcfg = cfg.get("quality_filter") or {"enabled": False}
     q_enabled = qcfg.get("enabled", False)
     oc_cfg = cfg.get("session_outcome") or {"enabled": False}
@@ -348,7 +408,8 @@ def main():
             tier = derive_tier(outcomes, tiers_cfg)
 
             rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
-                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}),
+                             render_mode=render_mode)
             bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
             for r in rows:
                 r["metadata"]["session_outcome"] = outcomes
@@ -368,7 +429,11 @@ def main():
                     outcome_counts[o2] += 1
                 tier_counts[tier] += 1
                 for m in r["conversations"]:
-                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if "content" in m and m["content"] is not None:
+                        m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if m.get("tool_calls"):
+                        m["tool_calls"] = redact_nested(m["tool_calls"], redactor,
+                                                        redaction_counts)
                 fout.write(json.dumps(r, ensure_ascii=False) + "\n")
                 stats["rows"] += 1
                 bucket = ("accept" if r["label"] is True else

--- a/.claude/skills/transcript-distillation/SKILL.md
+++ b/.claude/skills/transcript-distillation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transcript-distillation
-description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO/DPO/GRPO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
 allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 ---
 
@@ -75,10 +75,14 @@ Each knob is documented in `reference/config-schema.md`. Highlights:
 - **`quality_filter`** — drop ceremony tools (orchestration), trivial text
   turns, and duplicate completions. Set `require_outcomes` to keep ONLY
   verified-good sessions.
+- **`distill.render.render_mode`** — `flat` keeps today's text row shape and
+  remains the default; `native` emits source rows with structured assistant
+  `tool_calls` and `role:"tool"` results linked by stable `tool_call_id`.
 
 ## Output row schema
 
-One JSON object per line, shaped for SFT/KTO:
+One JSON object per line. In default `render_mode: flat`, rows keep the current
+text-first shape used by SFT/KTO/DPO/GRPO projections:
 
 ```json
 {
@@ -99,7 +103,15 @@ One JSON object per line, shaped for SFT/KTO:
 
 Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
 SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
-LLM-as-judge to mint KTO negatives.
+LLM-as-judge to mint KTO negatives; build DPO pairs and GRPO reward/rollout
+inputs with explicit method-specific projections.
+
+With `render_mode: native`, rows are a high-fidelity source/emit format for
+tool-use data, not a universal trainer input replacement. Assistant messages
+carry structured `tool_calls`; tool-result messages carry `role:"tool"`,
+the matching stable `tool_call_id`, and the captured output content. Prepare or
+trainer-specific dataset builders must project those native rows into the final
+SFT, KTO, DPO, static-GRPO, or env-GRPO schema they accept.
 
 ## Privacy
 

--- a/.claude/skills/transcript-distillation/configs/template.yaml
+++ b/.claude/skills/transcript-distillation/configs/template.yaml
@@ -34,6 +34,13 @@ output:
   rows_file: "rows.jsonl"
   smoke_subdir: "smoke"
 
+# ---- row rendering ----
+distill:
+  render:
+    # flat preserves the legacy completion shape. Set to native to emit
+    # OpenAI-style assistant tool_calls plus role=tool result messages.
+    render_mode: "flat"          # flat | native
+
 # ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
 sanitize:
   enabled: true

--- a/.claude/skills/transcript-distillation/reference/config-schema.md
+++ b/.claude/skills/transcript-distillation/reference/config-schema.md
@@ -32,6 +32,19 @@ The scope-key is adapter-defined: `claude_code` uses the project-slug;
 - `rows_file`: filename (default `rows.jsonl`).
 - `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
 
+## `distill.render` (map)
+- `render_mode`: `flat` or `native` (default `flat`).
+
+`flat` preserves the legacy row shape: assistant completions include serialized
+tool calls as text and tool context messages use `[tool result]`.
+
+`native` emits OpenAI-style tool messages for source/native emit workflows:
+assistant messages may include
+`tool_calls: [{id, type: "function", function: {name, arguments}}]`, and tool
+result messages use `role: tool`, `tool_call_id`, and output `content`.
+Legacy row fields such as `prompt`, `completion`, `label`, and `metadata` are
+still present. In native mode, `completion` is assistant text only.
+
 ## `sanitize` (map)
 Deterministic secret scrub, applied to every text field at emit time.
 - `enabled`: bool.

--- a/.claude/skills/transcript-distillation/scripts/adapters/base.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/base.py
@@ -11,8 +11,9 @@ parse(path) returns (events, signals).
 events: ordered list of dicts, one per logical turn:
   human turn     -> {"role": "human",     "text": str}
   assistant turn -> {"role": "assistant", "text": str,
-                     "tool_calls": [{"name": str, "input": any}]}
+                     "tool_calls": [{"id": str, "name": str, "input": any}]}
   tool result    -> {"role": "tool", "tool_error": bool,
+                     "tool_call_id": str, # matches assistant tool_calls[].id
                      "command": str,   # the command this result is answering
                      "output": str}    # the result text (for outcome detection)
 

--- a/.claude/skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from .base import Adapter, blocks_text
 
 
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"claude_{Path(path).stem}_{seq:04d}"
+
+
 def _command_of(tool_use: dict) -> str:
     inp = tool_use.get("input")
     if isinstance(inp, dict):
@@ -39,6 +43,9 @@ class ClaudeCodeAdapter(Adapter):
         events: list[dict] = []
         signals = {"pr_created": False}
         id2cmd: dict[str, str] = {}
+        pending_tool_ids: list[str] = []
+        tool_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             line = line.strip()
@@ -67,9 +74,13 @@ class ClaudeCodeAdapter(Adapter):
                         if bt == "text":
                             text += str(b.get("text", ""))
                         elif bt == "tool_use":
-                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
-                            if b.get("id"):
-                                id2cmd[b["id"]] = _command_of(b)
+                            tool_seq += 1
+                            tool_call_id = str(b.get("id") or _fallback_tool_call_id(path, tool_seq))
+                            tool_calls.append({"id": tool_call_id,
+                                               "name": b.get("name"),
+                                               "input": b.get("input") or {}})
+                            id2cmd[tool_call_id] = _command_of(b)
+                            pending_tool_ids.append(tool_call_id)
                 elif isinstance(content, str):
                     text = content
                 events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
@@ -86,8 +97,19 @@ class ClaudeCodeAdapter(Adapter):
                         if not err:  # some errors only show in the text, not the flag
                             low = out[:200].lower()
                             err = "error" in low or "traceback" in low
+                        source_id = b.get("tool_use_id")
+                        if source_id:
+                            tool_call_id = str(source_id)
+                            if tool_call_id in pending_tool_ids:
+                                pending_tool_ids.remove(tool_call_id)
+                        elif pending_tool_ids:
+                            tool_call_id = pending_tool_ids.pop(0)
+                        else:
+                            orphan_result_seq += 1
+                            tool_call_id = _fallback_tool_call_id(path, tool_seq + orphan_result_seq)
                         events.append({"role": "tool", "tool_error": err,
-                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "tool_call_id": tool_call_id,
+                                       "command": id2cmd.get(tool_call_id, ""),
                                        "output": out})
                 else:
                     events.append({"role": "human", "text": blocks_text(content)})

--- a/.claude/skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.claude/skills/transcript-distillation/scripts/adapters/codex.py
@@ -6,8 +6,13 @@ function_call_output pairs; exit status is plaintext "Process exited with code N
 """
 from __future__ import annotations
 import json
+from pathlib import Path
 
 from .base import Adapter, blocks_text
+
+
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"codex_{Path(path).stem}_{seq:04d}"
 
 
 def _command_of(arguments) -> str:
@@ -48,7 +53,9 @@ class CodexAdapter(Adapter):
     def parse(self, path: str):
         events: list[dict] = []
         signals = {"pr_created": False}
-        pending_cmd = ""
+        pending_calls: list[tuple[str, str]] = []
+        call_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             try:
@@ -71,11 +78,13 @@ class CodexAdapter(Adapter):
             elif pt in ("function_call", "custom_tool_call"):
                 args = p.get("arguments") or p.get("input") or ""
                 cmd = _command_of(args)
+                call_seq += 1
+                tool_call_id = str(p.get("call_id") or p.get("id") or _fallback_tool_call_id(path, call_seq))
                 if "gh pr create" in cmd:
                     signals["pr_created"] = True
                 events.append({"role": "assistant", "text": "",
-                               "tool_calls": [{"name": p.get("name"), "input": args}]})
-                pending_cmd = cmd
+                               "tool_calls": [{"id": tool_call_id, "name": p.get("name"), "input": args}]})
+                pending_calls.append((tool_call_id, cmd))
 
             elif pt in ("function_call_output", "custom_tool_call_output"):
                 out = p.get("output")
@@ -83,7 +92,21 @@ class CodexAdapter(Adapter):
                 low = s.lower()
                 err = ("exited with code" in low and "exited with code 0" not in low) \
                     or "traceback (most recent call last)" in low
+                source_id = p.get("call_id")
+                if source_id:
+                    tool_call_id = str(source_id)
+                    cmd = ""
+                    for idx, (pending_id, pending_cmd) in enumerate(pending_calls):
+                        if pending_id == tool_call_id:
+                            cmd = pending_cmd
+                            pending_calls.pop(idx)
+                            break
+                elif pending_calls:
+                    tool_call_id, cmd = pending_calls.pop(0)
+                else:
+                    orphan_result_seq += 1
+                    tool_call_id, cmd = _fallback_tool_call_id(path, call_seq + orphan_result_seq), ""
                 events.append({"role": "tool", "tool_error": err,
-                               "command": pending_cmd, "output": s})
-                pending_cmd = ""
+                               "tool_call_id": tool_call_id,
+                               "command": cmd, "output": s})
         return events, signals

--- a/.claude/skills/transcript-distillation/scripts/distill.py
+++ b/.claude/skills/transcript-distillation/scripts/distill.py
@@ -52,6 +52,54 @@ def render_completion(ev: dict) -> str:
     return "\n".join(parts)
 
 
+def render_native_completion(ev: dict) -> str:
+    return ev.get("text", "").strip()
+
+
+def _serialize_tool_arguments(value) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False)
+
+
+def native_message(e: dict) -> dict:
+    if e["role"] == "human":
+        return {"role": "user", "content": e.get("text", "")}
+    if e["role"] == "tool":
+        return {
+            "role": "tool",
+            "tool_call_id": str(e.get("tool_call_id") or ""),
+            "content": e.get("output", ""),
+        }
+
+    msg = {"role": "assistant", "content": e.get("text", "").strip() or None}
+    tool_calls = []
+    for idx, call in enumerate(e.get("tool_calls") or []):
+        tool_calls.append({
+            "id": str(call.get("id") or f"call_{idx:04d}"),
+            "type": "function",
+            "function": {
+                "name": str(call.get("name") or ""),
+                "arguments": _serialize_tool_arguments(call.get("input")),
+            },
+        })
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def redact_nested(value, redactor, counts):
+    if isinstance(value, str):
+        return redactor.redact(value, counts)
+    if isinstance(value, list):
+        return [redact_nested(v, redactor, counts) for v in value]
+    if isinstance(value, dict):
+        return {k: redact_nested(v, redactor, counts) for k, v in value.items()}
+    return value
+
+
 def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     low = text.strip().lower()
     if not low or len(low) > max_len:
@@ -59,8 +107,9 @@ def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     return any(low.startswith(m) for m in markers)
 
 
-def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget, render_mode="flat"):
     rows = []
+    native = render_mode == "native"
     corr_markers = lab["correction_markers"]
     intr_markers = lab["interrupt_markers"]
     max_tokens = ctx_budget.get("max_context_tokens", 8192)
@@ -70,8 +119,14 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
 
     def _content(e):
         if e["role"] == "tool":
-            return "[tool result]"
+            return e.get("output", "") if native else "[tool result]"
         return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    def _message(e):
+        if native:
+            return native_message(e)
+        role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+        return {"role": role, "content": _content(e)}
 
     for i, ev in enumerate(events):
         if ev["role"] != "assistant":
@@ -113,10 +168,10 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
         else:
             label, tier = True, "good"
 
-        completion_str = render_completion(ev)
+        completion_str = render_native_completion(ev) if native else render_completion(ev)
         budget = max_tokens - est(completion_str)
         oversize = budget < 0
-        conv_rev = [{"role": "assistant", "content": completion_str}]
+        conv_rev = [native_message(ev) if native else {"role": "assistant", "content": completion_str}]
         used = 0
         for e in reversed(events[:i]):
             if len(conv_rev) >= max_msgs:
@@ -126,8 +181,7 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
             if used + t > budget and len(conv_rev) > 1:
                 break
             used += t
-            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
-            conv_rev.append({"role": role, "content": c})
+            conv_rev.append(_message(e))
         conv = list(reversed(conv_rev))
 
         prompt = ""
@@ -233,7 +287,10 @@ def should_keep(row, q, seen, cpt):
 
     if tools:
         kept = [t for t in tools if t not in drop_tools]
-        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        current_msg = (row.get("conversations") or [{}])[-1]
+        tool_payload = comp + " " + json.dumps(current_msg.get("tool_calls") or [],
+                                               ensure_ascii=False)
+        ceremony_skill = "Skill" in tools and any(sk in tool_payload for sk in drop_skills)
         if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
             return False, "ceremony_tool"
     else:
@@ -289,6 +346,9 @@ def main():
         cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
     redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
     redaction_counts: Counter = Counter()
+    render_mode = ((cfg.get("distill") or {}).get("render") or {}).get("render_mode", "flat")
+    if render_mode not in ("flat", "native"):
+        raise SystemExit("distill.render.render_mode must be 'flat' or 'native'")
     qcfg = cfg.get("quality_filter") or {"enabled": False}
     q_enabled = qcfg.get("enabled", False)
     oc_cfg = cfg.get("session_outcome") or {"enabled": False}
@@ -348,7 +408,8 @@ def main():
             tier = derive_tier(outcomes, tiers_cfg)
 
             rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
-                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}),
+                             render_mode=render_mode)
             bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
             for r in rows:
                 r["metadata"]["session_outcome"] = outcomes
@@ -368,7 +429,11 @@ def main():
                     outcome_counts[o2] += 1
                 tier_counts[tier] += 1
                 for m in r["conversations"]:
-                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if "content" in m and m["content"] is not None:
+                        m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if m.get("tool_calls"):
+                        m["tool_calls"] = redact_nested(m["tool_calls"], redactor,
+                                                        redaction_counts)
                 fout.write(json.dumps(r, ensure_ascii=False) + "\n")
                 stats["rows"] += 1
                 bucket = ("accept" if r["label"] is True else

--- a/.skills/transcript-distillation/SKILL.md
+++ b/.skills/transcript-distillation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transcript-distillation
-description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
+description: Turn local agent transcripts (Claude Code, Codex CLI, or any format with an adapter) into high-quality fine-tuning rows. Use when someone wants to mine their own coding-agent conversation logs into an SFT/KTO/DPO/GRPO dataset — parse the logs, extract substantive turns, scrub secrets, score each session by outcome (tests passed / built clean / committed / PR'd), dedup, and tier by quality. Config-driven and format-pluggable; point it at a transcript directory and it produces deduped, quality-tiered JSONL. This skill is about USING the checked-in distill engine via CLI + YAML.
 allowed-tools: Read, Bash, Write, Edit, Grep, Glob
 ---
 
@@ -75,10 +75,14 @@ Each knob is documented in `reference/config-schema.md`. Highlights:
 - **`quality_filter`** — drop ceremony tools (orchestration), trivial text
   turns, and duplicate completions. Set `require_outcomes` to keep ONLY
   verified-good sessions.
+- **`distill.render.render_mode`** — `flat` keeps today's text row shape and
+  remains the default; `native` emits source rows with structured assistant
+  `tool_calls` and `role:"tool"` results linked by stable `tool_call_id`.
 
 ## Output row schema
 
-One JSON object per line, shaped for SFT/KTO:
+One JSON object per line. In default `render_mode: flat`, rows keep the current
+text-first shape used by SFT/KTO/DPO/GRPO projections:
 
 ```json
 {
@@ -99,7 +103,15 @@ One JSON object per line, shaped for SFT/KTO:
 
 Build a dataset from it by filtering on `metadata.quality_tier` and/or `label`:
 SFT on `label==true` gold rows; route `label==null` (borderline) rows to an
-LLM-as-judge to mint KTO negatives.
+LLM-as-judge to mint KTO negatives; build DPO pairs and GRPO reward/rollout
+inputs with explicit method-specific projections.
+
+With `render_mode: native`, rows are a high-fidelity source/emit format for
+tool-use data, not a universal trainer input replacement. Assistant messages
+carry structured `tool_calls`; tool-result messages carry `role:"tool"`,
+the matching stable `tool_call_id`, and the captured output content. Prepare or
+trainer-specific dataset builders must project those native rows into the final
+SFT, KTO, DPO, static-GRPO, or env-GRPO schema they accept.
 
 ## Privacy
 

--- a/.skills/transcript-distillation/configs/template.yaml
+++ b/.skills/transcript-distillation/configs/template.yaml
@@ -34,6 +34,13 @@ output:
   rows_file: "rows.jsonl"
   smoke_subdir: "smoke"
 
+# ---- row rendering ----
+distill:
+  render:
+    # flat preserves the legacy completion shape. Set to native to emit
+    # OpenAI-style assistant tool_calls plus role=tool result messages.
+    render_mode: "flat"          # flat | native
+
 # ---- secret scrub (runs at emit time; raw secrets never hit disk) ----
 sanitize:
   enabled: true

--- a/.skills/transcript-distillation/reference/config-schema.md
+++ b/.skills/transcript-distillation/reference/config-schema.md
@@ -32,6 +32,19 @@ The scope-key is adapter-defined: `claude_code` uses the project-slug;
 - `rows_file`: filename (default `rows.jsonl`).
 - `smoke_subdir`: subdir used when `--smoke` is passed (default `smoke`).
 
+## `distill.render` (map)
+- `render_mode`: `flat` or `native` (default `flat`).
+
+`flat` preserves the legacy row shape: assistant completions include serialized
+tool calls as text and tool context messages use `[tool result]`.
+
+`native` emits OpenAI-style tool messages for source/native emit workflows:
+assistant messages may include
+`tool_calls: [{id, type: "function", function: {name, arguments}}]`, and tool
+result messages use `role: tool`, `tool_call_id`, and output `content`.
+Legacy row fields such as `prompt`, `completion`, `label`, and `metadata` are
+still present. In native mode, `completion` is assistant text only.
+
 ## `sanitize` (map)
 Deterministic secret scrub, applied to every text field at emit time.
 - `enabled`: bool.

--- a/.skills/transcript-distillation/scripts/adapters/base.py
+++ b/.skills/transcript-distillation/scripts/adapters/base.py
@@ -11,8 +11,9 @@ parse(path) returns (events, signals).
 events: ordered list of dicts, one per logical turn:
   human turn     -> {"role": "human",     "text": str}
   assistant turn -> {"role": "assistant", "text": str,
-                     "tool_calls": [{"name": str, "input": any}]}
+                     "tool_calls": [{"id": str, "name": str, "input": any}]}
   tool result    -> {"role": "tool", "tool_error": bool,
+                     "tool_call_id": str, # matches assistant tool_calls[].id
                      "command": str,   # the command this result is answering
                      "output": str}    # the result text (for outcome detection)
 

--- a/.skills/transcript-distillation/scripts/adapters/claude_code.py
+++ b/.skills/transcript-distillation/scripts/adapters/claude_code.py
@@ -11,6 +11,10 @@ from pathlib import Path
 from .base import Adapter, blocks_text
 
 
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"claude_{Path(path).stem}_{seq:04d}"
+
+
 def _command_of(tool_use: dict) -> str:
     inp = tool_use.get("input")
     if isinstance(inp, dict):
@@ -39,6 +43,9 @@ class ClaudeCodeAdapter(Adapter):
         events: list[dict] = []
         signals = {"pr_created": False}
         id2cmd: dict[str, str] = {}
+        pending_tool_ids: list[str] = []
+        tool_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             line = line.strip()
@@ -67,9 +74,13 @@ class ClaudeCodeAdapter(Adapter):
                         if bt == "text":
                             text += str(b.get("text", ""))
                         elif bt == "tool_use":
-                            tool_calls.append({"name": b.get("name"), "input": b.get("input") or {}})
-                            if b.get("id"):
-                                id2cmd[b["id"]] = _command_of(b)
+                            tool_seq += 1
+                            tool_call_id = str(b.get("id") or _fallback_tool_call_id(path, tool_seq))
+                            tool_calls.append({"id": tool_call_id,
+                                               "name": b.get("name"),
+                                               "input": b.get("input") or {}})
+                            id2cmd[tool_call_id] = _command_of(b)
+                            pending_tool_ids.append(tool_call_id)
                 elif isinstance(content, str):
                     text = content
                 events.append({"role": "assistant", "text": text, "tool_calls": tool_calls})
@@ -86,8 +97,19 @@ class ClaudeCodeAdapter(Adapter):
                         if not err:  # some errors only show in the text, not the flag
                             low = out[:200].lower()
                             err = "error" in low or "traceback" in low
+                        source_id = b.get("tool_use_id")
+                        if source_id:
+                            tool_call_id = str(source_id)
+                            if tool_call_id in pending_tool_ids:
+                                pending_tool_ids.remove(tool_call_id)
+                        elif pending_tool_ids:
+                            tool_call_id = pending_tool_ids.pop(0)
+                        else:
+                            orphan_result_seq += 1
+                            tool_call_id = _fallback_tool_call_id(path, tool_seq + orphan_result_seq)
                         events.append({"role": "tool", "tool_error": err,
-                                       "command": id2cmd.get(b.get("tool_use_id"), ""),
+                                       "tool_call_id": tool_call_id,
+                                       "command": id2cmd.get(tool_call_id, ""),
                                        "output": out})
                 else:
                     events.append({"role": "human", "text": blocks_text(content)})

--- a/.skills/transcript-distillation/scripts/adapters/codex.py
+++ b/.skills/transcript-distillation/scripts/adapters/codex.py
@@ -6,8 +6,13 @@ function_call_output pairs; exit status is plaintext "Process exited with code N
 """
 from __future__ import annotations
 import json
+from pathlib import Path
 
 from .base import Adapter, blocks_text
+
+
+def _fallback_tool_call_id(path: str, seq: int) -> str:
+    return f"codex_{Path(path).stem}_{seq:04d}"
 
 
 def _command_of(arguments) -> str:
@@ -48,7 +53,9 @@ class CodexAdapter(Adapter):
     def parse(self, path: str):
         events: list[dict] = []
         signals = {"pr_created": False}
-        pending_cmd = ""
+        pending_calls: list[tuple[str, str]] = []
+        call_seq = 0
+        orphan_result_seq = 0
 
         for line in open(path, errors="ignore"):
             try:
@@ -71,11 +78,13 @@ class CodexAdapter(Adapter):
             elif pt in ("function_call", "custom_tool_call"):
                 args = p.get("arguments") or p.get("input") or ""
                 cmd = _command_of(args)
+                call_seq += 1
+                tool_call_id = str(p.get("call_id") or p.get("id") or _fallback_tool_call_id(path, call_seq))
                 if "gh pr create" in cmd:
                     signals["pr_created"] = True
                 events.append({"role": "assistant", "text": "",
-                               "tool_calls": [{"name": p.get("name"), "input": args}]})
-                pending_cmd = cmd
+                               "tool_calls": [{"id": tool_call_id, "name": p.get("name"), "input": args}]})
+                pending_calls.append((tool_call_id, cmd))
 
             elif pt in ("function_call_output", "custom_tool_call_output"):
                 out = p.get("output")
@@ -83,7 +92,21 @@ class CodexAdapter(Adapter):
                 low = s.lower()
                 err = ("exited with code" in low and "exited with code 0" not in low) \
                     or "traceback (most recent call last)" in low
+                source_id = p.get("call_id")
+                if source_id:
+                    tool_call_id = str(source_id)
+                    cmd = ""
+                    for idx, (pending_id, pending_cmd) in enumerate(pending_calls):
+                        if pending_id == tool_call_id:
+                            cmd = pending_cmd
+                            pending_calls.pop(idx)
+                            break
+                elif pending_calls:
+                    tool_call_id, cmd = pending_calls.pop(0)
+                else:
+                    orphan_result_seq += 1
+                    tool_call_id, cmd = _fallback_tool_call_id(path, call_seq + orphan_result_seq), ""
                 events.append({"role": "tool", "tool_error": err,
-                               "command": pending_cmd, "output": s})
-                pending_cmd = ""
+                               "tool_call_id": tool_call_id,
+                               "command": cmd, "output": s})
         return events, signals

--- a/.skills/transcript-distillation/scripts/distill.py
+++ b/.skills/transcript-distillation/scripts/distill.py
@@ -52,6 +52,54 @@ def render_completion(ev: dict) -> str:
     return "\n".join(parts)
 
 
+def render_native_completion(ev: dict) -> str:
+    return ev.get("text", "").strip()
+
+
+def _serialize_tool_arguments(value) -> str:
+    if isinstance(value, str):
+        return value
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False)
+
+
+def native_message(e: dict) -> dict:
+    if e["role"] == "human":
+        return {"role": "user", "content": e.get("text", "")}
+    if e["role"] == "tool":
+        return {
+            "role": "tool",
+            "tool_call_id": str(e.get("tool_call_id") or ""),
+            "content": e.get("output", ""),
+        }
+
+    msg = {"role": "assistant", "content": e.get("text", "").strip() or None}
+    tool_calls = []
+    for idx, call in enumerate(e.get("tool_calls") or []):
+        tool_calls.append({
+            "id": str(call.get("id") or f"call_{idx:04d}"),
+            "type": "function",
+            "function": {
+                "name": str(call.get("name") or ""),
+                "arguments": _serialize_tool_arguments(call.get("input")),
+            },
+        })
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return msg
+
+
+def redact_nested(value, redactor, counts):
+    if isinstance(value, str):
+        return redactor.redact(value, counts)
+    if isinstance(value, list):
+        return [redact_nested(v, redactor, counts) for v in value]
+    if isinstance(value, dict):
+        return {k: redact_nested(v, redactor, counts) for k, v in value.items()}
+    return value
+
+
 def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     low = text.strip().lower()
     if not low or len(low) > max_len:
@@ -59,8 +107,9 @@ def _is_correction(text: str, markers: list[str], max_len: int) -> bool:
     return any(low.startswith(m) for m in markers)
 
 
-def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
+def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget, render_mode="flat"):
     rows = []
+    native = render_mode == "native"
     corr_markers = lab["correction_markers"]
     intr_markers = lab["interrupt_markers"]
     max_tokens = ctx_budget.get("max_context_tokens", 8192)
@@ -70,8 +119,14 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
 
     def _content(e):
         if e["role"] == "tool":
-            return "[tool result]"
+            return e.get("output", "") if native else "[tool result]"
         return render_completion(e) if e["role"] == "assistant" else e.get("text", "")
+
+    def _message(e):
+        if native:
+            return native_message(e)
+        role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
+        return {"role": role, "content": _content(e)}
 
     for i, ev in enumerate(events):
         if ev["role"] != "assistant":
@@ -113,10 +168,10 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
         else:
             label, tier = True, "good"
 
-        completion_str = render_completion(ev)
+        completion_str = render_native_completion(ev) if native else render_completion(ev)
         budget = max_tokens - est(completion_str)
         oversize = budget < 0
-        conv_rev = [{"role": "assistant", "content": completion_str}]
+        conv_rev = [native_message(ev) if native else {"role": "assistant", "content": completion_str}]
         used = 0
         for e in reversed(events[:i]):
             if len(conv_rev) >= max_msgs:
@@ -126,8 +181,7 @@ def emit_rows(events, *, source_kind, project, rel_id, lab, ctx_budget):
             if used + t > budget and len(conv_rev) > 1:
                 break
             used += t
-            role = {"human": "user", "assistant": "assistant", "tool": "tool"}[e["role"]]
-            conv_rev.append({"role": role, "content": c})
+            conv_rev.append(_message(e))
         conv = list(reversed(conv_rev))
 
         prompt = ""
@@ -233,7 +287,10 @@ def should_keep(row, q, seen, cpt):
 
     if tools:
         kept = [t for t in tools if t not in drop_tools]
-        ceremony_skill = "Skill" in tools and any(sk in comp for sk in drop_skills)
+        current_msg = (row.get("conversations") or [{}])[-1]
+        tool_payload = comp + " " + json.dumps(current_msg.get("tool_calls") or [],
+                                               ensure_ascii=False)
+        ceremony_skill = "Skill" in tools and any(sk in tool_payload for sk in drop_skills)
         if not kept or (len(kept) == 1 and kept[0] == "Skill" and ceremony_skill):
             return False, "ceremony_tool"
     else:
@@ -289,6 +346,9 @@ def main():
         cfg.setdefault("context_budget", {})["max_context_tokens"] = args.max_context_tokens
     redactor = Redactor(cfg.get("sanitize") or {"enabled": False})
     redaction_counts: Counter = Counter()
+    render_mode = ((cfg.get("distill") or {}).get("render") or {}).get("render_mode", "flat")
+    if render_mode not in ("flat", "native"):
+        raise SystemExit("distill.render.render_mode must be 'flat' or 'native'")
     qcfg = cfg.get("quality_filter") or {"enabled": False}
     q_enabled = qcfg.get("enabled", False)
     oc_cfg = cfg.get("session_outcome") or {"enabled": False}
@@ -348,7 +408,8 @@ def main():
             tier = derive_tier(outcomes, tiers_cfg)
 
             rows = emit_rows(events, source_kind=kind, project=project, rel_id=rel_id,
-                             lab=lab, ctx_budget=cfg.get("context_budget", {}))
+                             lab=lab, ctx_budget=cfg.get("context_budget", {}),
+                             render_mode=render_mode)
             bs = by_source.setdefault(kind, {"accept": 0, "reject": 0, "borderline": 0})
             for r in rows:
                 r["metadata"]["session_outcome"] = outcomes
@@ -368,7 +429,11 @@ def main():
                     outcome_counts[o2] += 1
                 tier_counts[tier] += 1
                 for m in r["conversations"]:
-                    m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if "content" in m and m["content"] is not None:
+                        m["content"] = redactor.redact(m["content"], redaction_counts)
+                    if m.get("tool_calls"):
+                        m["tool_calls"] = redact_nested(m["tool_calls"], redactor,
+                                                        redaction_counts)
                 fout.write(json.dumps(r, ensure_ascii=False) + "\n")
                 stats["rows"] += 1
                 bucket = ("accept" if r["label"] is True else

--- a/docs/plans/distiller-native-tool-emit-and-flywheel-verdict-plan.md
+++ b/docs/plans/distiller-native-tool-emit-and-flywheel-verdict-plan.md
@@ -1,0 +1,326 @@
+# Distiller Native Tool Emit + Flywheel Verdict Rationale Plan
+
+**Date:** 2026-06-30
+**Status:** Proposed
+**Prior Art:** Arize Phoenix / OpenInference — [Phoenix docs](https://arize.com/docs/phoenix), [OpenInference semantic conventions](https://github.com/Arize-ai/openinference/blob/main/spec/semantic_conventions.md)
+**Branch:** TBD (`feat/distiller-native-tool-emit`)
+
+---
+
+## Origin
+
+A scan of Arize Phoenix to see if anything was worth borrowing. Direct code comparison **deflated** most of it: we already have a richer judge than Phoenix's `llm_classify` "rails" (`shared/judge/models.py` — JSON-Schema output, per-dimension reason-first scoring, `quality_gate` floors-as-gates), and we already attach a score to each inference record and filter by it (`InferenceLogRecord.fitness_score` + catalog `min_score`/`max_score`/`unscored_only` + `update_score()`). We also already have a canonical native tool schema internally (`InferenceLogRecord` stores OpenAI-native `messages`/`tools`/`tool_calls`; SynthChat ships an `openai_native` format). So **OpenInference is not worth adopting wholesale** — it is useful only as a cross-check schema.
+
+What the comparison *did* surface is three concrete, self-contained gaps, in priority order:
+
+1. **The distiller flattens tool calls and discards tool I/O** — internal inconsistency with the native shape the rest of the repo already uses. (Highest payoff; self-contained.)
+2. **The flywheel record stores the judge *score* but not the judge *rationale*** — Phoenix's one genuine differentiator (label **and** explanation on every span).
+3. **No frozen regression fixtures** — the flywheel routes failures to retrain, but never freezes a curated set of failing logs into a re-runnable `Evaluator/` scenario.
+
+---
+
+## Findings from the codebase
+
+- **`render_completion()` flattens tool calls into prose.** `distill.py:46-52` builds the completion as `text + "\nTool calls: " + json.dumps(tool_calls)`. The emitted `completion` is a string; the assistant turn carries no structured `tool_calls` array.
+- **Tool results are stubbed to a literal placeholder.** In `emit_rows`, `_content()` returns the constant string `"[tool result]"` for any `role == "tool"` event (`distill.py:72-73`). The training row's `conversations` context therefore never contains what a tool actually returned.
+- **The parse layer already keeps the data the emit layer throws away.** The Claude Code adapter preserves `command` and `output` on each tool event (`adapters/claude_code.py:89-91`); the adapter contract is `{"role":"assistant", "tool_calls":[{"name","input"}]}` (`adapters/base.py:14`). So this is purely an **emit-side** loss, matching the standing note in memory: *"distiller stubs tool I/O but parse layer keeps it → tool-use needs native-format emit."*
+- **We already own the target shape.** `InferenceLogRecord` stores OpenAI-native `messages` + `tools` + `tool_calls` (`catalog.py:37-45`); SynthChat's `tool_call_formats.yaml` ships an `openai_native` format (lines 57-82). The distiller is the only producer that does not emit this shape.
+- **The flywheel record has score but no rationale.** `InferenceLogRecord` carries `fitness_score`, `is_valid`, `tag`, `errors` (`catalog.py:59-63`) and the catalog indexes/filters on `fitness_score` with `update_score()` (`catalog.py:161,194,328`). `JudgeScore.feedback` + `per_dimension` reasoning exist in the judge module (`shared/judge/models.py:84-90`) but there is **no field on the record to hold them**.
+
+---
+
+## Goal
+
+Bring the transcript distiller's output into line with the OpenAI-native tool shape the rest of the repo already uses (structured `tool_calls` on assistant turns, real tool output linked by id on tool turns), and let the flywheel persist the judge's *rationale* alongside its score so production logs can be triaged by **why**, not just by number. Optionally, add a path to freeze curated flywheel failures into a re-runnable `Evaluator/` regression set.
+
+**Design principle:** Internal consistency over external adoption. The native target schema is the one we already emit elsewhere — do not introduce OpenInference as a dependency. All flywheel changes are additive and opt-in; existing SFT/KTO/DPO/GRPO consumers and old JSONL rows stay byte-compatible.
+
+---
+
+## Why This Fits
+
+| Phoenix / OpenInference Concept | Existing Infrastructure | Gap |
+|---|---|---|
+| Structured tool-call span (`tool_call.function.name`/`.arguments`) | `InferenceLogRecord.tool_calls`, SynthChat `openai_native` format | Distiller flattens to a `"Tool calls: …"` string (`distill.py:46-52`) |
+| Tool result linked to its call (`message.tool_call_id` ↔ `tool_call.id`) | Adapter keeps `command`+`output` per tool event (`claude_code.py:89-91`) | Emit layer replaces it with `"[tool result]"` (`distill.py:72-73`) |
+| Eval label **and explanation** attached to each span | `fitness_score`/`is_valid` on record + `update_score()` + score index | No field for the judge's `feedback`/`per_dimension` rationale |
+| Datasets-as-experiments (freeze examples, re-run versions) | Stager routes logs to sft/kto/skip; `Evaluator/` runs YAML scenarios | No path from flywheel failures → frozen, re-runnable eval set |
+| Rails (constrained label + forced explanation) | `RubricDef.output_schema` + `quality_gate` (`models.py`) | **None — already richer than Phoenix.** Not borrowed. |
+
+---
+
+## What Gets Built
+
+| # | Artifact | Type | Est. Lines | Purpose |
+|---|----------|------|-----------|---------|
+| 0 | Trainer conversation-schema spike | Investigation | — | Confirm exactly what conversation/tool shape the SFT/KTO/DPO/GRPO loaders accept, so native emit stays consumable through method-specific projections |
+| 1 | `.skills/transcript-distillation/scripts/distill.py` | Edit | +~60 | Emit structured `tool_calls` on assistant turns + real tool output (linked by id) on tool turns, behind a config flag; keep flat-string mode as default until trainer-verified |
+| 2 | `.skills/transcript-distillation/scripts/adapters/*` | Edit | +~25 | Surface a stable `tool_call_id` ↔ result linkage in the normalized event contract (`base.py`, `claude_code.py`, `codex.py`) |
+| 3 | `.skills/transcript-distillation/configs/*.yaml` | Edit | +~10 | `render_mode: flat \| native` (+ tool-output truncation budget) |
+| 4 | `shared/flywheel/catalog.py` (`InferenceLogRecord` + backends) | Edit | +~30 | Add `verdict_rationale: str \| None` (+ optional per-rubric labels); additive sqlite/postgres column |
+| 5 | `shared/flywheel/*` writer of scores | Edit | +~15 | Extend `update_score()` path to also persist judge `feedback`/`per_dimension` when present |
+| 6 | Frozen-fixtures exporter (flywheel → `Evaluator/`) | New | ~120 | CLI to select failing logs by filter and emit a versioned assertion-YAML scenario set |
+| 7 | `tests/` (distiller + flywheel) | New test | ~200 | Native-emit shape, id linkage, flat back-compat, rationale persistence, fixture export shape |
+| 8 | Skill + docs updates | Skill update | +~50 | `transcript-distillation`, `fine-tuning`/flywheel, `evaluation` sections + mirror sync |
+
+**Total: ~110 net lines Python, ~10 lines YAML, ~200 lines tests, ~50 lines docs/skills. 5 files edited, 2 new artifacts, config + skill updates.** No new dependency. No change to the default distiller output or SFT/KTO/DPO/GRPO staging until trainer-verified.
+
+---
+
+## Data Flow
+
+```
+Agent transcript (Claude Code / Codex JSONL)
+        │
+        ▼
+┌─────────────────────────────┐
+│ adapters/*.py               │  Parse → normalized events. Already keep
+│  (parse layer)              │  tool name/input + result command/output;
+│                             │  ADD: stable tool_call_id ↔ result linkage.
+└──────────┬──────────────────┘
+           │ normalized events
+           ▼
+┌─────────────────────────────┐   render_mode: native
+│ distill.py emit_rows()      │  ── assistant turn → {content, tool_calls:[…]}
+│                             │  ── tool turn → real output, linked by id
+│                             │   render_mode: flat  (default, unchanged)
+│                             │  ── "Tool calls: …" string + "[tool result]"
+└──────────┬──────────────────┘
+           │ training rows ({conversations, completion, label, …})
+           ▼
+   SFT / KTO / DPO / GRPO projections  (shape confirmed in Phase 0)
+
+─────────────────────────────────────────────────────────────────────
+
+Production inference (separate path)
+   proxy → inference_logger → InferenceLogRecord (fitness_score)
+        │
+        ▼  judge scores a record
+   update_score(log_id, fitness_score, is_valid, errors,
+                + verdict_rationale, + per_rubric_labels)   ← NEW
+        │
+        ▼  (offline, optional)
+   frozen-fixtures exporter → versioned Evaluator/ scenario set
+```
+
+---
+
+## Config Schema
+
+### Distiller config additions
+
+```yaml
+distill:
+  render:
+    # flat  = today's behavior: tool calls flattened into the completion
+    #         string ("Tool calls: …"), tool results stubbed to "[tool result]".
+    # native = structured tool_calls on assistant turns + real tool output
+    #          (linked by tool_call_id) on tool turns.
+    # Default stays `flat` until the trainer loaders are confirmed (Phase 0).
+    render_mode: flat
+    # Cap per tool-result body in native mode (chars). Oversized output is
+    # truncated with a marker so context budget stays bounded.
+    max_tool_output_chars: 2000
+```
+
+### Flywheel config / record additions
+
+```yaml
+flywheel:
+  scoring:
+    # Persist the judge's rationale + per-rubric labels onto the record,
+    # not just the numeric fitness_score. Off by default (additive column).
+    persist_verdict_rationale: false
+```
+
+**Backward compatibility:** `render_mode: flat` reproduces today's distiller output byte-for-byte. `persist_verdict_rationale: false` and the new NULL-able `verdict_rationale` column leave the catalog readable by current code; old JSONL rows deserialize unchanged.
+
+---
+
+## Implementation Phases
+
+### Phase 0: Trainer Conversation-Schema Spike
+
+**Delegate to:** `pact-architect`
+
+| Task | Details |
+|------|---------|
+| Confirm loader contract | Determine exactly what conversation/tool shape the SFT, KTO, DPO, and GRPO loaders accept today (do they read `conversations` as `{role, content}` only, or can they consume `tool_calls` + `role:"tool"` turns with `tool_call_id`?). |
+| Decide native target | Pick the native emit shape: OpenAI-native messages (`tool_calls` on assistant, `role:"tool"` + `tool_call_id`) vs. a render that keeps a single `completion` string but structured. Reuse SynthChat's `openai_native` conventions where possible. |
+| Cross-check vs OpenInference | One-time check that the chosen shape covers id linkage (`tool_call.id` ↔ `message.tool_call_id`) and multi-call turns. Do **not** adopt OpenInference attribute names. |
+| Record findings | Append a "native emit contract" note to this plan before Phase 1. |
+
+**Gate:** Phase 1 emit design follows what the trainers actually accept. Do not change the default `render_mode` until this confirms native rows train cleanly.
+
+### Phase 0 Native Emit Contract Decision
+
+Native emit is a distiller source/emit format, not a replacement for every trainer's final input schema. The distiller keeps `render_mode: flat` as the default and adds opt-in `render_mode: native`; downstream training paths must project native rows into the shape each method actually accepts.
+
+Native rows use the existing OpenAI-native message convention:
+
+```json
+{
+  "conversations": [
+    {"role": "user", "content": "..."},
+    {
+      "role": "assistant",
+      "content": "...",
+      "tool_calls": [
+        {
+          "id": "call_stable_id",
+          "type": "function",
+          "function": {"name": "Edit", "arguments": "{\"file_path\":\"...\"}"}
+        }
+      ]
+    },
+    {"role": "tool", "tool_call_id": "call_stable_id", "content": "..."}
+  ],
+  "prompt": "...",
+  "completion": "...",
+  "label": true,
+  "metadata": {"render_mode": "native"}
+}
+```
+
+Every assistant tool call and its matching tool-result turn must share a stable `tool_call_id`. Existing source ids should be preserved where the transcript format provides them; otherwise the adapter must derive a deterministic id from stable transcript position data so repeated distillation runs produce the same linkage.
+
+Trainer compatibility findings:
+
+| Method | Native compatibility decision |
+|--------|-------------------------------|
+| SFT | Prepare currently renders native tool messages back into text for training. Native emit is useful as source data, but SFT still needs a text projection until the SFT loader intentionally accepts structured tool messages. |
+| KTO | KTO partially handles assistant tool calls, but drops tool-result target context. KTO rows need a projection that preserves the intended preference target rather than assuming native rows can be consumed directly. |
+| DPO | DPO requires paired role/content `prompt`, `chosen`, and `rejected` examples. Native rows require a pair-building projection before DPO training. |
+| Static GRPO | Static GRPO needs a prompt plus reward-ground-truth columns. Native rows require projection into the configured reward data shape. |
+| Env-GRPO | Environment-backed GRPO is rollout-row based. Native distiller rows can seed prompts or references, but do not replace rollout records. |
+
+This means `render_mode: native` is the high-fidelity emitted source contract for tool-use data; each trainer owns an explicit method-specific projection from that source contract into its runtime dataset contract.
+
+---
+
+### Phase 1: Adapter Linkage Contract
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Stable call↔result id | Extend the normalized event contract (`adapters/base.py`) so each assistant `tool_calls[i]` and its corresponding `role:"tool"` result share a `tool_call_id`. Claude Code already has `tool_use_id` (`claude_code.py:90`); thread it through instead of only `id2cmd`. |
+| Codex parity | Mirror the linkage in `adapters/codex.py` (`function_call` / `function_call_output`). |
+| No emit change yet | Adapters only enrich events; `emit_rows` still defaults to flat. Keep adapters independently testable. |
+
+---
+
+### Phase 2: Native Emit in the Distiller
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| `render_mode` switch | Add the config flag; `flat` keeps `render_completion()` exactly as-is (`distill.py:46-52`). |
+| Native assistant turn | In native mode, emit structured `tool_calls` (name + parsed input) on the assistant turn instead of the `"Tool calls: …"` string. |
+| Native tool turn | Replace the `"[tool result]"` stub (`distill.py:72-73`) with the real captured `output`, truncated to `max_tool_output_chars`, carrying its `tool_call_id`. |
+| Context-budget accounting | `est()`/budget logic in `emit_rows` must count real tool output; ensure oversize handling still trims oldest-first without dropping the linked call/result pair inconsistently. |
+| Labeling untouched | The deterministic good/bad/borderline labeling and `failure_labels` must be byte-identical between flat and native (only the rendered content differs). |
+
+---
+
+### Phase 3: Flywheel Verdict Rationale
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Record field | Add `verdict_rationale: str \| None` (and optional `rubric_labels: dict \| None`) to `InferenceLogRecord` (`catalog.py`), `None` by default; `to_json()` omits when unset. |
+| Catalog migration | Additive NULL-able column on both sqlite and postgres backends; existing rows tolerate NULL. |
+| Persist on score | Extend the `update_score()` write path so that, when `persist_verdict_rationale` is on and a `JudgeResult` is available, the judge's `feedback`/`per_dimension` reasoning is written alongside `fitness_score`. |
+| Make it filterable | Ensure the rationale is retrievable in the same catalog query path that already filters by `fitness_score`. |
+
+---
+
+### Phase 4: Frozen Regression Fixtures (optional, lower priority)
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Exporter CLI | Select flywheel logs by existing filters (e.g. `is_valid == false`, `max_score`, `tag`) and emit a versioned `Evaluator/` assertion-YAML scenario set. |
+| Reuse Evaluator schema | Output must be a valid Evaluator scenario consumable by the existing config-driven runner — no new eval engine. |
+| Versioning | Stamp the frozen set with a version/date so re-runs across candidate models are comparable. |
+
+**Gate:** Only build after Phases 1–3 land and there is demand for a standing regression set.
+
+---
+
+### Phase 5: Tests
+
+**Delegate to:** `pact-test-engineer`
+
+| Test | Type | What |
+|------|------|------|
+| `test_emit_flat_unchanged` | Unit | `render_mode: flat` output is byte-identical to current emit on a fixture transcript. |
+| `test_emit_native_tool_calls` | Unit | Native mode emits structured `tool_calls` on the assistant turn; no `"Tool calls: …"` string. |
+| `test_emit_native_tool_result` | Unit | Tool turn carries real (truncated) output with the linking `tool_call_id`, not `"[tool result]"`. |
+| `test_adapter_id_linkage` | Unit | Claude Code + Codex adapters emit matching `tool_call_id` on call and result. |
+| `test_native_budget_trim` | Unit | Oversize tool output truncates; call/result pairing stays consistent under context-budget trimming. |
+| `test_verdict_rationale_persist` | Unit | With the flag on, `update_score` writes rationale; with it off, record is byte-compatible. |
+| `test_catalog_backcompat` | Unit | Old rows (no `verdict_rationale`) deserialize and index on both backends. |
+| `test_fixture_export_shape` | Integration | Exporter emits a valid Evaluator scenario the runner can load. |
+
+---
+
+### Phase 6: Documentation
+
+**Delegate to:** `pact-backend-coder`
+
+| Task | Details |
+|------|---------|
+| Skill updates | `transcript-distillation` (render modes), `fine-tuning`/flywheel (verdict rationale, fixture export), `evaluation` (frozen regression set). |
+| Sync mirrors | `python3 .skills/scripts/sync_skill_trees.py` after editing `.skills/` (mirrors under `.agents/skills`, `.claude/skills`, `.codex/skills`). |
+
+---
+
+## Risk Mitigation
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Native rows don't train cleanly in SFT/KTO/DPO/GRPO loaders | High | Phase 0 gate; default stays `flat` until method-specific projections are verified; native is opt-in. |
+| Default distiller output changes silently | High | `render_mode: flat` is the default and asserted byte-identical (`test_emit_flat_unchanged`). |
+| Context-budget blowup from real tool output | Medium | `max_tool_output_chars` truncation; oversize trimming covered by test. |
+| Call/result pairing breaks under trimming | Medium | Linkage by `tool_call_id`; explicit pairing-consistency test. |
+| Catalog migration breaks existing rows | Medium | Additive NULL-able column on both backends; back-compat test. |
+| Skill mirrors drift from `.skills/` source | Low | `sync_skill_trees.py --check` in Phase 6. |
+| Scope creep into adopting OpenInference as a dependency | Medium | Explicitly out of scope — internal native shape only. |
+
+---
+
+## Connection to Existing Systems
+
+| Existing System | Relationship |
+|---|---|
+| **Transcript distiller** (`.skills/transcript-distillation/scripts/`) | Direct target. New `render_mode`; adapters enrich linkage; flat path unchanged. |
+| **SynthChat tool formats** (`SynthChat/config/tool_call_formats.yaml`) | Reference shape — native emit reuses `openai_native` conventions for consistency. |
+| **Flywheel record/catalog** (`shared/flywheel/catalog.py`) | Additive `verdict_rationale` column; existing score index/filters untouched. |
+| **Judge** (`shared/judge/models.py`) | Source of the rationale (`JudgeScore.feedback`/`per_dimension`) now persisted onto the record. |
+| **Evaluator** (`Evaluator/`) | Frozen-fixtures exporter emits scenarios consumable by the existing runner. |
+| **`project_finetune_personal_transcripts` memory** | This plan resolves the standing "tool-use needs native-format emit" gap it records. |
+
+---
+
+## Out of Scope (explicitly)
+
+- **Adopting OpenInference / OpenTelemetry as a schema or dependency.** We already have an internal native tool shape; the borrow is internal consistency, not external instrumentation.
+- **A Phoenix-style trace collector or UI.** We are not debugging a deployed app; the flywheel JSONL + catalog already serve offline triage.
+- **Phoenix prompt playground / span replay.** Assumes a live app surface we don't run.
+- **Changing the judge's scoring mechanics.** The judge is already richer than Phoenix's rails; only its *output persistence* changes here.
+
+---
+
+## Success Criteria
+
+1. Phase 0 produces a written "native emit contract" decision appended to this plan, confirming the trainer-accepted shape.
+2. `render_mode: flat` output is byte-identical to today's distiller on fixture transcripts.
+3. `render_mode: native` emits structured `tool_calls` on assistant turns and real, id-linked tool output on tool turns — no `"Tool calls: …"` string, no `"[tool result]"` stub.
+4. Claude Code and Codex adapters emit matching `tool_call_id` on each call and its result.
+5. With `persist_verdict_rationale: true`, scored flywheel records carry the judge's rationale; with it off, records are byte-compatible with current readers on both backends.
+6. (If Phase 4 built) The exporter produces a versioned Evaluator scenario set the existing runner loads and runs.
+7. All existing distiller, flywheel, and evaluator tests pass unchanged; skills updated and mirrors synced.

--- a/requirements-flywheel.txt
+++ b/requirements-flywheel.txt
@@ -8,6 +8,9 @@
 # Async SQLite for local log catalog
 aiosqlite>=0.20.0,<1.0
 
+# Async test support for flywheel catalog checks
+pytest-asyncio>=0.23.0,<1.0
+
 # Async PostgreSQL for cloud/multi-tenant log catalog
 asyncpg>=0.29.0,<1.0
 

--- a/shared/flywheel/catalog.py
+++ b/shared/flywheel/catalog.py
@@ -20,6 +20,13 @@ from typing import Any, Protocol, runtime_checkable
 logger = logging.getLogger(__name__)
 
 
+def _load_json_field(value: Any) -> Any:
+    """Decode JSON values from SQL drivers while tolerating NULLs."""
+    if value is None or isinstance(value, (dict, list)):
+        return value
+    return json.loads(value)
+
+
 # ---------------------------------------------------------------------------
 # Data structures
 # ---------------------------------------------------------------------------
@@ -58,6 +65,8 @@ class InferenceLogRecord:
     latency_ms: float = 0.0
     fitness_score: float | None = None
     is_valid: bool | None = None
+    verdict_rationale: str | None = None
+    rubric_scores: list[dict[str, Any]] | None = None
     tag: str | None = None
     dataset_version: str | None = None
     errors: list[str] = field(default_factory=list)
@@ -76,11 +85,15 @@ class InferenceLogRecord:
         "completion_token_ids",
         "completion_logprobs",
     )
+    _OPTIONAL_VERDICT_FIELDS = (
+        "verdict_rationale",
+        "rubric_scores",
+    )
 
     def to_json(self) -> str:
         """Serialize to JSON string (omitting unset token-capture fields)."""
         data = asdict(self)
-        for key in self._OPTIONAL_TOKEN_FIELDS:
+        for key in self._OPTIONAL_TOKEN_FIELDS + self._OPTIONAL_VERDICT_FIELDS:
             if data.get(key) is None:
                 data.pop(key, None)
         return json.dumps(data, ensure_ascii=False, separators=(",", ":"))
@@ -159,7 +172,13 @@ class LogCatalog(Protocol):
     async def count_logs(self, filters: LogFilter) -> int: ...
     async def avg_score(self, filters: LogFilter) -> float: ...
     async def update_score(
-        self, log_id: str, fitness_score: float, is_valid: bool, errors: list[str],
+        self,
+        log_id: str,
+        fitness_score: float,
+        is_valid: bool,
+        errors: list[str],
+        verdict_rationale: str | None = None,
+        rubric_scores: list[dict[str, Any]] | None = None,
     ) -> None: ...
     async def update_tag(self, log_id: str, tag: str, tag_source: str) -> None: ...
     async def mark_used(self, log_ids: list[str], dataset_version: str) -> None: ...
@@ -182,6 +201,8 @@ CREATE TABLE IF NOT EXISTS inference_logs (
     tools_requested INTEGER NOT NULL DEFAULT 0,
     fitness_score   REAL,
     is_valid        INTEGER,
+    verdict_rationale TEXT,
+    rubric_scores   TEXT,
     tag             TEXT,
     tag_source      TEXT,
     dataset_version TEXT,
@@ -233,6 +254,7 @@ class SQLiteLogCatalog:
         self._conn = await aiosqlite.connect(str(self._db_path))
         await self._conn.execute("PRAGMA journal_mode=WAL")
         await self._conn.executescript(_SQLITE_SCHEMA)
+        await self._ensure_schema()
         await self._conn.commit()
 
     async def close(self) -> None:
@@ -326,14 +348,29 @@ class SQLiteLogCatalog:
         return float(row[0]) if row and row[0] is not None else 0.0
 
     async def update_score(
-        self, log_id: str, fitness_score: float, is_valid: bool, errors: list[str],
+        self,
+        log_id: str,
+        fitness_score: float,
+        is_valid: bool,
+        errors: list[str],
+        verdict_rationale: str | None = None,
+        rubric_scores: list[dict[str, Any]] | None = None,
     ) -> None:
         """Update fitness score and validation status."""
         await self._conn.execute(
             """UPDATE inference_logs
-               SET fitness_score = ?, is_valid = ?
+               SET fitness_score = ?,
+                   is_valid = ?,
+                   verdict_rationale = ?,
+                   rubric_scores = ?
                WHERE log_id = ?""",
-            (fitness_score, 1 if is_valid else 0, log_id),
+            (
+                fitness_score,
+                1 if is_valid else 0,
+                verdict_rationale,
+                json.dumps(rubric_scores) if rubric_scores is not None else None,
+                log_id,
+            ),
         )
         await self._conn.commit()
 
@@ -414,6 +451,20 @@ class SQLiteLogCatalog:
 
     # -- Internal helpers ---------------------------------------------------
 
+    async def _ensure_schema(self) -> None:
+        """Add nullable columns introduced after the initial SQLite schema."""
+        cursor = await self._conn.execute("PRAGMA table_info(inference_logs)")
+        rows = await cursor.fetchall()
+        existing = {row[1] for row in rows}
+        if "verdict_rationale" not in existing:
+            await self._conn.execute(
+                "ALTER TABLE inference_logs ADD COLUMN verdict_rationale TEXT"
+            )
+        if "rubric_scores" not in existing:
+            await self._conn.execute(
+                "ALTER TABLE inference_logs ADD COLUMN rubric_scores TEXT"
+            )
+
     def _build_query(
         self, select: str, filters: LogFilter,
     ) -> tuple[str, list]:
@@ -475,6 +526,8 @@ class SQLiteLogCatalog:
             tool_calls=[{}] if row.get("has_tool_calls") else [],
             fitness_score=row.get("fitness_score"),
             is_valid=bool(row["is_valid"]) if row.get("is_valid") is not None else None,
+            verdict_rationale=row.get("verdict_rationale"),
+            rubric_scores=_load_json_field(row.get("rubric_scores")),
             tag=row.get("tag"),
             dataset_version=row.get("dataset_version"),
             source_file=row.get("source_file", ""),
@@ -550,6 +603,8 @@ class PostgresLogCatalog:
                     tools_requested BOOLEAN NOT NULL DEFAULT FALSE,
                     fitness_score   DOUBLE PRECISION,
                     is_valid        BOOLEAN,
+                    verdict_rationale TEXT,
+                    rubric_scores   JSONB,
                     tag             TEXT,
                     tag_source      TEXT,
                     dataset_version TEXT,
@@ -559,6 +614,14 @@ class PostgresLogCatalog:
                     created_at      TEXT NOT NULL DEFAULT NOW()::TEXT
                 )
             """)
+            await conn.execute(
+                f"ALTER TABLE {self._schema}.inference_logs "
+                "ADD COLUMN IF NOT EXISTS verdict_rationale TEXT"
+            )
+            await conn.execute(
+                f"ALTER TABLE {self._schema}.inference_logs "
+                "ADD COLUMN IF NOT EXISTS rubric_scores JSONB"
+            )
             await conn.execute(f"""
                 CREATE TABLE IF NOT EXISTS {self._schema}.dataset_versions (
                     version_id      TEXT PRIMARY KEY,
@@ -668,15 +731,28 @@ class PostgresLogCatalog:
         return float(row) if row is not None else 0.0
 
     async def update_score(
-        self, log_id: str, fitness_score: float, is_valid: bool, errors: list[str],
+        self,
+        log_id: str,
+        fitness_score: float,
+        is_valid: bool,
+        errors: list[str],
+        verdict_rationale: str | None = None,
+        rubric_scores: list[dict[str, Any]] | None = None,
     ) -> None:
         """Update fitness score and validation status."""
         async with self._pool.acquire() as conn:
             await conn.execute(
                 f"""UPDATE {self._schema}.inference_logs
-                    SET fitness_score = $1, is_valid = $2
-                    WHERE log_id = $3""",
-                fitness_score, is_valid, log_id,
+                    SET fitness_score = $1,
+                        is_valid = $2,
+                        verdict_rationale = $3,
+                        rubric_scores = $4::jsonb
+                    WHERE log_id = $5""",
+                fitness_score,
+                is_valid,
+                verdict_rationale,
+                json.dumps(rubric_scores) if rubric_scores is not None else None,
+                log_id,
             )
 
     async def update_tag(
@@ -821,6 +897,8 @@ class PostgresLogCatalog:
             tool_calls=[{}] if row.get("has_tool_calls") else [],
             fitness_score=row.get("fitness_score"),
             is_valid=row["is_valid"] if row.get("is_valid") is not None else None,
+            verdict_rationale=row.get("verdict_rationale"),
+            rubric_scores=_load_json_field(row.get("rubric_scores")),
             tag=row.get("tag"),
             dataset_version=row.get("dataset_version"),
             source_file=row.get("source_file", ""),

--- a/tests/flywheel/test_catalog.py
+++ b/tests/flywheel/test_catalog.py
@@ -28,6 +28,8 @@ class TestInferenceLogRecord:
         assert r.tools_requested is False
         assert r.tool_calls == []
         assert r.fitness_score is None
+        assert r.verdict_rationale is None
+        assert r.rubric_scores is None
         assert r.tag is None
         assert r.errors == []
 
@@ -46,6 +48,28 @@ class TestInferenceLogRecord:
         assert data["tools_requested"] is True
         assert len(data["tool_calls"]) == 1
         assert data["fitness_score"] == 0.85
+        assert "verdict_rationale" not in data
+        assert "rubric_scores" not in data
+
+    def test_to_json_includes_verdict_fields_when_set(self):
+        r = InferenceLogRecord(
+            log_id="test-1",
+            timestamp="2026-01-01T00:00:00Z",
+            model_id="gpt-test",
+            verdict_rationale="Clear tool use and concise answer.",
+            rubric_scores=[
+                {
+                    "rubric_key": "tool_quality",
+                    "score": 0.91,
+                    "per_dimension": [
+                        {"key": "correctness", "score": 0.9, "reasoning": "ok"}
+                    ],
+                }
+            ],
+        )
+        data = json.loads(r.to_json())
+        assert data["verdict_rationale"] == "Clear tool use and concise answer."
+        assert data["rubric_scores"][0]["rubric_key"] == "tool_quality"
 
     def test_from_dict_ignores_unknown_fields(self):
         data = {
@@ -178,6 +202,48 @@ class TestSQLiteLogCatalog:
         low = await catalog.find_logs(LogFilter(max_score=0.5))
         assert len(low) == 0
 
+    async def test_update_score_persists_verdict_rationale_and_rubric_scores(
+        self, catalog,
+    ):
+        r = _make_record("score-meta")
+        rubric_scores = [
+            {
+                "rubric_key": "tool_quality",
+                "rubric_name": "Tool Quality",
+                "score": 0.88,
+                "passed": True,
+                "pass_threshold": 0.8,
+                "feedback": "Good structure.",
+                "per_dimension": [
+                    {
+                        "key": "correctness",
+                        "name": "Correctness",
+                        "weight": 0.7,
+                        "reasoning": "The tool call matches the request.",
+                        "score": 0.9,
+                    }
+                ],
+                "quality_gated_score": 0.86,
+            }
+        ]
+        await catalog.insert_log(r)
+        await catalog.update_score(
+            "score-meta",
+            0.88,
+            True,
+            [],
+            verdict_rationale="Good structure.",
+            rubric_scores=rubric_scores,
+        )
+
+        results = await catalog.find_logs(LogFilter())
+
+        assert len(results) == 1
+        assert results[0].fitness_score == 0.88
+        assert results[0].is_valid is True
+        assert results[0].verdict_rationale == "Good structure."
+        assert results[0].rubric_scores == rubric_scores
+
     async def test_unscored_only_filter(self, catalog):
         r1 = _make_record("us1")
         r2 = _make_record("us2")
@@ -281,6 +347,55 @@ class TestSQLiteLogCatalog:
         with_tools = await catalog.find_logs(LogFilter(has_tool_calls=True))
         assert len(with_tools) == 1
         assert with_tools[0].log_id == "tc1"
+
+    async def test_initialize_migrates_existing_sqlite_catalog(self, tmp_path):
+        import aiosqlite
+
+        db_path = tmp_path / "old.db"
+        conn = await aiosqlite.connect(str(db_path))
+        await conn.execute(
+            """CREATE TABLE inference_logs (
+                log_id          TEXT PRIMARY KEY,
+                timestamp       TEXT NOT NULL,
+                model_id        TEXT NOT NULL,
+                adapter_name    TEXT,
+                has_tool_calls  INTEGER NOT NULL DEFAULT 0,
+                tools_requested INTEGER NOT NULL DEFAULT 0,
+                fitness_score   REAL,
+                is_valid        INTEGER,
+                tag             TEXT,
+                tag_source      TEXT,
+                dataset_version TEXT,
+                source_file     TEXT NOT NULL,
+                line_number     INTEGER NOT NULL,
+                created_at      TEXT NOT NULL DEFAULT ''
+            )"""
+        )
+        await conn.commit()
+        await conn.close()
+
+        migrated = SQLiteLogCatalog(db_path)
+        await migrated.initialize()
+        await migrated.insert_log(_make_record("migrated"))
+        await migrated.update_score(
+            "migrated",
+            0.92,
+            True,
+            [],
+            verdict_rationale="Migrated schema stores rationale.",
+            rubric_scores=[{"rubric_key": "migration", "score": 0.92}],
+        )
+
+        results = await migrated.find_logs(LogFilter())
+
+        assert (
+            results[0].verdict_rationale
+            == "Migrated schema stores rationale."
+        )
+        assert results[0].rubric_scores == [
+            {"rubric_key": "migration", "score": 0.92}
+        ]
+        await migrated.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/transcript_distillation/test_native_render.py
+++ b/tests/transcript_distillation/test_native_render.py
@@ -1,0 +1,180 @@
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / ".skills" / "transcript-distillation" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from adapters.claude_code import ClaudeCodeAdapter  # noqa: E402
+from adapters.codex import CodexAdapter  # noqa: E402
+from distill import emit_rows, redact_nested  # noqa: E402
+from sanitize import Redactor  # noqa: E402
+
+
+LAB = {
+    "correction_markers": ["no"],
+    "interrupt_markers": ["[request interrupted"],
+    "max_correction_chars": 180,
+}
+
+
+def test_native_render_preserves_legacy_fields_and_native_tool_messages():
+    events = [
+        {"role": "human", "text": "Run the command"},
+        {
+            "role": "assistant",
+            "text": "I'll run it.",
+            "tool_calls": [{"id": "call_1", "name": "shell", "input": {"command": "echo ok"}}],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "tool_error": False,
+            "command": "echo ok",
+            "output": "ok",
+        },
+        {"role": "assistant", "text": "Done.", "tool_calls": []},
+    ]
+
+    rows = emit_rows(
+        events,
+        source_kind="unit",
+        project="proj",
+        rel_id="session.jsonl",
+        lab=LAB,
+        ctx_budget={"max_context_tokens": 8192, "chars_per_token": 4.0, "max_context_messages": 10},
+        render_mode="native",
+    )
+
+    tool_call_row = rows[0]
+    assert tool_call_row["prompt"] == "Run the command"
+    assert tool_call_row["completion"] == "I'll run it."
+    assert tool_call_row["label"] is True
+    assistant = tool_call_row["conversations"][-1]
+    assert assistant == {
+        "role": "assistant",
+        "content": "I'll run it.",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "shell", "arguments": '{"command": "echo ok"}'},
+            }
+        ],
+    }
+
+    final_row = rows[1]
+    assert final_row["completion"] == "Done."
+    tool_msg = final_row["conversations"][-2]
+    assert tool_msg == {"role": "tool", "tool_call_id": "call_1", "content": "ok"}
+
+
+def test_flat_render_remains_default_tool_calls_text_shape():
+    rows = emit_rows(
+        [
+            {"role": "human", "text": "Run it"},
+            {
+                "role": "assistant",
+                "text": "",
+                "tool_calls": [{"id": "call_1", "name": "shell", "input": {"command": "echo ok"}}],
+            },
+        ],
+        source_kind="unit",
+        project="proj",
+        rel_id="session.jsonl",
+        lab=LAB,
+        ctx_budget={},
+    )
+
+    assert rows[0]["completion"].startswith("Tool calls: ")
+    assert rows[0]["conversations"][-1] == {
+        "role": "assistant",
+        "content": rows[0]["completion"],
+    }
+
+
+def test_native_redaction_covers_serialized_tool_arguments():
+    redactor = Redactor({
+        "enabled": True,
+        "replacement": "[REDACTED:{name}]",
+        "patterns": {"openai_key": "sk-[A-Za-z0-9_-]{20,}"},
+    })
+    counts = Counter()
+
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "arguments": '{"command": "echo sk-abcdefghijklmnopqrst"}',
+            },
+        }
+    ]
+
+    redacted = redact_nested(tool_calls, redactor, counts)
+    assert redacted[0]["function"]["arguments"] == '{"command": "echo [REDACTED:openai_key]"}'
+    assert counts["openai_key"] == 1
+
+
+def test_codex_adapter_links_call_id_to_tool_result(tmp_path):
+    transcript = tmp_path / "codex.jsonl"
+    transcript.write_text(
+        "\n".join([
+            json.dumps({"type": "session_meta", "payload": {"cwd": str(tmp_path)}}),
+            json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "call_id": "call_abc",
+                    "name": "shell",
+                    "arguments": json.dumps({"cmd": "pytest"}),
+                },
+            }),
+            json.dumps({
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call_abc",
+                    "output": "1 passed",
+                },
+            }),
+        ])
+    )
+
+    events, _ = CodexAdapter().parse(str(transcript))
+    assert events[0]["tool_calls"][0]["id"] == "call_abc"
+    assert events[1]["tool_call_id"] == "call_abc"
+    assert events[1]["command"] == "pytest"
+
+
+def test_claude_adapter_links_tool_use_id_to_tool_result(tmp_path):
+    transcript = tmp_path / "claude.jsonl"
+    transcript.write_text(
+        "\n".join([
+            json.dumps({
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "id": "toolu_1", "name": "Bash",
+                         "input": {"command": "pytest"}}
+                    ]
+                },
+            }),
+            json.dumps({
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "toolu_1", "content": "1 passed"}
+                    ]
+                },
+            }),
+        ])
+    )
+
+    events, _ = ClaudeCodeAdapter().parse(str(transcript))
+    assert events[0]["tool_calls"][0]["id"] == "toolu_1"
+    assert events[1]["tool_call_id"] == "toolu_1"
+    assert events[1]["command"] == "pytest"


### PR DESCRIPTION
Adds opt-in native tool trace emission for transcript distillation, additive flywheel verdict rationale persistence, and docs/tests for SFT, KTO, DPO, and GRPO trainer contract scope. Validation run from the isolated worktree: python -m pytest tests\transcript_distillation\test_native_render.py, python -m pytest tests\flywheel\test_catalog.py, python .skills\scripts\sync_skill_trees.py --check, git diff --check.