### PR TITLE
[codex] Export flywheel failures as evaluator fixtures

### DIFF
--- a/configs/flywheel/evaluator_fixture_export.example.yaml
+++ b/configs/flywheel/evaluator_fixture_export.example.yaml
@@ -1,0 +1,39 @@
+# Example config for:
+#   python tuner.py flywheel export-fixtures --export-config configs/flywheel/evaluator_fixture_export.example.yaml --output Evaluator/config/scenarios/flywheel_frozen.yaml
+#
+# Correctness is intentionally provided only by templates below. The exporter
+# does not infer semantic correctness from responses or environment execution.
+
+catalog_filter:
+  tag:
+    - sft
+    - grpo
+  is_valid: true
+  limit: 50
+
+# Optional post-hydration filters. These use the generic RolloutFilterSet grammar
+# and evaluate record fields at top level plus full log JSON under content.*.
+filters:
+  - field: content.messages
+    op: exists
+  - field: fitness_score
+    op: gte
+    value: 0.8
+    on_missing: drop
+
+output:
+  name: Flywheel Frozen Fixtures
+  description: Frozen Evaluator fixtures exported from curated flywheel logs.
+  metadata:
+    source: flywheel
+    correctness_source: export_config
+  test:
+    id: flywheel_{{ log_id }}
+    messages: "{{ content.messages }}"
+    tags:
+      - flywheel
+      - frozen
+      - "{{ tag }}"
+    correct:
+      response_content: "{{ content.response_content }}"
+      tool_calls: "{{ content.tool_calls }}"

