### PR TITLE
[codex] Project distiller rows for flywheel training

### DIFF
--- a/.agents/skills/transcript-distillation/scripts/project_rows.py
+++ b/.agents/skills/transcript-distillation/scripts/project_rows.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Project transcript-distillation rows into trainer-specific JSONL targets.
+
+The distiller emits a shared flat/native row shape. This script keeps the
+method-specific DPO and static-GRPO projections outside trainer loaders.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+TOOL_CALLS_RE = re.compile(r"Tool calls:\s*(\[[\s\S]*\])\s*$")
+
+
+@dataclass
+class ProjectConfig:
+    target: str = "dpo"
+    input_path: Path | None = None
+    output_path: Path | None = None
+    report_path: Path | None = None
+    prompt_mode: str = "prior_messages"
+    include_tool_messages: bool = False
+    prompt_key_field: str | None = None
+
+
+@dataclass
+class ProjectionResult:
+    rows: list[dict[str, Any]]
+    counters: Counter = field(default_factory=Counter)
+
+
+def load_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"projection config must be a mapping: {path}")
+    return loaded
+
+
+def resolve_project_config(args: argparse.Namespace) -> ProjectConfig:
+    cfg = load_config(args.config)
+    projection = cfg.get("projection") or cfg
+    if not isinstance(projection, dict):
+        raise ValueError("projection config must be a mapping")
+
+    target_cfg = projection.get("targets") or {}
+    dpo_cfg = projection.get("dpo") or target_cfg.get("dpo") or {}
+
+    target = args.target or projection.get("target") or "dpo"
+    prompt_mode = args.prompt_mode or projection.get("prompt_mode") or "prior_messages"
+    include_tool_messages = (
+        args.include_tool_messages
+        if args.include_tool_messages is not None
+        else bool(projection.get("include_tool_messages", False))
+    )
+    prompt_key_field = args.prompt_key_field or dpo_cfg.get("prompt_key_field")
+
+    return ProjectConfig(
+        target=target,
+        input_path=args.input or _optional_path(projection.get("input")),
+        output_path=args.output or _optional_path(projection.get("output")),
+        report_path=args.report or _optional_path(projection.get("report")),
+        prompt_mode=prompt_mode,
+        include_tool_messages=include_tool_messages,
+        prompt_key_field=prompt_key_field,
+    )
+
+
+def _optional_path(value: str | None) -> Path | None:
+    return Path(value) if value else None
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                row = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSONL row: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_no}: row must be a JSON object")
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+            fh.write("\n")
+
+
+def write_report(path: Path, counters: Counter) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"counts": {key: counters[key] for key in sorted(counters)}}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def project_dpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    buckets: dict[str, dict[bool, list[dict[str, Any]]]] = defaultdict(lambda: {True: [], False: []})
+
+    for row in rows:
+        counters["input_rows"] += 1
+        label = row.get("label")
+        if label is None:
+            counters["dropped_null_label"] += 1
+            continue
+        if label not in (True, False):
+            counters["dropped_non_boolean_label"] += 1
+            continue
+
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        key = configured_prompt_key(row, cfg.prompt_key_field)
+        if key is None:
+            key = prompt_hash(prompt)
+        elif key == "":
+            counters["dropped_missing_prompt_key"] += 1
+            continue
+
+        buckets[str(key)][label].append({
+            "prompt": prompt,
+            "target": serialize_assistant_for_dpo(target[1]),
+            "source_example_id": row.get("source_example_id"),
+        })
+        counters["eligible_rows"] += 1
+
+    out: list[dict[str, Any]] = []
+    for key in sorted(buckets):
+        chosen_rows = buckets[key][True]
+        rejected_rows = buckets[key][False]
+        if not chosen_rows:
+            counters["unpaired_rejected"] += len(rejected_rows)
+            continue
+        if not rejected_rows:
+            counters["unpaired_chosen"] += len(chosen_rows)
+            continue
+        for chosen in chosen_rows:
+            for rejected in rejected_rows:
+                out.append({
+                    "prompt": chosen["prompt"],
+                    "chosen": [chosen["target"]],
+                    "rejected": [rejected["target"]],
+                    "provenance": {
+                        "prompt_key": key,
+                        "chosen_source_example_id": chosen["source_example_id"],
+                        "rejected_source_example_id": rejected["source_example_id"],
+                    },
+                })
+                counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def project_static_grpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        counters["input_rows"] += 1
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        tool_call = first_target_tool_call(row, target[1])
+        if tool_call is None:
+            counters["dropped_missing_tool_call"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        name, args_json = normalize_tool_call(tool_call)
+        if not name:
+            counters["dropped_missing_tool_name"] += 1
+            continue
+
+        out.append({
+            "prompt": prompt,
+            "ground_truth_tool": name,
+            "ground_truth_args_json": args_json,
+            "provenance": {
+                "source_example_id": row.get("source_example_id"),
+                "prompt_hash": prompt_hash(prompt),
+            },
+        })
+        counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def prompt_messages(row: dict[str, Any], cfg: ProjectConfig, *, target_index: int) -> list[dict[str, str]]:
+    prior = row.get("conversations") or []
+    if not isinstance(prior, list):
+        return []
+    prior = prior[:target_index]
+    if not cfg.include_tool_messages:
+        prior = [msg for msg in prior if msg.get("role") != "tool"]
+
+    if cfg.prompt_mode == "last_user_only":
+        for msg in reversed(prior):
+            if msg.get("role") == "user":
+                return [role_content_message(msg)]
+        return []
+    if cfg.prompt_mode != "prior_messages":
+        raise ValueError("prompt_mode must be 'prior_messages' or 'last_user_only'")
+    roles = {"system", "user", "assistant"}
+    if cfg.include_tool_messages:
+        roles.add("tool")
+    return [role_content_message(msg) for msg in prior if msg.get("role") in roles]
+
+
+def role_content_message(message: dict[str, Any]) -> dict[str, str]:
+    return {
+        "role": str(message.get("role") or ""),
+        "content": "" if message.get("content") is None else str(message.get("content")),
+    }
+
+
+def target_assistant_message(row: dict[str, Any]) -> tuple[int, dict[str, Any]] | None:
+    conversations = row.get("conversations") or []
+    if isinstance(conversations, list):
+        for idx in range(len(conversations) - 1, -1, -1):
+            msg = conversations[idx]
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                return idx, msg
+
+    completion = row.get("completion")
+    if completion is not None:
+        return len(conversations) if isinstance(conversations, list) else 0, {
+            "role": "assistant",
+            "content": str(completion),
+        }
+    return None
+
+
+def serialize_assistant_for_dpo(message: dict[str, Any]) -> dict[str, str]:
+    content = "" if message.get("content") is None else str(message.get("content")).strip()
+    serialized_calls = serialize_tool_calls_text(message.get("tool_calls") or [])
+    if serialized_calls:
+        content = "\n".join(part for part in [content, serialized_calls] if part)
+    return {"role": "assistant", "content": content}
+
+
+def serialize_tool_calls_text(tool_calls: list[Any]) -> str:
+    if not tool_calls:
+        return ""
+    normalized = [normalize_tool_call_payload(call) for call in tool_calls]
+    return "Tool calls: " + json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def normalize_tool_call_payload(call: Any) -> dict[str, Any]:
+    if not isinstance(call, dict):
+        return {"name": "", "arguments": "{}"}
+    if isinstance(call.get("function"), dict):
+        fn = call["function"]
+        return {
+            "name": str(fn.get("name") or ""),
+            "arguments": canonical_args_json(fn.get("arguments")),
+        }
+    return {
+        "name": str(call.get("name") or ""),
+        "arguments": canonical_args_json(call.get("input")),
+    }
+
+
+def first_target_tool_call(row: dict[str, Any], target_message: dict[str, Any]) -> Any | None:
+    native_calls = target_message.get("tool_calls")
+    if isinstance(native_calls, list) and native_calls:
+        return native_calls[0]
+
+    completion = row.get("completion")
+    if completion is None:
+        completion = target_message.get("content")
+    calls = parse_flat_tool_calls(str(completion or ""))
+    return calls[0] if calls else None
+
+
+def parse_flat_tool_calls(completion: str) -> list[Any]:
+    match = TOOL_CALLS_RE.search(completion)
+    if not match:
+        return []
+    payload = match.group(1)
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        try:
+            parsed = ast.literal_eval(payload)
+        except (ValueError, SyntaxError):
+            return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def normalize_tool_call(call: Any) -> tuple[str, str]:
+    payload = normalize_tool_call_payload(call)
+    return payload["name"], payload["arguments"]
+
+
+def canonical_args_json(value: Any) -> str:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return "{}"
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return json.dumps(stripped, ensure_ascii=False)
+        return json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def configured_prompt_key(row: dict[str, Any], field: str | None) -> Any | None:
+    if not field:
+        return None
+    current: Any = row
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return ""
+        current = current[part]
+    return current
+
+
+def prompt_hash(messages: list[dict[str, str]]) -> str:
+    payload = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def project_rows(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    if cfg.target == "dpo":
+        return project_dpo(rows, cfg)
+    if cfg.target in {"static-grpo", "static_grpo"}:
+        return project_static_grpo(rows, cfg)
+    raise ValueError("target must be 'dpo' or 'static-grpo'")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="YAML projection config")
+    parser.add_argument("--input", type=Path, help="input rows.jsonl path")
+    parser.add_argument("--output", type=Path, help="output JSONL path")
+    parser.add_argument("--report", type=Path, help="optional JSON report path")
+    parser.add_argument("--target", choices=["dpo", "static-grpo", "static_grpo"])
+    parser.add_argument("--prompt-mode", choices=["prior_messages", "last_user_only"])
+    parser.add_argument("--prompt-key-field", help="dot path used to pair DPO rows")
+    parser.add_argument(
+        "--include-tool-messages",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="include role=tool messages in projected prompts",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = resolve_project_config(args)
+    if cfg.input_path is None or cfg.output_path is None:
+        raise SystemExit("--input and --output are required, either as CLI flags or config values")
+
+    result = project_rows(read_jsonl(cfg.input_path), cfg)
+    write_jsonl(cfg.output_path, result.rows)
+    if cfg.report_path:
+        write_report(cfg.report_path, result.counters)
+    print(json.dumps({"output_rows": result.counters["output_rows"], "counts": dict(result.counters)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/transcript-distillation/scripts/project_rows.py
+++ b/.claude/skills/transcript-distillation/scripts/project_rows.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Project transcript-distillation rows into trainer-specific JSONL targets.
+
+The distiller emits a shared flat/native row shape. This script keeps the
+method-specific DPO and static-GRPO projections outside trainer loaders.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+TOOL_CALLS_RE = re.compile(r"Tool calls:\s*(\[[\s\S]*\])\s*$")
+
+
+@dataclass
+class ProjectConfig:
+    target: str = "dpo"
+    input_path: Path | None = None
+    output_path: Path | None = None
+    report_path: Path | None = None
+    prompt_mode: str = "prior_messages"
+    include_tool_messages: bool = False
+    prompt_key_field: str | None = None
+
+
+@dataclass
+class ProjectionResult:
+    rows: list[dict[str, Any]]
+    counters: Counter = field(default_factory=Counter)
+
+
+def load_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"projection config must be a mapping: {path}")
+    return loaded
+
+
+def resolve_project_config(args: argparse.Namespace) -> ProjectConfig:
+    cfg = load_config(args.config)
+    projection = cfg.get("projection") or cfg
+    if not isinstance(projection, dict):
+        raise ValueError("projection config must be a mapping")
+
+    target_cfg = projection.get("targets") or {}
+    dpo_cfg = projection.get("dpo") or target_cfg.get("dpo") or {}
+
+    target = args.target or projection.get("target") or "dpo"
+    prompt_mode = args.prompt_mode or projection.get("prompt_mode") or "prior_messages"
+    include_tool_messages = (
+        args.include_tool_messages
+        if args.include_tool_messages is not None
+        else bool(projection.get("include_tool_messages", False))
+    )
+    prompt_key_field = args.prompt_key_field or dpo_cfg.get("prompt_key_field")
+
+    return ProjectConfig(
+        target=target,
+        input_path=args.input or _optional_path(projection.get("input")),
+        output_path=args.output or _optional_path(projection.get("output")),
+        report_path=args.report or _optional_path(projection.get("report")),
+        prompt_mode=prompt_mode,
+        include_tool_messages=include_tool_messages,
+        prompt_key_field=prompt_key_field,
+    )
+
+
+def _optional_path(value: str | None) -> Path | None:
+    return Path(value) if value else None
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                row = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSONL row: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_no}: row must be a JSON object")
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+            fh.write("\n")
+
+
+def write_report(path: Path, counters: Counter) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"counts": {key: counters[key] for key in sorted(counters)}}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def project_dpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    buckets: dict[str, dict[bool, list[dict[str, Any]]]] = defaultdict(lambda: {True: [], False: []})
+
+    for row in rows:
+        counters["input_rows"] += 1
+        label = row.get("label")
+        if label is None:
+            counters["dropped_null_label"] += 1
+            continue
+        if label not in (True, False):
+            counters["dropped_non_boolean_label"] += 1
+            continue
+
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        key = configured_prompt_key(row, cfg.prompt_key_field)
+        if key is None:
+            key = prompt_hash(prompt)
+        elif key == "":
+            counters["dropped_missing_prompt_key"] += 1
+            continue
+
+        buckets[str(key)][label].append({
+            "prompt": prompt,
+            "target": serialize_assistant_for_dpo(target[1]),
+            "source_example_id": row.get("source_example_id"),
+        })
+        counters["eligible_rows"] += 1
+
+    out: list[dict[str, Any]] = []
+    for key in sorted(buckets):
+        chosen_rows = buckets[key][True]
+        rejected_rows = buckets[key][False]
+        if not chosen_rows:
+            counters["unpaired_rejected"] += len(rejected_rows)
+            continue
+        if not rejected_rows:
+            counters["unpaired_chosen"] += len(chosen_rows)
+            continue
+        for chosen in chosen_rows:
+            for rejected in rejected_rows:
+                out.append({
+                    "prompt": chosen["prompt"],
+                    "chosen": [chosen["target"]],
+                    "rejected": [rejected["target"]],
+                    "provenance": {
+                        "prompt_key": key,
+                        "chosen_source_example_id": chosen["source_example_id"],
+                        "rejected_source_example_id": rejected["source_example_id"],
+                    },
+                })
+                counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def project_static_grpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        counters["input_rows"] += 1
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        tool_call = first_target_tool_call(row, target[1])
+        if tool_call is None:
+            counters["dropped_missing_tool_call"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        name, args_json = normalize_tool_call(tool_call)
+        if not name:
+            counters["dropped_missing_tool_name"] += 1
+            continue
+
+        out.append({
+            "prompt": prompt,
+            "ground_truth_tool": name,
+            "ground_truth_args_json": args_json,
+            "provenance": {
+                "source_example_id": row.get("source_example_id"),
+                "prompt_hash": prompt_hash(prompt),
+            },
+        })
+        counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def prompt_messages(row: dict[str, Any], cfg: ProjectConfig, *, target_index: int) -> list[dict[str, str]]:
+    prior = row.get("conversations") or []
+    if not isinstance(prior, list):
+        return []
+    prior = prior[:target_index]
+    if not cfg.include_tool_messages:
+        prior = [msg for msg in prior if msg.get("role") != "tool"]
+
+    if cfg.prompt_mode == "last_user_only":
+        for msg in reversed(prior):
+            if msg.get("role") == "user":
+                return [role_content_message(msg)]
+        return []
+    if cfg.prompt_mode != "prior_messages":
+        raise ValueError("prompt_mode must be 'prior_messages' or 'last_user_only'")
+    roles = {"system", "user", "assistant"}
+    if cfg.include_tool_messages:
+        roles.add("tool")
+    return [role_content_message(msg) for msg in prior if msg.get("role") in roles]
+
+
+def role_content_message(message: dict[str, Any]) -> dict[str, str]:
+    return {
+        "role": str(message.get("role") or ""),
+        "content": "" if message.get("content") is None else str(message.get("content")),
+    }
+
+
+def target_assistant_message(row: dict[str, Any]) -> tuple[int, dict[str, Any]] | None:
+    conversations = row.get("conversations") or []
+    if isinstance(conversations, list):
+        for idx in range(len(conversations) - 1, -1, -1):
+            msg = conversations[idx]
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                return idx, msg
+
+    completion = row.get("completion")
+    if completion is not None:
+        return len(conversations) if isinstance(conversations, list) else 0, {
+            "role": "assistant",
+            "content": str(completion),
+        }
+    return None
+
+
+def serialize_assistant_for_dpo(message: dict[str, Any]) -> dict[str, str]:
+    content = "" if message.get("content") is None else str(message.get("content")).strip()
+    serialized_calls = serialize_tool_calls_text(message.get("tool_calls") or [])
+    if serialized_calls:
+        content = "\n".join(part for part in [content, serialized_calls] if part)
+    return {"role": "assistant", "content": content}
+
+
+def serialize_tool_calls_text(tool_calls: list[Any]) -> str:
+    if not tool_calls:
+        return ""
+    normalized = [normalize_tool_call_payload(call) for call in tool_calls]
+    return "Tool calls: " + json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def normalize_tool_call_payload(call: Any) -> dict[str, Any]:
+    if not isinstance(call, dict):
+        return {"name": "", "arguments": "{}"}
+    if isinstance(call.get("function"), dict):
+        fn = call["function"]
+        return {
+            "name": str(fn.get("name") or ""),
+            "arguments": canonical_args_json(fn.get("arguments")),
+        }
+    return {
+        "name": str(call.get("name") or ""),
+        "arguments": canonical_args_json(call.get("input")),
+    }
+
+
+def first_target_tool_call(row: dict[str, Any], target_message: dict[str, Any]) -> Any | None:
+    native_calls = target_message.get("tool_calls")
+    if isinstance(native_calls, list) and native_calls:
+        return native_calls[0]
+
+    completion = row.get("completion")
+    if completion is None:
+        completion = target_message.get("content")
+    calls = parse_flat_tool_calls(str(completion or ""))
+    return calls[0] if calls else None
+
+
+def parse_flat_tool_calls(completion: str) -> list[Any]:
+    match = TOOL_CALLS_RE.search(completion)
+    if not match:
+        return []
+    payload = match.group(1)
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        try:
+            parsed = ast.literal_eval(payload)
+        except (ValueError, SyntaxError):
+            return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def normalize_tool_call(call: Any) -> tuple[str, str]:
+    payload = normalize_tool_call_payload(call)
+    return payload["name"], payload["arguments"]
+
+
+def canonical_args_json(value: Any) -> str:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return "{}"
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return json.dumps(stripped, ensure_ascii=False)
+        return json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def configured_prompt_key(row: dict[str, Any], field: str | None) -> Any | None:
+    if not field:
+        return None
+    current: Any = row
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return ""
+        current = current[part]
+    return current
+
+
+def prompt_hash(messages: list[dict[str, str]]) -> str:
+    payload = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def project_rows(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    if cfg.target == "dpo":
+        return project_dpo(rows, cfg)
+    if cfg.target in {"static-grpo", "static_grpo"}:
+        return project_static_grpo(rows, cfg)
+    raise ValueError("target must be 'dpo' or 'static-grpo'")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="YAML projection config")
+    parser.add_argument("--input", type=Path, help="input rows.jsonl path")
+    parser.add_argument("--output", type=Path, help="output JSONL path")
+    parser.add_argument("--report", type=Path, help="optional JSON report path")
+    parser.add_argument("--target", choices=["dpo", "static-grpo", "static_grpo"])
+    parser.add_argument("--prompt-mode", choices=["prior_messages", "last_user_only"])
+    parser.add_argument("--prompt-key-field", help="dot path used to pair DPO rows")
+    parser.add_argument(
+        "--include-tool-messages",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="include role=tool messages in projected prompts",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = resolve_project_config(args)
+    if cfg.input_path is None or cfg.output_path is None:
+        raise SystemExit("--input and --output are required, either as CLI flags or config values")
+
+    result = project_rows(read_jsonl(cfg.input_path), cfg)
+    write_jsonl(cfg.output_path, result.rows)
+    if cfg.report_path:
+        write_report(cfg.report_path, result.counters)
+    print(json.dumps({"output_rows": result.counters["output_rows"], "counts": dict(result.counters)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.skills/transcript-distillation/scripts/project_rows.py
+++ b/.skills/transcript-distillation/scripts/project_rows.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Project transcript-distillation rows into trainer-specific JSONL targets.
+
+The distiller emits a shared flat/native row shape. This script keeps the
+method-specific DPO and static-GRPO projections outside trainer loaders.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+
+TOOL_CALLS_RE = re.compile(r"Tool calls:\s*(\[[\s\S]*\])\s*$")
+
+
+@dataclass
+class ProjectConfig:
+    target: str = "dpo"
+    input_path: Path | None = None
+    output_path: Path | None = None
+    report_path: Path | None = None
+    prompt_mode: str = "prior_messages"
+    include_tool_messages: bool = False
+    prompt_key_field: str | None = None
+
+
+@dataclass
+class ProjectionResult:
+    rows: list[dict[str, Any]]
+    counters: Counter = field(default_factory=Counter)
+
+
+def load_config(path: Path | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    with path.open("r", encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh) or {}
+    if not isinstance(loaded, dict):
+        raise ValueError(f"projection config must be a mapping: {path}")
+    return loaded
+
+
+def resolve_project_config(args: argparse.Namespace) -> ProjectConfig:
+    cfg = load_config(args.config)
+    projection = cfg.get("projection") or cfg
+    if not isinstance(projection, dict):
+        raise ValueError("projection config must be a mapping")
+
+    target_cfg = projection.get("targets") or {}
+    dpo_cfg = projection.get("dpo") or target_cfg.get("dpo") or {}
+
+    target = args.target or projection.get("target") or "dpo"
+    prompt_mode = args.prompt_mode or projection.get("prompt_mode") or "prior_messages"
+    include_tool_messages = (
+        args.include_tool_messages
+        if args.include_tool_messages is not None
+        else bool(projection.get("include_tool_messages", False))
+    )
+    prompt_key_field = args.prompt_key_field or dpo_cfg.get("prompt_key_field")
+
+    return ProjectConfig(
+        target=target,
+        input_path=args.input or _optional_path(projection.get("input")),
+        output_path=args.output or _optional_path(projection.get("output")),
+        report_path=args.report or _optional_path(projection.get("report")),
+        prompt_mode=prompt_mode,
+        include_tool_messages=include_tool_messages,
+        prompt_key_field=prompt_key_field,
+    )
+
+
+def _optional_path(value: str | None) -> Path | None:
+    return Path(value) if value else None
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line_no, line in enumerate(fh, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            try:
+                row = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_no}: invalid JSONL row: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_no}: row must be a JSON object")
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="\n") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False, sort_keys=True))
+            fh.write("\n")
+
+
+def write_report(path: Path, counters: Counter) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"counts": {key: counters[key] for key in sorted(counters)}}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def project_dpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    buckets: dict[str, dict[bool, list[dict[str, Any]]]] = defaultdict(lambda: {True: [], False: []})
+
+    for row in rows:
+        counters["input_rows"] += 1
+        label = row.get("label")
+        if label is None:
+            counters["dropped_null_label"] += 1
+            continue
+        if label not in (True, False):
+            counters["dropped_non_boolean_label"] += 1
+            continue
+
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        key = configured_prompt_key(row, cfg.prompt_key_field)
+        if key is None:
+            key = prompt_hash(prompt)
+        elif key == "":
+            counters["dropped_missing_prompt_key"] += 1
+            continue
+
+        buckets[str(key)][label].append({
+            "prompt": prompt,
+            "target": serialize_assistant_for_dpo(target[1]),
+            "source_example_id": row.get("source_example_id"),
+        })
+        counters["eligible_rows"] += 1
+
+    out: list[dict[str, Any]] = []
+    for key in sorted(buckets):
+        chosen_rows = buckets[key][True]
+        rejected_rows = buckets[key][False]
+        if not chosen_rows:
+            counters["unpaired_rejected"] += len(rejected_rows)
+            continue
+        if not rejected_rows:
+            counters["unpaired_chosen"] += len(chosen_rows)
+            continue
+        for chosen in chosen_rows:
+            for rejected in rejected_rows:
+                out.append({
+                    "prompt": chosen["prompt"],
+                    "chosen": [chosen["target"]],
+                    "rejected": [rejected["target"]],
+                    "provenance": {
+                        "prompt_key": key,
+                        "chosen_source_example_id": chosen["source_example_id"],
+                        "rejected_source_example_id": rejected["source_example_id"],
+                    },
+                })
+                counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def project_static_grpo(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    counters: Counter = Counter()
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        counters["input_rows"] += 1
+        target = target_assistant_message(row)
+        if target is None:
+            counters["dropped_missing_target_assistant"] += 1
+            continue
+
+        tool_call = first_target_tool_call(row, target[1])
+        if tool_call is None:
+            counters["dropped_missing_tool_call"] += 1
+            continue
+
+        prompt = prompt_messages(row, cfg, target_index=target[0])
+        if not prompt:
+            counters["dropped_empty_prompt"] += 1
+            continue
+
+        name, args_json = normalize_tool_call(tool_call)
+        if not name:
+            counters["dropped_missing_tool_name"] += 1
+            continue
+
+        out.append({
+            "prompt": prompt,
+            "ground_truth_tool": name,
+            "ground_truth_args_json": args_json,
+            "provenance": {
+                "source_example_id": row.get("source_example_id"),
+                "prompt_hash": prompt_hash(prompt),
+            },
+        })
+        counters["output_rows"] += 1
+
+    return ProjectionResult(out, counters)
+
+
+def prompt_messages(row: dict[str, Any], cfg: ProjectConfig, *, target_index: int) -> list[dict[str, str]]:
+    prior = row.get("conversations") or []
+    if not isinstance(prior, list):
+        return []
+    prior = prior[:target_index]
+    if not cfg.include_tool_messages:
+        prior = [msg for msg in prior if msg.get("role") != "tool"]
+
+    if cfg.prompt_mode == "last_user_only":
+        for msg in reversed(prior):
+            if msg.get("role") == "user":
+                return [role_content_message(msg)]
+        return []
+    if cfg.prompt_mode != "prior_messages":
+        raise ValueError("prompt_mode must be 'prior_messages' or 'last_user_only'")
+    roles = {"system", "user", "assistant"}
+    if cfg.include_tool_messages:
+        roles.add("tool")
+    return [role_content_message(msg) for msg in prior if msg.get("role") in roles]
+
+
+def role_content_message(message: dict[str, Any]) -> dict[str, str]:
+    return {
+        "role": str(message.get("role") or ""),
+        "content": "" if message.get("content") is None else str(message.get("content")),
+    }
+
+
+def target_assistant_message(row: dict[str, Any]) -> tuple[int, dict[str, Any]] | None:
+    conversations = row.get("conversations") or []
+    if isinstance(conversations, list):
+        for idx in range(len(conversations) - 1, -1, -1):
+            msg = conversations[idx]
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                return idx, msg
+
+    completion = row.get("completion")
+    if completion is not None:
+        return len(conversations) if isinstance(conversations, list) else 0, {
+            "role": "assistant",
+            "content": str(completion),
+        }
+    return None
+
+
+def serialize_assistant_for_dpo(message: dict[str, Any]) -> dict[str, str]:
+    content = "" if message.get("content") is None else str(message.get("content")).strip()
+    serialized_calls = serialize_tool_calls_text(message.get("tool_calls") or [])
+    if serialized_calls:
+        content = "\n".join(part for part in [content, serialized_calls] if part)
+    return {"role": "assistant", "content": content}
+
+
+def serialize_tool_calls_text(tool_calls: list[Any]) -> str:
+    if not tool_calls:
+        return ""
+    normalized = [normalize_tool_call_payload(call) for call in tool_calls]
+    return "Tool calls: " + json.dumps(normalized, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def normalize_tool_call_payload(call: Any) -> dict[str, Any]:
+    if not isinstance(call, dict):
+        return {"name": "", "arguments": "{}"}
+    if isinstance(call.get("function"), dict):
+        fn = call["function"]
+        return {
+            "name": str(fn.get("name") or ""),
+            "arguments": canonical_args_json(fn.get("arguments")),
+        }
+    return {
+        "name": str(call.get("name") or ""),
+        "arguments": canonical_args_json(call.get("input")),
+    }
+
+
+def first_target_tool_call(row: dict[str, Any], target_message: dict[str, Any]) -> Any | None:
+    native_calls = target_message.get("tool_calls")
+    if isinstance(native_calls, list) and native_calls:
+        return native_calls[0]
+
+    completion = row.get("completion")
+    if completion is None:
+        completion = target_message.get("content")
+    calls = parse_flat_tool_calls(str(completion or ""))
+    return calls[0] if calls else None
+
+
+def parse_flat_tool_calls(completion: str) -> list[Any]:
+    match = TOOL_CALLS_RE.search(completion)
+    if not match:
+        return []
+    payload = match.group(1)
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        try:
+            parsed = ast.literal_eval(payload)
+        except (ValueError, SyntaxError):
+            return []
+    return parsed if isinstance(parsed, list) else []
+
+
+def normalize_tool_call(call: Any) -> tuple[str, str]:
+    payload = normalize_tool_call_payload(call)
+    return payload["name"], payload["arguments"]
+
+
+def canonical_args_json(value: Any) -> str:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return "{}"
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            try:
+                parsed = ast.literal_eval(stripped)
+            except (ValueError, SyntaxError):
+                return json.dumps(stripped, ensure_ascii=False)
+        return json.dumps(parsed, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    if value is None:
+        return "{}"
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def configured_prompt_key(row: dict[str, Any], field: str | None) -> Any | None:
+    if not field:
+        return None
+    current: Any = row
+    for part in field.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return ""
+        current = current[part]
+    return current
+
+
+def prompt_hash(messages: list[dict[str, str]]) -> str:
+    payload = json.dumps(messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def project_rows(rows: Iterable[dict[str, Any]], cfg: ProjectConfig) -> ProjectionResult:
+    if cfg.target == "dpo":
+        return project_dpo(rows, cfg)
+    if cfg.target in {"static-grpo", "static_grpo"}:
+        return project_static_grpo(rows, cfg)
+    raise ValueError("target must be 'dpo' or 'static-grpo'")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="YAML projection config")
+    parser.add_argument("--input", type=Path, help="input rows.jsonl path")
+    parser.add_argument("--output", type=Path, help="output JSONL path")
+    parser.add_argument("--report", type=Path, help="optional JSON report path")
+    parser.add_argument("--target", choices=["dpo", "static-grpo", "static_grpo"])
+    parser.add_argument("--prompt-mode", choices=["prior_messages", "last_user_only"])
+    parser.add_argument("--prompt-key-field", help="dot path used to pair DPO rows")
+    parser.add_argument(
+        "--include-tool-messages",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="include role=tool messages in projected prompts",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = resolve_project_config(args)
+    if cfg.input_path is None or cfg.output_path is None:
+        raise SystemExit("--input and --output are required, either as CLI flags or config values")
+
+    result = project_rows(read_jsonl(cfg.input_path), cfg)
+    write_jsonl(cfg.output_path, result.rows)
+    if cfg.report_path:
+        write_report(cfg.report_path, result.counters)
+    print(json.dumps({"output_rows": result.counters["output_rows"], "counts": dict(result.counters)}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shared/flywheel/cleaner.py
+++ b/shared/flywheel/cleaner.py
@@ -151,6 +151,8 @@ class DataCleaner:
                         fitness.score,
                         fitness.is_valid,
                         fitness.errors,
+                        verdict_rationale=self._verdict_rationale(fitness),
+                        rubric_scores=None,
                     )
                     result.scored += 1
 
@@ -226,3 +228,15 @@ class DataCleaner:
         if score < 0.8:
             return "0.3-0.8"
         return "0.8-1.0"
+
+    @staticmethod
+    def _verdict_rationale(fitness: FitnessResult) -> str:
+        """Build a deterministic rationale from the fitness result."""
+        validity = "valid" if fitness.is_valid else "invalid"
+        errors = "; ".join(fitness.errors) if fitness.errors else "none"
+        return (
+            f"score={fitness.score:.3f}; "
+            f"verdict={validity}; "
+            f"method={fitness.scoring_method}; "
+            f"errors={errors}"
+        )

--- a/shared/flywheel/stager.py
+++ b/shared/flywheel/stager.py
@@ -112,8 +112,14 @@ class DatasetStager:
             LogFilter(tag="kto", unused_only=True),
         )
         grpo_logs = await self._catalog.find_logs(
-            LogFilter(tag="grpo", unused_only=True),
+            LogFilter(
+                tag=["sft", "grpo"],
+                unused_only=True,
+                is_valid=True,
+                has_tool_calls=True,
+            ),
         )
+        grpo_logs = [r for r in grpo_logs if r.tools_requested]
 
         if not sft_logs and not kto_logs and not grpo_logs:
             logger.info("No tagged logs to stage")
@@ -155,6 +161,14 @@ class DatasetStager:
             result.grpo_count = grpo_count
             file_paths["grpo"] = grpo_path
             used_log_ids.extend(r.log_id for r in grpo_logs)
+
+        total_staged = (
+            result.sft_count + result.kto_pos_count
+            + result.kto_neg_count + result.grpo_count
+        )
+        if total_staged == 0:
+            logger.info("No records staged after target filtering/config")
+            return result
 
         # Compute content hash
         content_hash = self._compute_content_hash(file_paths)
@@ -213,10 +227,7 @@ class DatasetStager:
         run_id = self._register_flywheel_cycle(version)
 
         result.version_id = version_id
-        result.total_records = (
-            result.sft_count + result.kto_pos_count
-            + result.kto_neg_count + result.grpo_count
-        )
+        result.total_records = total_staged
         result.file_paths = {k: str(v) for k, v in file_paths.items()}
         result.content_hash = content_hash
         result.run_id = run_id
@@ -408,6 +419,8 @@ class DatasetStager:
                 if not self._passes_filters(record, content, "grpo", stats):
                     continue
                 example = self._format_grpo_example(record, content)
+                if example is None:
+                    continue
                 f.write(json.dumps(example, ensure_ascii=False) + "\n")
                 count += 1
         return count
@@ -428,24 +441,25 @@ class DatasetStager:
 
     def _format_grpo_example(
         self, record: InferenceLogRecord, content: dict,
-    ) -> dict:
-        """Format a log as a GRPO training example.
+    ) -> dict | None:
+        """Format a log as a static-GRPO trainer example."""
+        tool_calls = content.get("tool_calls") or []
+        if not tool_calls:
+            return None
 
-        When the log carries token-faithful rollout capture (completion token
-        ids + per-token logprobs, from a logprobs-enabled proxy), those fields
-        are passed through alongside the conversational form so a downstream
-        token-faithful / replay GRPO consumer can use the exact sampled tokens.
-        Records without capture are unchanged.
-        """
-        conversations = self._build_conversations(content)
-        reward = (record.fitness_score or 0.0) * self._config.grpo_reward_scale
-        example: dict[str, Any] = {"conversations": conversations, "reward": reward}
+        function = (tool_calls[0] or {}).get("function") or {}
+        tool_name = function.get("name")
+        args_json = function.get("arguments")
+        if not tool_name or args_json is None:
+            return None
+        if not isinstance(args_json, str):
+            args_json = json.dumps(args_json, ensure_ascii=False)
 
-        for key in ("prompt_token_ids", "completion_token_ids", "completion_logprobs"):
-            value = content.get(key)
-            if value is not None:
-                example[key] = value
-        return example
+        return {
+            "prompt": content.get("messages", []),
+            "ground_truth_tool": tool_name,
+            "ground_truth_args_json": args_json,
+        }
 
     @staticmethod
     def _build_conversations(content: dict) -> list[dict[str, str]]:

--- a/tests/flywheel/test_catalog_postgres_integration.py
+++ b/tests/flywheel/test_catalog_postgres_integration.py
@@ -1,0 +1,163 @@
+"""Env-gated Postgres integration tests for the flywheel log catalog."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from shared.flywheel.catalog import InferenceLogRecord, LogFilter, PostgresLogCatalog
+
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not os.getenv("FLYWHEEL_POSTGRES_DSN")
+        or not os.getenv("FLYWHEEL_POSTGRES_TENANT"),
+        reason=(
+            "requires FLYWHEEL_POSTGRES_DSN and FLYWHEEL_POSTGRES_TENANT "
+            "for opt-in Postgres catalog integration"
+        ),
+    ),
+]
+
+
+def _record(log_id: str, *, model_id: str = "catalog-pg-test") -> InferenceLogRecord:
+    return InferenceLogRecord(
+        log_id=log_id,
+        timestamp="2026-06-30T12:00:00Z",
+        model_id=model_id,
+        adapter_name="test-adapter",
+        tools_requested=True,
+        tool_calls=[{"function": {"name": "lookup"}}],
+        source_file="postgres-integration.jsonl",
+        line_number=1,
+    )
+
+
+async def _assert_verdict_schema(catalog: PostgresLogCatalog, tenant_id: str) -> None:
+    async with catalog._pool.acquire() as conn:
+        rows = await conn.fetch(
+            """
+            SELECT column_name, data_type, udt_name
+            FROM information_schema.columns
+            WHERE table_schema = $1
+              AND table_name = 'inference_logs'
+              AND column_name IN (
+                  'verdict_rationale',
+                  'rubric_scores',
+                  'tenant_id'
+              )
+            """,
+            f"tenant_{tenant_id}",
+        )
+
+    columns = {row["column_name"]: dict(row) for row in rows}
+    assert columns["verdict_rationale"]["data_type"] == "text"
+    assert columns["rubric_scores"]["udt_name"] == "jsonb"
+    assert columns["tenant_id"]["data_type"] == "text"
+
+
+@pytest.fixture
+def postgres_env() -> tuple[str, str]:
+    asyncpg = pytest.importorskip("asyncpg")
+    assert asyncpg is not None
+    return (
+        os.environ["FLYWHEEL_POSTGRES_DSN"],
+        os.environ["FLYWHEEL_POSTGRES_TENANT"],
+    )
+
+
+@pytest.fixture
+def tenant_ids(postgres_env) -> tuple[str, str]:
+    _, tenant = postgres_env
+    if not PostgresLogCatalog._TENANT_ID_RE.match(tenant):
+        pytest.skip("FLYWHEEL_POSTGRES_TENANT must match ^[a-zA-Z0-9_]+$")
+    suffix = uuid.uuid4().hex[:12]
+    return f"{tenant}_catalog_it_{suffix}", f"{tenant}_catalog_iso_{suffix}"
+
+
+@pytest_asyncio.fixture
+async def cleanup_tenant_schemas(postgres_env, tenant_ids):
+    asyncpg = pytest.importorskip("asyncpg")
+    dsn, _ = postgres_env
+    yield
+    conn = await asyncpg.connect(dsn)
+    try:
+        for tenant_id in tenant_ids:
+            await conn.execute(f"DROP SCHEMA IF EXISTS tenant_{tenant_id} CASCADE")
+    finally:
+        await conn.close()
+
+
+async def test_postgres_catalog_persists_verdict_rubric_and_isolates_tenants(
+    postgres_env, tenant_ids, cleanup_tenant_schemas
+):
+    dsn, _ = postgres_env
+    tenant_id, isolated_tenant_id = tenant_ids
+    catalog = PostgresLogCatalog(dsn, tenant_id, pool_size=1)
+    isolated_catalog = PostgresLogCatalog(dsn, isolated_tenant_id, pool_size=1)
+    log_id = f"pg-catalog-{uuid.uuid4().hex}"
+    rubric_scores = [
+        {
+            "rubric_key": "tool_quality",
+            "rubric_name": "Tool Quality",
+            "score": 0.91,
+            "passed": True,
+            "pass_threshold": 0.8,
+            "feedback": "The response used the requested lookup tool.",
+            "per_dimension": [
+                {
+                    "key": "correctness",
+                    "name": "Correctness",
+                    "weight": 0.7,
+                    "reasoning": "The tool call matches the user request.",
+                    "score": 0.93,
+                }
+            ],
+            "quality_gated_score": 0.9,
+        }
+    ]
+
+    try:
+        await catalog.initialize()
+        await isolated_catalog.initialize()
+        await _assert_verdict_schema(catalog, tenant_id)
+
+        await catalog.insert_log(_record(log_id))
+        await catalog.update_score(
+            log_id,
+            0.91,
+            True,
+            [],
+            verdict_rationale="The answer used the requested lookup tool.",
+            rubric_scores=rubric_scores,
+        )
+
+        results = await catalog.find_logs(LogFilter(model_id="catalog-pg-test"))
+
+        assert [record.log_id for record in results] == [log_id]
+        assert results[0].fitness_score == 0.91
+        assert results[0].is_valid is True
+        assert (
+            results[0].verdict_rationale
+            == "The answer used the requested lookup tool."
+        )
+        assert results[0].rubric_scores == rubric_scores
+        assert results[0].tools_requested is True
+        assert results[0].tool_calls == [{}]
+
+        await catalog.mark_used([log_id], "dataset-pg-it")
+
+        used = await catalog.find_logs(LogFilter(dataset_version="dataset-pg-it"))
+        unused = await catalog.find_logs(LogFilter(unused_only=True))
+        isolated_results = await isolated_catalog.find_logs(LogFilter())
+
+        assert [record.log_id for record in used] == [log_id]
+        assert unused == []
+        assert isolated_results == []
+    finally:
+        await isolated_catalog.close()
+        await catalog.close()

--- a/tests/flywheel/test_cleaner.py
+++ b/tests/flywheel/test_cleaner.py
@@ -98,7 +98,16 @@ class TestDataCleanerScoring:
 
         assert result.total_processed == 1
         assert result.scored == 1
-        mock_catalog.update_score.assert_called_once_with("tc-1", 0.9, True, [])
+        mock_catalog.update_score.assert_called_once_with(
+            "tc-1",
+            0.9,
+            True,
+            [],
+            verdict_rationale=(
+                "score=0.900; verdict=valid; method=error_count; errors=none"
+            ),
+            rubric_scores=None,
+        )
 
     @pytest.mark.asyncio
     async def test_scores_text_response(self, tmp_path):
@@ -141,7 +150,16 @@ class TestDataCleanerScoring:
 
         assert result.scored == 1
         # Cleaner stores the score regardless of text_response_policy
-        mock_catalog.update_score.assert_called_once_with("text-1", 0.0, True, [])
+        mock_catalog.update_score.assert_called_once_with(
+            "text-1",
+            0.0,
+            True,
+            [],
+            verdict_rationale=(
+                "score=0.000; verdict=valid; method=error_count; errors=none"
+            ),
+            rubric_scores=None,
+        )
 
     @pytest.mark.asyncio
     async def test_missing_source_file_scores_zero(self):
@@ -172,6 +190,11 @@ class TestDataCleanerScoring:
         call_args = mock_catalog.update_score.call_args
         assert call_args[0][1] == 0.0  # score
         assert call_args[0][2] is False  # is_valid
+        assert call_args.kwargs["verdict_rationale"] == (
+            "score=0.000; verdict=invalid; method=error; "
+            "errors=Source file not readable"
+        )
+        assert call_args.kwargs["rubric_scores"] is None
 
     @pytest.mark.asyncio
     async def test_error_during_scoring_counted(self, tmp_path):

--- a/tests/flywheel/test_stager.py
+++ b/tests/flywheel/test_stager.py
@@ -135,16 +135,23 @@ class TestDatasetStagerWrite:
 
     @pytest.mark.asyncio
     async def test_grpo_jsonl_format(self, tmp_path):
-        """GRPO output has conversations + reward field."""
+        """GRPO output has the static trainer schema."""
         log_file = tmp_path / "logs.jsonl"
         _write_log_file(log_file, [{
             "messages": [{"role": "user", "content": "Search for X"}],
             "response_content": "Found X",
+            "tool_calls": [{
+                "function": {
+                    "name": "search",
+                    "arguments": "{\"query\":\"X\"}",
+                },
+            }],
         }])
 
         grpo_record = _make_record(
             "grpo-1", source_file=str(log_file), line_number=0,
-            tag="grpo", fitness_score=0.7,
+            tag="grpo", fitness_score=0.7, is_valid=True,
+            tools_requested=True, tool_calls=[{}],
         )
 
         stager = self._make_stager(tmp_path)
@@ -160,9 +167,81 @@ class TestDatasetStagerWrite:
         assert result.grpo_count == 1
         grpo_path = Path(result.file_paths["grpo"])
         example = json.loads(grpo_path.read_text().strip())
-        assert "reward" in example
-        assert example["reward"] == pytest.approx(0.7)
-        assert "conversations" in example
+        assert example == {
+            "prompt": [{"role": "user", "content": "Search for X"}],
+            "ground_truth_tool": "search",
+            "ground_truth_args_json": "{\"query\":\"X\"}",
+        }
+        assert "reward" not in example
+        assert "conversations" not in example
+
+        grpo_filter = stager._catalog.find_logs.call_args_list[2].args[0]
+        assert grpo_filter.tag == ["sft", "grpo"]
+        assert grpo_filter.unused_only is True
+        assert grpo_filter.is_valid is True
+        assert grpo_filter.has_tool_calls is True
+
+    @pytest.mark.asyncio
+    async def test_grpo_eligible_sft_tool_call_log_staged(self, tmp_path):
+        """SFT-tagged valid tool-call logs are eligible for GRPO staging."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [{
+            "messages": [{"role": "user", "content": "Lookup A"}],
+            "response_content": "",
+            "tool_calls": [{
+                "function": {"name": "lookup", "arguments": {"id": "A"}},
+            }],
+        }])
+
+        record = _make_record(
+            "sft-tool-1", source_file=str(log_file), line_number=0,
+            tag="sft", fitness_score=1.0, is_valid=True,
+            tools_requested=True, tool_calls=[{}],
+        )
+
+        stager = self._make_stager(tmp_path)
+        stager._catalog.find_logs = AsyncMock(side_effect=[
+            [],        # sft query
+            [],        # kto query
+            [record],  # grpo eligibility query can return sft-tagged logs
+        ])
+
+        with patch.object(stager, "_register_flywheel_cycle", return_value="run-1"):
+            result = await stager.stage_dataset()
+
+        assert result.grpo_count == 1
+        grpo_path = Path(result.file_paths["grpo"])
+        example = json.loads(grpo_path.read_text().strip())
+        assert example["ground_truth_tool"] == "lookup"
+        assert example["ground_truth_args_json"] == "{\"id\": \"A\"}"
+
+    @pytest.mark.asyncio
+    async def test_grpo_requires_tools_requested(self, tmp_path):
+        """GRPO staging locally rejects rows without tools requested."""
+        log_file = tmp_path / "logs.jsonl"
+        _write_log_file(log_file, [{
+            "messages": [{"role": "user", "content": "Lookup A"}],
+            "response_content": "",
+            "tool_calls": [{
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
+        }])
+
+        record = _make_record(
+            "no-tools-requested", source_file=str(log_file), line_number=0,
+            tag="grpo", fitness_score=1.0, is_valid=True,
+            tools_requested=False, tool_calls=[{}],
+        )
+
+        stager = self._make_stager(tmp_path)
+        stager._catalog.find_logs = AsyncMock(side_effect=[
+            [], [], [record],
+        ])
+
+        result = await stager.stage_dataset()
+
+        assert result.version_id == ""
+        assert result.grpo_count == 0
 
     @pytest.mark.asyncio
     async def test_grpo_disabled_skips(self, tmp_path):
@@ -171,11 +250,15 @@ class TestDatasetStagerWrite:
         _write_log_file(log_file, [{
             "messages": [{"role": "user", "content": "X"}],
             "response_content": "Y",
+            "tool_calls": [{
+                "function": {"name": "lookup", "arguments": "{}"},
+            }],
         }])
 
         grpo_record = _make_record(
             "grpo-skip", source_file=str(log_file), line_number=0,
-            tag="grpo", fitness_score=0.6,
+            tag="grpo", fitness_score=0.6, is_valid=True,
+            tools_requested=True, tool_calls=[{}],
         )
 
         stager = self._make_stager(tmp_path, grpo_enabled=False)
@@ -185,11 +268,18 @@ class TestDatasetStagerWrite:
             [grpo_record],   # grpo
         ])
 
-        with patch.object(stager, "_register_flywheel_cycle", return_value=""):
+        with patch.object(
+            stager, "_register_flywheel_cycle", return_value="",
+        ) as register:
             result = await stager.stage_dataset()
 
+        assert result.version_id == ""
         assert result.grpo_count == 0
+        assert result.total_records == 0
         assert "grpo" not in result.file_paths
+        stager._catalog.create_dataset_version.assert_not_called()
+        stager._catalog.mark_used.assert_not_called()
+        register.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_no_logs_returns_empty_result(self, tmp_path):
@@ -333,7 +423,13 @@ class TestDatasetStagerFilters:
         """
         log_file = tmp_path / "logs.jsonl"
         _write_log_file(log_file, [
-            {"messages": [{"role": "user", "content": "a"}], "response_content": "A"},
+            {
+                "messages": [{"role": "user", "content": "a"}],
+                "response_content": "A",
+                "tool_calls": [{
+                    "function": {"name": "answer", "arguments": "{}"},
+                }],
+            },
             {"messages": [{"role": "user", "content": "b"}], "response_content": "B"},
             {"messages": [{"role": "user", "content": "c"}], "response_content": "C"},
         ])
@@ -344,7 +440,12 @@ class TestDatasetStagerFilters:
                 _make_record("s2", str(log_file), 1, tag="sft", fitness_score=0.5),
             ]
             kto = [_make_record("k1", str(log_file), 2, tag="kto", fitness_score=0.1)]
-            grpo = [_make_record("g1", str(log_file), 0, tag="grpo", fitness_score=0.95)]
+            grpo = [
+                _make_record(
+                    "g1", str(log_file), 0, tag="grpo", fitness_score=0.95,
+                    is_valid=True, tools_requested=True, tool_calls=[{}],
+                )
+            ]
             return sft, kto, grpo
 
         # Run with no filters key.
@@ -377,7 +478,13 @@ class TestDatasetStagerFilters:
         """fitness_score gte 0.9 drops low-score logs from sft/kto_positive/grpo."""
         log_file = tmp_path / "logs.jsonl"
         _write_log_file(log_file, [
-            {"messages": [{"role": "user", "content": "hi"}], "response_content": "ok"},
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "response_content": "ok",
+                "tool_calls": [{
+                    "function": {"name": "answer", "arguments": "{}"},
+                }],
+            },
         ] * 4)
 
         sft = [
@@ -387,8 +494,14 @@ class TestDatasetStagerFilters:
         # KTO positive comes from sft_logs; negative from kto_logs.
         kto = [_make_record("kn", str(log_file), 0, tag="kto", fitness_score=0.1)]
         grpo = [
-            _make_record("ghi", str(log_file), 0, tag="grpo", fitness_score=0.95),
-            _make_record("glo", str(log_file), 0, tag="grpo", fitness_score=0.2),
+            _make_record(
+                "ghi", str(log_file), 0, tag="grpo", fitness_score=0.95,
+                is_valid=True, tools_requested=True, tool_calls=[{}],
+            ),
+            _make_record(
+                "glo", str(log_file), 0, tag="grpo", fitness_score=0.2,
+                is_valid=True, tools_requested=True, tool_calls=[{}],
+            ),
         ]
 
         cat = self._make_catalog(sft=sft, kto=kto, grpo=grpo)

--- a/tests/transcript_distillation/test_project_rows.py
+++ b/tests/transcript_distillation/test_project_rows.py
@@ -1,0 +1,211 @@
+import json
+import sys
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / ".skills" / "transcript-distillation" / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from project_rows import ProjectConfig, main, project_rows  # noqa: E402
+
+
+def test_dpo_pairs_same_default_prompt_hash_and_drops_null_or_unpaired_labels():
+    prompt = [{"role": "user", "content": "Pick a tool"}]
+    chosen = {
+        "conversations": prompt + [{"role": "assistant", "content": "Use search"}],
+        "label": True,
+        "source_example_id": "chosen",
+    }
+    rejected = {
+        "conversations": prompt + [{"role": "assistant", "content": "Guess"}],
+        "label": False,
+        "source_example_id": "rejected",
+    }
+    null_label = {
+        "conversations": prompt + [{"role": "assistant", "content": "Maybe"}],
+        "label": None,
+        "source_example_id": "null",
+    }
+    unpaired = {
+        "conversations": [{"role": "user", "content": "Different"}] + [{"role": "assistant", "content": "No pair"}],
+        "label": True,
+        "source_example_id": "unpaired",
+    }
+
+    result = project_rows([chosen, rejected, null_label, unpaired], ProjectConfig(target="dpo"))
+
+    assert result.rows == [
+        {
+            "prompt": prompt,
+            "chosen": [{"role": "assistant", "content": "Use search"}],
+            "rejected": [{"role": "assistant", "content": "Guess"}],
+            "provenance": {
+                "prompt_key": result.rows[0]["provenance"]["prompt_key"],
+                "chosen_source_example_id": "chosen",
+                "rejected_source_example_id": "rejected",
+            },
+        }
+    ]
+    assert result.counters["output_rows"] == 1
+    assert result.counters["dropped_null_label"] == 1
+    assert result.counters["unpaired_chosen"] == 1
+
+
+def test_dpo_uses_configured_prompt_key_and_serializes_native_tool_calls_to_text():
+    rows = [
+        {
+            "conversations": [
+                {"role": "user", "content": "Make a file"},
+                {
+                    "role": "assistant",
+                    "content": "Creating it.",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "shell",
+                                "arguments": '{"path":"a.txt","body":"ok"}',
+                            },
+                        }
+                    ],
+                },
+            ],
+            "label": True,
+            "metadata": {"pair_key": "same"},
+            "source_example_id": "chosen",
+        },
+        {
+            "conversations": [
+                {"role": "user", "content": "A different visible prompt"},
+                {"role": "assistant", "content": "No."},
+            ],
+            "label": False,
+            "metadata": {"pair_key": "same"},
+            "source_example_id": "rejected",
+        },
+    ]
+
+    result = project_rows(
+        rows,
+        ProjectConfig(target="dpo", prompt_key_field="metadata.pair_key"),
+    )
+
+    assert len(result.rows) == 1
+    chosen = result.rows[0]["chosen"][0]
+    assert chosen["role"] == "assistant"
+    assert chosen["content"] == (
+        'Creating it.\nTool calls: [{"arguments":"{\\"body\\":\\"ok\\",\\"path\\":\\"a.txt\\"}",'
+        '"name":"shell"}]'
+    )
+    assert result.rows[0]["provenance"]["prompt_key"] == "same"
+
+
+def test_static_grpo_extracts_native_first_target_tool_call_and_excludes_tool_messages_by_default():
+    row = {
+        "conversations": [
+            {"role": "system", "content": "Follow policy"},
+            {"role": "user", "content": "Run tests"},
+            {"role": "tool", "tool_call_id": "old", "content": "prior result"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": '{"cmd":"pytest","env":{"CI":"1"}}',
+                        },
+                    }
+                ],
+            },
+        ],
+        "source_example_id": "native",
+    }
+
+    result = project_rows([row], ProjectConfig(target="static-grpo"))
+
+    assert result.rows == [
+        {
+            "prompt": [
+                {"role": "system", "content": "Follow policy"},
+                {"role": "user", "content": "Run tests"},
+            ],
+            "ground_truth_tool": "shell",
+            "ground_truth_args_json": '{"cmd":"pytest","env":{"CI":"1"}}',
+            "provenance": {
+                "source_example_id": "native",
+                "prompt_hash": result.rows[0]["provenance"]["prompt_hash"],
+            },
+        }
+    ]
+    assert result.counters["output_rows"] == 1
+
+    with_tools = project_rows(
+        [row],
+        ProjectConfig(target="static-grpo", include_tool_messages=True),
+    )
+    assert with_tools.rows[0]["prompt"][2] == {"role": "tool", "content": "prior result"}
+
+
+def test_static_grpo_parses_flat_completion_tool_calls_and_supports_last_user_only_prompt():
+    row = {
+        "conversations": [
+            {"role": "user", "content": "First"},
+            {"role": "assistant", "content": "Ack"},
+            {"role": "user", "content": "Search now"},
+            {
+                "role": "assistant",
+                "content": 'Tool calls: [{"name":"search","input":{"query":"abc"}}]',
+            },
+        ],
+        "completion": 'Tool calls: [{"name":"search","input":{"query":"abc"}}]',
+        "source_example_id": "flat",
+    }
+
+    result = project_rows(
+        [row],
+        ProjectConfig(target="static-grpo", prompt_mode="last_user_only"),
+    )
+
+    assert result.rows[0]["prompt"] == [{"role": "user", "content": "Search now"}]
+    assert result.rows[0]["ground_truth_tool"] == "search"
+    assert result.rows[0]["ground_truth_args_json"] == '{"query":"abc"}'
+
+
+def test_cli_writes_jsonl_and_report_from_yaml_config(tmp_path):
+    source = tmp_path / "rows.jsonl"
+    output = tmp_path / "dpo.jsonl"
+    report = tmp_path / "report.json"
+    config = tmp_path / "project.yaml"
+    prompt = [{"role": "user", "content": "Choose"}]
+    source.write_text(
+        "\n".join(
+            [
+                json.dumps({"conversations": prompt + [{"role": "assistant", "content": "Good"}], "label": True}),
+                json.dumps({"conversations": prompt + [{"role": "assistant", "content": "Bad"}], "label": False}),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    config.write_text(
+        f"""
+projection:
+  target: dpo
+  input: {source.as_posix()}
+  output: {output.as_posix()}
+  report: {report.as_posix()}
+""",
+        encoding="utf-8",
+    )
+
+    assert main(["--config", str(config)]) == 0
+
+    projected = [json.loads(line) for line in output.read_text(encoding="utf-8").splitlines()]
+    assert projected[0]["chosen"] == [{"role": "assistant", "content": "Good"}]
+    counts = json.loads(report.read_text(encoding="utf-8"))["counts"]
+    assert counts["input_rows"] == 2
+    assert counts["output_rows"] == 1


### PR DESCRIPTION
Adds transcript-distillation row projection for DPO/static-GRPO, aligns flywheel static-GRPO staging with trainer schema, stores a deterministic fitness-based verdict rationale, and adds skip-by-default Postgres catalog integration coverage.\n\nValidation run from the isolated worktree:\n- python -m pytest tests\\transcript_distillation -q\n- python -m pytest tests\\flywheel\\test_stager.py tests\\flywheel\\test_cleaner.py -q\n- python -m pytest tests\\flywheel\\test_catalog.py tests\\flywheel\\test_catalog_postgres_integration.py -q\n- python .skills\\scripts\\sync_skill_trees.py --check\n- python -m py_compile .skills\\transcript-distillation\\scripts\\project_rows.py shared\\flywheel\\stager.py shared\\flywheel\\cleaner.py\n\nDeferred intentionally: frozen Evaluator fixture exporter, live Postgres execution, LLM-based rationale/rubric producer, and env-GRPO rollout projection changes.