--- a/shared/flywheel/evaluator_exporter.py
+++ b/shared/flywheel/evaluator_exporter.py
@@ -1,0 +1,233 @@
+"""Export flywheel inference logs as frozen Evaluator scenario fixtures."""
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from shared.validation import RolloutFilterSet
+from shared.validation.rollout_filters import MISSING, get_path
+
+from .catalog import InferenceLogRecord, LogCatalog, LogFilter
+from .utils import read_log_content
+
+
+_PLACEHOLDER_RE = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}")
+_EXACT_PLACEHOLDER_RE = re.compile(r"^\s*{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}\s*$")
+_DEFAULT_FILTER_TARGET = "evaluator_fixture"
+
+
+@dataclass
+class EvaluatorFixtureExportResult:
+    """Summary of an Evaluator fixture export."""
+
+    output_path: str
+    selected_count: int
+    hydrated_count: int
+    exported_count: int
+    skipped_by_filter_count: int
+    missing_content_count: int
+    dry_run: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class EvaluatorFixtureExporter:
+    """Config-driven exporter from flywheel logs to Evaluator YAML scenarios."""
+
+    def __init__(self, catalog: LogCatalog) -> None:
+        self._catalog = catalog
+
+    async def export(
+        self,
+        export_config_path: str | Path,
+        output_path: str | Path,
+        *,
+        overwrite: bool = False,
+        dry_run: bool = False,
+    ) -> EvaluatorFixtureExportResult:
+        config_path = Path(export_config_path)
+        output = Path(output_path)
+        config = load_export_config(config_path)
+
+        if output.exists() and not overwrite and not dry_run:
+            raise FileExistsError(
+                f"Output file already exists: {output}. Pass --yes to overwrite."
+            )
+
+        records = await self._catalog.find_logs(_build_log_filter(config.get("catalog_filter") or {}))
+        scenario, result = build_evaluator_scenario(
+            records,
+            config,
+            output_path=output,
+        )
+
+        if dry_run:
+            result.dry_run = True
+            return result
+
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with open(output, "w", encoding="utf-8") as f:
+            yaml.safe_dump(scenario, f, sort_keys=False, allow_unicode=False)
+        return result
+
+
+def load_export_config(path: str | Path) -> dict[str, Any]:
+    """Load and minimally validate an exporter config YAML file."""
+    config_path = Path(path)
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f) or {}
+    if not isinstance(config, dict):
+        raise ValueError("export config must be a YAML object")
+
+    output = config.get("output")
+    if not isinstance(output, dict):
+        raise ValueError("export config requires an 'output' mapping")
+
+    test_template = output.get("test")
+    if not isinstance(test_template, dict):
+        raise ValueError("export config requires output.test mapping")
+
+    correct = test_template.get("correct")
+    if not isinstance(correct, dict) or not correct:
+        raise ValueError("output.test.correct is required and must be a non-empty mapping")
+
+    has_prompt = any(key in test_template for key in ("question", "messages"))
+    if not has_prompt:
+        raise ValueError("output.test must configure either 'question' or 'messages'")
+
+    if "catalog_filter" in config and not isinstance(config["catalog_filter"], dict):
+        raise ValueError("catalog_filter must be a mapping")
+    if "filters" in config and not isinstance(config["filters"], list):
+        raise ValueError("filters must be a list")
+
+    return config
+
+
+def build_evaluator_scenario(
+    records: list[InferenceLogRecord],
+    config: dict[str, Any],
+    *,
+    output_path: str | Path,
+) -> tuple[dict[str, Any], EvaluatorFixtureExportResult]:
+    """Build an Evaluator scenario payload from already-selected records."""
+    output_cfg = config["output"]
+    test_template = output_cfg["test"]
+    filters = RolloutFilterSet(
+        filters=config.get("filters") or [],
+        default_targets=[str(config.get("filter_target") or _DEFAULT_FILTER_TARGET)],
+    )
+    filter_target = str(config.get("filter_target") or _DEFAULT_FILTER_TARGET)
+
+    tests: list[dict[str, Any]] = []
+    hydrated = 0
+    skipped_by_filter = 0
+    missing_content = 0
+
+    for index, record in enumerate(records):
+        content = read_log_content(record)
+        if content is None:
+            missing_content += 1
+            continue
+        hydrated += 1
+
+        context = _template_context(record, content, index)
+        if not filters.is_empty and not filters.apply(context, filter_target).passed:
+            skipped_by_filter += 1
+            continue
+
+        tests.append(_render_test(test_template, context))
+
+    scenario = {
+        "name": _render_value(output_cfg.get("name", "Flywheel Evaluator Fixtures"), {"derived": {"export_count": len(tests)}}),
+        "description": _render_value(output_cfg.get("description", ""), {"derived": {"export_count": len(tests)}}),
+    }
+    defaults = output_cfg.get("defaults")
+    if isinstance(defaults, dict) and defaults:
+        scenario["defaults"] = _render_value(defaults, {"derived": {"export_count": len(tests)}})
+    metadata = output_cfg.get("metadata")
+    if isinstance(metadata, dict) and metadata:
+        scenario["metadata"] = _render_value(metadata, {"derived": {"export_count": len(tests)}})
+    scenario["tests"] = tests
+
+    return scenario, EvaluatorFixtureExportResult(
+        output_path=str(output_path),
+        selected_count=len(records),
+        hydrated_count=hydrated,
+        exported_count=len(tests),
+        skipped_by_filter_count=skipped_by_filter,
+        missing_content_count=missing_content,
+    )
+
+
+def _build_log_filter(raw: dict[str, Any]) -> LogFilter:
+    valid_fields = set(LogFilter.__dataclass_fields__)
+    unknown = set(raw) - valid_fields
+    if unknown:
+        raise ValueError(f"catalog_filter has unknown key(s): {sorted(unknown)}")
+    return LogFilter(**raw)
+
+
+def _template_context(
+    record: InferenceLogRecord,
+    content: dict[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    context = asdict(record)
+    context["content"] = content
+    context["record"] = asdict(record)
+    context["derived"] = {
+        "index": index,
+        "ordinal": index + 1,
+    }
+    return context
+
+
+def _render_test(template: dict[str, Any], context: dict[str, Any]) -> dict[str, Any]:
+    rendered = _render_value(template, context)
+    if not isinstance(rendered, dict):
+        raise ValueError("rendered test must be a mapping")
+    if not rendered.get("id"):
+        raise ValueError("rendered test is missing required id")
+    if "correct" not in rendered or not isinstance(rendered["correct"], dict) or not rendered["correct"]:
+        raise ValueError(f"rendered test {rendered.get('id')!r} is missing non-empty correct mapping")
+    if "question" not in rendered and "messages" not in rendered:
+        raise ValueError(f"rendered test {rendered.get('id')!r} is missing question/messages")
+    return rendered
+
+
+def _render_value(value: Any, context: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        exact = _EXACT_PLACEHOLDER_RE.match(value)
+        if exact:
+            return _resolve_template_path(context, exact.group(1))
+
+        def replace(match: re.Match[str]) -> str:
+            resolved = _resolve_template_path(context, match.group(1))
+            return "" if resolved is None else str(resolved)
+
+        return _PLACEHOLDER_RE.sub(replace, value)
+    if isinstance(value, list):
+        return [_render_value(item, context) for item in value]
+    if isinstance(value, dict):
+        return {key: _render_value(item, context) for key, item in value.items()}
+    return value
+
+
+def _resolve_template_path(context: dict[str, Any], path: str) -> Any:
+    value = get_path(context, path)
+    if value is MISSING:
+        raise ValueError(f"Unresolved template variable: {path}")
+    return value
+
+
+__all__ = [
+    "EvaluatorFixtureExportResult",
+    "EvaluatorFixtureExporter",
+    "build_evaluator_scenario",
+    "load_export_config",
+]

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -253,3 +253,27 @@ def test_bucket_push_command_parses():
     assert args.subcommand == "push"
     assert args.path == "local/results.json"
     assert args.dest == "runs/manual_uploads/"
+
+
+def test_flywheel_export_fixtures_command_parses():
+    parser = create_parser()
+
+    args = parser.parse_args(
+        [
+            "flywheel",
+            "export-fixtures",
+            "--export-config",
+            "configs/flywheel/evaluator_fixture_export.example.yaml",
+            "--output",
+            "Evaluator/config/scenarios/flywheel_frozen.yaml",
+            "--dry-run",
+            "--yes",
+        ]
+    )
+
+    assert args.command == "flywheel"
+    assert args.subcommand == "export-fixtures"
+    assert args.export_config == "configs/flywheel/evaluator_fixture_export.example.yaml"
+    assert args.output == "Evaluator/config/scenarios/flywheel_frozen.yaml"
+    assert args.dry_run is True
+    assert args.auto_confirm is True

--- a/tests/flywheel/test_evaluator_exporter.py
+++ b/tests/flywheel/test_evaluator_exporter.py
@@ -1,0 +1,163 @@
+import json
+
+import pytest
+import yaml
+
+from shared.flywheel.catalog import InferenceLogRecord, LogFilter
+from shared.flywheel.evaluator_exporter import EvaluatorFixtureExporter
+
+
+class FakeCatalog:
+    def __init__(self, records):
+        self.records = records
+        self.last_filter = None
+
+    async def find_logs(self, filters: LogFilter):
+        self.last_filter = filters
+        return self.records
+
+
+def _record(tmp_path, *, log_id="log-1", response_content="done", fitness_score=0.9):
+    source = tmp_path / f"{log_id}.jsonl"
+    content = {
+        "messages": [{"role": "user", "content": "Do the task"}],
+        "response_content": response_content,
+        "tool_calls": [{"function": {"name": "useTools", "arguments": {"tool": "ls"}}}],
+    }
+    source.write_text(json.dumps(content) + "\n", encoding="utf-8")
+    return InferenceLogRecord(
+        log_id=log_id,
+        timestamp="2026-01-01T00:00:00Z",
+        model_id="model-a",
+        fitness_score=fitness_score,
+        is_valid=True,
+        tag="sft",
+        source_file=str(source),
+        line_number=0,
+    )
+
+
+def _config(tmp_path, **overrides):
+    data = {
+        "catalog_filter": {"tag": "sft", "limit": 5},
+        "output": {
+            "name": "Frozen Flywheel Fixtures",
+            "description": "Exported from flywheel logs",
+            "test": {
+                "id": "flywheel_{{ log_id }}",
+                "messages": "{{ content.messages }}",
+                "tags": ["flywheel", "{{ tag }}"],
+                "correct": {
+                    "tool_calls": "{{ content.tool_calls }}",
+                    "response_text": "{{ content.response_content }}",
+                },
+            },
+        },
+    }
+    data.update(overrides)
+    path = tmp_path / "export.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_export_preserves_exact_placeholder_native_values(tmp_path):
+    record = _record(tmp_path)
+    catalog = FakeCatalog([record])
+    output = tmp_path / "scenario.yaml"
+
+    result = await EvaluatorFixtureExporter(catalog).export(
+        _config(tmp_path),
+        output,
+        overwrite=False,
+    )
+
+    assert result.exported_count == 1
+    assert catalog.last_filter == LogFilter(tag="sft", limit=5)
+    exported = yaml.safe_load(output.read_text(encoding="utf-8"))
+    test = exported["tests"][0]
+    assert test["id"] == "flywheel_log-1"
+    assert test["messages"] == [{"role": "user", "content": "Do the task"}]
+    assert test["correct"]["tool_calls"][0]["function"]["name"] == "useTools"
+
+
+@pytest.mark.asyncio
+async def test_exported_yaml_loads_as_evaluator_scenario(tmp_path):
+    config_dir = tmp_path / "Evaluator" / "config"
+    scenarios_dir = config_dir / "scenarios"
+    scenarios_dir.mkdir(parents=True)
+    output = scenarios_dir / "flywheel_frozen.yaml"
+
+    await EvaluatorFixtureExporter(FakeCatalog([_record(tmp_path)])).export(
+        _config(tmp_path),
+        output,
+    )
+
+    from Evaluator.config_loader import ConfigLoader
+
+    cases = ConfigLoader(config_dir).load_all_scenarios(["flywheel_frozen.yaml"])
+
+    assert len(cases) == 1
+    assert cases[0].case_id == "flywheel_log-1"
+    assert cases[0].metadata["messages"] == [{"role": "user", "content": "Do the task"}]
+    assert cases[0].metadata["correct"]["response_text"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_export_applies_optional_rollout_filters_to_content(tmp_path):
+    keep = _record(tmp_path, log_id="keep", response_content="keep this", fitness_score=0.8)
+    drop = _record(tmp_path, log_id="drop", response_content="drop this", fitness_score=0.2)
+    config = _config(
+        tmp_path,
+        filters=[{"field": "fitness_score", "op": "gte", "value": 0.5}],
+    )
+
+    result = await EvaluatorFixtureExporter(FakeCatalog([keep, drop])).export(
+        config,
+        tmp_path / "scenario.yaml",
+    )
+
+    assert result.selected_count == 2
+    assert result.exported_count == 1
+    assert result.skipped_by_filter_count == 1
+
+
+@pytest.mark.asyncio
+async def test_export_unresolved_template_variable_is_fatal(tmp_path):
+    config = _config(tmp_path)
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["output"]["test"]["id"] = "bad_{{ content.nope }}"
+    config.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unresolved template variable: content.nope"):
+        await EvaluatorFixtureExporter(FakeCatalog([_record(tmp_path)])).export(
+            config,
+            tmp_path / "scenario.yaml",
+        )
+
+
+@pytest.mark.asyncio
+async def test_export_refuses_existing_output_without_overwrite(tmp_path):
+    output = tmp_path / "scenario.yaml"
+    output.write_text("name: existing\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="Pass --yes"):
+        await EvaluatorFixtureExporter(FakeCatalog([_record(tmp_path)])).export(
+            _config(tmp_path),
+            output,
+        )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_write_output(tmp_path):
+    output = tmp_path / "scenario.yaml"
+
+    result = await EvaluatorFixtureExporter(FakeCatalog([_record(tmp_path)])).export(
+        _config(tmp_path),
+        output,
+        dry_run=True,
+    )
+
+    assert result.dry_run is True
+    assert result.exported_count == 1
+    assert not output.exists()

--- a/tests/handlers/test_handlers.py
+++ b/tests/handlers/test_handlers.py
@@ -224,6 +224,63 @@ class TestFlywheelHandler:
         output = capsys.readouterr().out
         assert "v001" in output
 
+    def test_export_fixtures_requires_export_config(self, capsys):
+        args = Namespace(
+            json=True,
+            subcommand="export-fixtures",
+            export_config=None,
+            output="out.yaml",
+            dry_run=False,
+            auto_confirm=False,
+            flywheel_config=None,
+        )
+        handler = self._make_handler(args)
+
+        code = handler.handle()
+
+        assert code == 1
+        assert "MISSING_EXPORT_CONFIG" in capsys.readouterr().out
+
+    def test_export_fixtures_json_mode_dispatches(self, capsys):
+        args = Namespace(
+            json=True,
+            subcommand="export-fixtures",
+            export_config="export.yaml",
+            output="out.yaml",
+            dry_run=True,
+            auto_confirm=True,
+            flywheel_config=None,
+        )
+        handler = self._make_handler(args)
+        config = MagicMock()
+
+        from shared.flywheel.evaluator_exporter import EvaluatorFixtureExportResult
+
+        async def fake_export(**kwargs):
+            assert kwargs["config"] is config
+            assert kwargs["export_config"] == "export.yaml"
+            assert kwargs["output"] == "out.yaml"
+            assert kwargs["overwrite"] is True
+            assert kwargs["dry_run"] is True
+            return EvaluatorFixtureExportResult(
+                output_path="out.yaml",
+                selected_count=2,
+                hydrated_count=2,
+                exported_count=1,
+                skipped_by_filter_count=1,
+                missing_content_count=0,
+                dry_run=True,
+            )
+
+        with patch.object(handler, "_load_config", return_value=config):
+            with patch.object(handler, "_export_fixtures_async", side_effect=fake_export):
+                code = handler.handle()
+
+        assert code == 0
+        output = capsys.readouterr().out
+        assert "exported_count" in output
+        assert "out.yaml" in output
+
 
 # ---------------------------------------------------------------------------
 # CloudTrainHandler

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -103,6 +103,7 @@ Flywheel Subcommands:
   flywheel stage        Stage dataset version (no retrain)
   flywheel logs         Show inference log statistics
   flywheel versions     List staged dataset versions
+  flywheel export-fixtures --export-config <yaml> --output <yaml>
 
 List Subcommands:
   list datasets   List available JSONL datasets
@@ -205,12 +206,22 @@ Examples:
         "--dry-run",
         action="store_true",
         dest="dry_run",
-        help="Show what would happen without executing (flywheel run-cycle only)"
+        help="Show what would happen without executing (flywheel run-cycle/export-fixtures only)"
     )
     parser.add_argument(
         "--flywheel-config",
         dest="flywheel_config",
         help="Path to flywheel config YAML (flywheel commands only)"
+    )
+    parser.add_argument(
+        "--export-config",
+        dest="export_config",
+        help="Path to flywheel Evaluator fixture export config YAML (flywheel export-fixtures only)"
+    )
+    parser.add_argument(
+        "--output",
+        dest="output",
+        help="Output file path (flywheel export-fixtures only)"
     )
 
     # Surgery-specific flags

--- a/tuner/handlers/flywheel_handler.py
+++ b/tuner/handlers/flywheel_handler.py
@@ -31,6 +31,7 @@ class FlywheelHandler(BaseHandler):
         "stage": "_handle_stage",
         "logs": "_handle_logs",
         "versions": "_handle_versions",
+        "export-fixtures": "_handle_export_fixtures",
     }
 
     def __init__(self, args: Optional[Namespace] = None):
@@ -110,13 +111,15 @@ class FlywheelHandler(BaseHandler):
             ("5", "Logs       - Show inference log statistics"),
             ("6", "Versions   - List staged dataset versions"),
             ("7", "Configure  - View flywheel settings"),
+            ("8", "Export Fixtures - Export frozen Evaluator fixtures"),
             ("0", "Back"),
         ]
         choice = print_menu(menu_items, "Select action:")
         dispatch = {"1": self._handle_status, "2": self._handle_run_cycle,
                      "3": self._handle_readiness, "4": self._handle_stage,
                      "5": self._handle_logs, "6": self._handle_versions,
-                     "7": self._handle_configure}
+                     "7": self._handle_configure,
+                     "8": self._handle_export_fixtures}
         return dispatch[choice]() if choice in dispatch else 0
 
     def _handle_status(self) -> int:
@@ -339,3 +342,84 @@ class FlywheelHandler(BaseHandler):
             print(f"  {v['name']:<20} {v['files']:<8} {v['total_examples']:<10}")
         print()
         return 0
+
+    def _handle_export_fixtures(self) -> int:
+        """Export selected flywheel logs as frozen Evaluator YAML fixtures."""
+        export_config = getattr(self.args, "export_config", None) if self.args else None
+        output = getattr(self.args, "output", None) if self.args else None
+        dry_run = getattr(self.args, "dry_run", False) if self.args else False
+        overwrite = getattr(self.args, "auto_confirm", False) if self.args else False
+
+        if not export_config:
+            self.output_error(
+                "flywheel export-fixtures requires --export-config",
+                code="MISSING_EXPORT_CONFIG",
+            )
+            return 1
+        if not output:
+            self.output_error(
+                "flywheel export-fixtures requires --output",
+                code="MISSING_OUTPUT",
+            )
+            return 1
+
+        try:
+            config = self._load_config()
+            result = asyncio.run(
+                self._export_fixtures_async(
+                    config=config,
+                    export_config=export_config,
+                    output=output,
+                    overwrite=overwrite,
+                    dry_run=dry_run,
+                )
+            )
+        except Exception as exc:
+            logger.error("Fixture export failed: %s", exc, exc_info=True)
+            self.output_error(f"Fixture export failed: {exc}", code="FIXTURE_EXPORT_ERROR")
+            return 1
+
+        data = result.to_dict()
+        if self.json_mode:
+            self.output(data)
+            return 0
+
+        if dry_run:
+            self.output_info(
+                "Fixture export dry run: "
+                f"{result.exported_count}/{result.selected_count} records would be exported."
+            )
+        else:
+            self.output_info(
+                f"Exported {result.exported_count} Evaluator fixtures to {result.output_path}"
+            )
+        return 0
+
+    async def _export_fixtures_async(
+        self,
+        *,
+        config: Any,
+        export_config: str,
+        output: str,
+        overwrite: bool,
+        dry_run: bool,
+    ) -> Any:
+        from shared.flywheel.catalog import create_catalog
+        from shared.flywheel.evaluator_exporter import EvaluatorFixtureExporter
+
+        catalog = await create_catalog(
+            backend=config.catalog_backend,
+            path=config.catalog_path,
+            url=config.catalog_url,
+            tenant_id=config.tenant_id,
+        )
+        try:
+            exporter = EvaluatorFixtureExporter(catalog)
+            return await exporter.export(
+                export_config_path=export_config,
+                output_path=output,
+                overwrite=overwrite,
+                dry_run=dry_run,
+            )
+        finally:
+            await catalog.close()


### PR DESCRIPTION
Adds a config-driven flywheel-to-Evaluator fixture exporter. The new \	uner flywheel export-fixtures\ command selects catalog records, hydrates source JSONL content, applies optional filters, and emits existing Evaluator scenario YAML using config-provided correctness templates only.\n\nValidation run from the isolated worktree:\n- python -m pytest tests\\flywheel\\test_evaluator_exporter.py tests\\cli\\test_parser.py tests\\handlers\\test_handlers.py -q\n- targeted exporter probes for dry-run, unknown catalog filters, unresolved templates, missing output handling, and example config loading\n- git diff --check\n\nDeferred intentionally: live evaluator/model runs, environment execution assertion generation, automatic semantic correctness inference, and catalog schema changes.