### PR TITLE
Cloud artifact contract: unify Modal + RunPod on HF Hub with commit-level provenance

### DIFF
--- a/.agents/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.agents/skills/fine-tuning/reference/runpod-jobs.md
@@ -141,6 +141,26 @@ to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
 Because there is no log API, a wrapper that wants diagnostics from a failed run
 must upload them itself before it exits -- see "Failure telemetry" below.
 
+### 5. hf_xet download hang (cross-provider, not RunPod-specific)
+
+Symptom: the job freezes right after unsloth's "Fast downloading is enabled"
+banner. Uptime keeps climbing (the container is alive), but network RX is zero
+and the model download never completes; the job eventually hits the wall-clock
+timeout. Killed RunPod r6/r7/r8 and two Modal A0 attempts (2026-07-05).
+
+Diagnosis: attach `py-spy dump --pid <worker>` to a live hung process; the stack
+sits in `xet_get` (`huggingface_hub/file_download.py:626`). The hf_xet CAS
+backend hangs without a timeout on multi-GB pulls of some model repos. It
+SUPERSEDES hf_transfer, so `HF_HUB_ENABLE_HF_TRANSFER=0` alone does nothing
+(verified in the hung process env).
+
+Fix: `HF_HUB_DISABLE_XET=1` forces the classic resolve-endpoint HTTP path, which
+speed-tested healthy. The launcher sets `HF_HUB_DISABLE_XET=1` and
+`HF_HUB_ENABLE_HF_TRANSFER=0` as default pod env (override via `--env`). This
+applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
+INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
+(set them in the `@app.function` secrets or the container env).
+
 ---
 
 ## Outputs and the Artifact Contract
@@ -170,6 +190,10 @@ runs/modal/<tag>/      # Modal training runs
   `--publish-target-repo`) so the final model lands on the Hub, not just the
   Modal output Volume. The code default is off (a bare `modal run` should not
   silently publish); a real run always opts in.
+- **Modal runs need the hf_xet mitigation too.** The download hang in gotcha #5
+  is a `huggingface_hub` issue, not a RunPod one; a Modal run pulling a large
+  model repo must set `HF_HUB_DISABLE_XET=1` (and `HF_HUB_ENABLE_HF_TRANSFER=0`)
+  in the container env or it will freeze the same way.
 
 ### Failure telemetry
 

--- a/.agents/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.agents/skills/fine-tuning/reference/runpod-jobs.md
@@ -11,6 +11,11 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
 (`tuner/backends/training/cloud/runpod_backend.py`); see
 `reference/cloud-training.md`.
 
+The launcher (`scripts/runpod_run_job.py`) talks to the RunPod REST API
+(`https://rest.runpod.io/v1`) for pod create/terminate and to the GraphQL API
+for runtime polling. It does NOT use the `runpod` Python SDK. This split was
+forced by hard debugging (2026-07-05, 4 dead pods); see the gotchas below.
+
 ---
 
 ## Requirements
@@ -23,10 +28,8 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
   the wrapper).
 - `--commit` must be a FULL 40-char sha (derive with `git rev-parse`, never
   hand-expand a short sha; the script enforces the length).
-- The `runpod` SDK installed where you launch from (`pip install runpod`).
-  Gotcha: importing the SDK crashes if the current working directory is on a
-  dead/unstattable mount (its state dir uses a cwd-relative path) -- launch
-  from a healthy directory.
+- No SDK install needed: the launcher uses only the Python standard library
+  (`urllib`), so it runs from any environment with `RUNPOD_API_KEY` set.
 
 ---
 
@@ -39,13 +42,13 @@ python3 scripts/runpod_run_job.py \
   --commit <full-40-char-sha> \
   --wrapper path/inside/repo/job.sh \
   --wrapper-args "--stage extract --surface holdout" \
-  --gpu "NVIDIA GeForce RTX 4090" \
+  --gpu "NVIDIA GeForce RTX 3090" \
   --timeout-min 180
 ```
 
-Always validate with `--dry-run` first: it prints the resolved pod spec
-(image digest, GPU, disk, env keys, full `docker_args` chain) without any API
-call or cost.
+Always validate with `--dry-run` first: it prints the resolved pod spec as JSON
+(image digest, GPU, disk, env keys redacted, the full `dockerEntrypoint` chain)
+without any API call or cost.
 
 Key flags:
 
@@ -56,24 +59,125 @@ Key flags:
 - `--cloud-type` -- `COMMUNITY` (default, cheaper) or `SECURE`.
 - `--env KEY=VALUE` -- extra pod env vars, repeatable.
 - `--timeout-min` -- hard wall-clock cap; the pod is terminated at timeout.
+- `--min-download` -- minimum host download speed (Mbps, default 700). Community
+  hosts below this stall for tens of minutes pulling a large image; the boot
+  timeout then recycles onto a better host (see `--max-hosts`).
+- `--allowed-cuda "12.8,12.9,13.0"` -- CUDA versions the host driver must offer;
+  a host whose driver is older than the image's CUDA fails container start
+  silently.
+- `--max-hosts N` -- pods to try before giving up. A community host that never
+  starts the container within the boot timeout (stalled image pull) is
+  terminated and a fresh pod is created, up to N attempts (~$0.05/boot-fail at
+  3090 rates). Anything after boot (job error, timeout) is final, not retried.
+- `--probe-only` -- skip clone+wrapper; boot the image, print `nvidia-smi`, and
+  exit as soon as real container uptime is observed. Use this to isolate
+  boot/image reliability from wrapper logic before spending on a real run.
+- `--no-entrypoint-override` -- do not set `dockerEntrypoint`; let the image's
+  own ENTRYPOINT/CMD run (diagnostic: isolates whether the override itself
+  prevents container start).
 
 ---
 
 ## Lifecycle and Billing Safety
 
-The script owns the full pod lifecycle: `create_pod` -> wait for RUNNING ->
-poll every 30s (uptime, GPU/VRAM utilization) -> exit on pod EXITED -> and
-ALWAYS `terminate_pod` in a `finally` block, with 3 retries. A wedged or
-timed-out run cannot silently keep billing. If termination fails after
-retries, the script prints the console URL
-(https://www.runpod.io/console/pods) for a manual kill -- verify.
+The script owns the full pod lifecycle: REST `POST /pods` -> wait for REAL
+container uptime -> poll every 30s -> exit on pod EXITED -> and ALWAYS
+`DELETE /pods/{id}` in a `finally` block, with 3 retries. A wedged or timed-out
+run cannot silently keep billing. If termination fails after retries, the
+script prints the console URL (https://www.runpod.io/console/pods) for a manual
+kill -- verify.
 
-Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout
-(600s) / wall-clock timeout, 2 = bad arguments or missing credentials.
+Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout /
+wall-clock timeout / all `--max-hosts` boot attempts exhausted, 2 = bad
+arguments or missing credentials.
 
-## Outputs
+---
+
+## Gotchas (all adjudicated 2026-07-05 by local docker repro on the unsloth image)
+
+### 1. Non-root image + `cd /root` crash-loop (the r5/edrt9x saga)
+
+The wrapper command runs as the image's default container user, which is NOT
+necessarily root: the unsloth image runs as `unsloth:runtimeusers` with
+`HOME=/home/unsloth` and no write access to `/root`. A `cd /root` there fails
+"Permission denied", and under `set -e` that aborts in <1s, so RunPod
+restart-loops the container with uptime pinned at 1-2s -- indistinguishable from
+a boot failure over the API. The launcher uses an image-agnostic writable
+workdir instead:
+
+```
+{ cd ${WORKDIR:-/workspace} 2>/dev/null || cd "$HOME"; }
+```
+
+The braces matter: a bare `cd A || cd B && clone` parses as
+`cd A || (cd B && clone)` and SKIPS the clone whenever `cd A` succeeds.
+
+### 2. dockerEntrypoint override (why REST, not the SDK)
+
+Images that ship an ENTRYPOINT (unsloth's `/usr/local/bin/entrypoint.sh`)
+receive GraphQL `dockerArgs` as *arguments to the entrypoint*, which can
+crash-loop the container forever with uptime pinned at 0 while it bills as
+RUNNING. The REST `dockerEntrypoint` field REPLACES the ENTRYPOINT so the job
+command actually runs. The SDK also embeds `docker_args` into its GraphQL
+mutation with zero escaping, so any double quote corrupts the API call. REST
+takes a JSON body: no quoting restrictions.
+
+### 3. REST has no uptime; poll GraphQL
+
+The REST pod object carries no uptime field (only `desiredStatus`,
+`lastStartedAt`), so an uptime check against REST reads every pod as
+never-booted forever (six healthy-or-not pods were killed at the boot timeout by
+exactly that bug). Actual container runtime lives only in the GraphQL
+`pod.runtime.uptimeInSeconds`. GraphQL auth is the `?api_key=` query param (a
+Bearer header alone 403s), and `api.runpod.io` 403s the default urllib
+User-Agent (Cloudflare), so the poller sends an explicit UA.
+
+### 4. Fail-hold: "ran and failed" vs "never booted"
+
+RunPod has no logs API (`runpod-python#400`). On nonzero exit the job command
+prints the code and holds the container alive for `FAIL_HOLD_S` (300s) before
+exiting nonzero, so the uptime poller can tell "ran and failed" (uptime climbs
+to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
+Because there is no log API, a wrapper that wants diagnostics from a failed run
+must upload them itself before it exits -- see "Failure telemetry" below.
+
+---
+
+## Outputs and the Artifact Contract
 
 There is no network volume. The wrapper is responsible for uploading its own
-outputs (e.g. to a HuggingFace repo) before it exits; when the pod reports
-EXITED the outputs are already wherever the wrapper put them. Design wrappers
-so a preempted or re-run pod is safe (idempotent uploads, resumable work).
+outputs before it exits; when the pod reports EXITED the outputs are already
+wherever the wrapper put them. Design wrappers so a preempted or re-run pod is
+safe (idempotent uploads, resumable work).
+
+Every cloud job (RunPod or Modal) uploads its results + manifest + logs to an
+HF staging repo under a provider-tagged path, with the producing repo commit
+recorded:
+
+```
+runs/runpod/<tag>/     # RunPod wrapper jobs
+runs/modal/<tag>/      # Modal training runs
+```
+
+- **HF Hub is the durable system of record.** Provider-native storage (Modal
+  Volumes, a RunPod pod's local disk) is scratch / checkpoint space only; it is
+  ephemeral and must never be the sole copy of a result.
+- **The producing repo commit is recorded** in the manifest so any artifact
+  traces back to the exact code that made it. For the training scripts this is
+  the `repo_commit` field in `manifest.json`; for RunPod wrapper jobs, pass
+  `--commit <full-sha>` and stamp the same sha into whatever the wrapper writes.
+- **Modal real runs must pass `--publish-final-model`** (and
+  `--publish-target-repo`) so the final model lands on the Hub, not just the
+  Modal output Volume. The code default is off (a bare `modal run` should not
+  silently publish); a real run always opts in.
+
+### Failure telemetry
+
+Because RunPod has no log API, a failed wrapper leaves zero diagnostics unless
+it uploads them itself. The recommended pattern (see the Epistemic-Humility AL
+wrapper for a worked example): capture the wrapper's own stdout+stderr to a file
+from the first line (`exec > >(tee logfile) 2>&1`), and on ANY nonzero exit
+(bash `trap ... EXIT`) upload a failure marker plus the tail of that log to
+`<run_tag>/_failure/` in the staging repo. Make it best-effort (telemetry
+failure must not mask the original exit code) and redact `hf_`/`rpa_` secret
+patterns before upload.

--- a/.agents/skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.agents/skills/fine-tuning/scripts/runpod_run_job.py
@@ -6,26 +6,44 @@ repo at a pinned commit, execute a wrapper script inside a pinned container
 image, then terminate the pod. Generic by design -- the repo, commit, wrapper,
 and image are all arguments; nothing here is project-specific.
 
-Complements tuner/backends/training/cloud/runpod_backend.py (which is
-training-lane-only); this runs arbitrary wrapper scripts. Lifecycle is the
-same: create_pod -> wait RUNNING -> poll until EXITED -> ALWAYS terminate in
-finally (billing safety). No network volume: the wrapper is responsible for
-uploading its own outputs (e.g. to a HuggingFace repo).
+Uses the RunPod REST API (https://rest.runpod.io/v1) rather than the GraphQL
+SDK, for two hard-won reasons (2026-07-05 lane debugging, 4 dead pods):
+  1. dockerEntrypoint override. Images that ship an ENTRYPOINT (e.g.
+     unsloth/unsloth's /usr/local/bin/entrypoint.sh) receive GraphQL
+     dockerArgs as *arguments to the entrypoint*, which can crash-loop the
+     container forever with uptime pinned at 0 while the pod bills as
+     RUNNING. The REST field dockerEntrypoint replaces the ENTRYPOINT so the
+     job command actually runs.
+  2. The SDK embeds docker_args into its GraphQL mutation with zero escaping
+     (dockerArgs: "{docker_args}"), so any double quote corrupts the API
+     call. REST takes a JSON body; no quoting restrictions.
+
+Lifecycle: create pod -> wait for real container uptime (a stalled image
+pull or crash-looping entrypoint shows RUNNING with uptime 0 and must NOT
+disarm the boot timeout) -> poll until EXITED -> ALWAYS terminate in finally
+(billing safety). No network volume: the wrapper uploads its own outputs
+(e.g. to a HuggingFace repo).
 
 Env: RUNPOD_API_KEY (required); HF_TOKEN forwarded to the pod when set.
 Usage:
   python scripts/runpod_run_job.py --run-tag my-job \
       --repo-url https://github.com/org/repo.git --commit <full-40-char-sha> \
       --wrapper path/inside/repo/job.sh --wrapper-args "--stage extract" \
-      [--gpu "NVIDIA GeForce RTX 4090"] [--image <img@sha256:...>] \
-      [--timeout-min 180] [--dry-run]
+      [--gpu "NVIDIA GeForce RTX 3090"] [--image <img@sha256:...>] \
+      [--min-download 700] [--allowed-cuda "12.8,12.9,13.0"] \
+      [--timeout-min 180] [--probe-only] [--dry-run]
 """
 
 import argparse
+import json
 import os
 import shlex
 import sys
 import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://rest.runpod.io/v1"
 
 # Default image matches the tuner's runpod training backend pin.
 DEFAULT_IMAGE = (
@@ -33,7 +51,15 @@ DEFAULT_IMAGE = (
     "@sha256:5266c57be21059bfb407d80dc2f448868a5c2e2dbe7b2aa27780f48b48cbec39"
 )
 POLL_INTERVAL_S = 30
-BOOT_TIMEOUT_S = 600
+# Covers image pull + container start on a host passing --min-download;
+# a ~20GB image at 700 Mbps pulls in ~4-5 min, so 15 min is generous and
+# anything slower means we picked a bad host and should recycle.
+BOOT_TIMEOUT_S = 900
+# How long a failed job holds the container alive before exiting nonzero, so
+# the uptime poller can distinguish "ran and failed" (uptime climbs to this
+# then EXITED) from a sub-2s crash-loop (uptime never leaves 1-2s). One poll
+# interval plus margin.
+FAIL_HOLD_S = 300
 
 
 def parse_args() -> argparse.Namespace:
@@ -46,27 +72,85 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--image", default=DEFAULT_IMAGE, help="container image (pin by digest)")
     ap.add_argument("--gpu", default="NVIDIA GeForce RTX 4090", help="RunPod gpu_type_id")
     ap.add_argument("--cloud-type", default="COMMUNITY", choices=["COMMUNITY", "SECURE"])
+    ap.add_argument("--min-download", type=int, default=700,
+                    help="minimum host download speed in Mbps; community hosts "
+                         "below this stall for tens of minutes pulling large images")
+    ap.add_argument("--allowed-cuda", default="",
+                    help="comma-separated CUDA versions the host must offer "
+                         "(e.g. '12.8,12.9,13.0'); a host whose driver is older "
+                         "than the image's CUDA fails container start silently")
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
                     help="extra pod env var (repeatable)")
+    ap.add_argument("--probe-only", action="store_true",
+                    help="skip clone+wrapper; just print GPU info and exit "
+                         "(boot-reliability isolation test)")
+    ap.add_argument("--no-entrypoint-override", action="store_true",
+                    help="do not set dockerEntrypoint; let the image's own "
+                         "ENTRYPOINT/CMD run (isolates whether the override "
+                         "itself prevents container start)")
+    ap.add_argument("--max-hosts", type=int, default=3,
+                    help="pods to try before giving up: a community host that "
+                         "does not start the container within the boot timeout "
+                         "(stalled image pull) is terminated and a fresh pod "
+                         "is created, up to this many attempts (boot-fail "
+                         "cost is ~$0.05/attempt at 3090 rates)")
     ap.add_argument("--dry-run", action="store_true", help="print the pod spec and exit")
     return ap.parse_args()
 
 
-def build_startup_cmd(args: argparse.Namespace) -> str:
-    """Clone at the pinned commit and exec the wrapper as the pod's docker_args."""
+def build_job_command(args: argparse.Namespace) -> str:
+    """The shell command the container runs (via dockerEntrypoint bash -lc).
+
+    The command runs as the image's default container user, which is NOT
+    necessarily root: the unsloth image runs as unsloth:runtimeusers with
+    HOME=/home/unsloth and no write access to /root. A `cd /root` there fails
+    "Permission denied", and under `set -e` that aborts in <1s, so RunPod
+    restart-loops the container with uptime pinned at 1-2s -- exactly the
+    r5/edrt9x crash-loop (adjudicated by a local docker repro on the same
+    image family, 2026-07-05). Use a writable, image-agnostic workdir instead
+    of assuming root's home is available or writable.
+    """
+    if args.probe_only:
+        # Stay alive long enough for uptime polling to observe the container:
+        # a command that exits immediately gets restart-looped by RunPod and
+        # is indistinguishable from a boot failure via the API (no log API,
+        # runpod-python#400). Uptime > 0 IS the probe signal.
+        return "nvidia-smi; echo PROBE_OK; sleep 240"
+    # /workspace is the unsloth image's WORKDIR and is writable by the
+    # container user; runpod/pytorch images also provide it. Falling back to
+    # $HOME keeps this working on any image whose user can write there.
+    workdir = "${WORKDIR:-/workspace}"
     inner = " && ".join(
         [
             "set -euo pipefail",
-            "cd /root",
+            # Grouped so the fallback binds only to the cd, not to the rest of
+            # the && chain: a bare `cd A || cd B && clone` parses as
+            # `cd A || (cd B && clone)` and SKIPS the clone whenever cd A
+            # succeeds (equal-precedence left-associative && / ||).
+            f'{{ cd {workdir} 2>/dev/null || cd "$HOME"; }}',
+            # Idempotent: RunPod restarts an exited container against the SAME
+            # writable layer, so a stale ./repo from a prior life would make
+            # `git clone ... repo` die "destination path exists" every restart.
+            "rm -rf repo",
             f"git clone --filter=blob:none {shlex.quote(args.repo_url)} repo",
             "cd repo",
             f"git checkout {shlex.quote(args.commit)}",
             f"bash {shlex.quote(args.wrapper)} {args.wrapper_args}",
         ]
     )
-    return f"bash -lc {shlex.quote(inner)}"
+    # Failure persistence: on nonzero exit, print the code and hold the
+    # container alive past one poll interval so the uptime poller can tell
+    # "ran and failed" (uptime climbs to FAIL_HOLD_S then EXITED) apart from a
+    # crash-loop (uptime stuck at 1-2s). Without this, every fast failure is
+    # invisibly indistinguishable from a boot failure over the API.
+    return (
+        f"( {inner} ); rc=$?; "
+        'if [ "$rc" -ne 0 ]; then '
+        'echo "[runpod-job] JOB FAILED rc=$rc; holding for diagnosis"; '
+        f"sleep {FAIL_HOLD_S}; fi; exit $rc"
+    )
 
 
 def build_pod_env(args: argparse.Namespace) -> dict:
@@ -82,11 +166,82 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     return env
 
 
-def terminate(runpod_module, pod_id: str) -> None:
+def api(method: str, path: str, api_key: str, body: dict | None = None) -> dict:
+    req = urllib.request.Request(
+        f"{API_BASE}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "runpod-run-job/1.0",
+        },
+        data=json.dumps(body).encode() if body is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:500]
+        raise RuntimeError(f"{method} {path} -> HTTP {e.code}: {detail}") from e
+
+
+def poll_pod(api_key: str, pod_id: str) -> dict:
+    """Return {status, uptime} for a pod.
+
+    Create/terminate go through REST, but boot polling CANNOT: the REST pod
+    object carries no uptime field at all (only desiredStatus/lastStartedAt),
+    so an uptime check against REST reads every pod as never-booted forever
+    (2026-07-05: six healthy-or-not pods were killed at the boot timeout by
+    exactly that bug). Actual container runtime lives only in the GraphQL
+    pod.runtime.uptimeInSeconds.
+    """
+    query = ('query{pod(input:{podId:"%s"}){desiredStatus '
+             "runtime{uptimeInSeconds}}}" % pod_id)
+    # GraphQL auth is the SDK-style api_key query param; a Bearer header
+    # alone gets 403. api.runpod.io also 403s the default Python-urllib
+    # User-Agent (Cloudflare), so send an explicit UA (both observed
+    # 2026-07-05).
+    req = urllib.request.Request(
+        f"https://api.runpod.io/graphql?api_key={api_key}",
+        method="POST",
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "runpod-run-job/1.0"},
+        data=json.dumps({"query": query}).encode(),
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    pod = (data.get("data") or {}).get("pod") or {}
+    runtime = pod.get("runtime") or {}
+    return {"status": pod.get("desiredStatus", "UNKNOWN"),
+            "uptime": int(runtime.get("uptimeInSeconds") or 0)}
+
+
+def build_pod_spec(args: argparse.Namespace) -> dict:
+    spec = {
+        "name": args.run_tag,
+        "imageName": args.image,
+        "gpuTypeIds": [args.gpu],
+        "gpuCount": 1,
+        "cloudType": args.cloud_type,
+        "containerDiskInGb": args.disk_gb,
+        "minDownloadMbps": args.min_download,
+        "env": build_pod_env(args),
+    }
+    if not args.no_entrypoint_override:
+        # Full ENTRYPOINT replacement: the image's own entrypoint never runs.
+        spec["dockerEntrypoint"] = ["bash", "-lc", build_job_command(args)]
+    cuda = [v.strip() for v in args.allowed_cuda.split(",") if v.strip()]
+    if cuda:
+        spec["allowedCudaVersions"] = cuda
+    return spec
+
+
+def terminate(api_key: str, pod_id: str) -> None:
     """Terminate with retry; the one call that must never be skipped."""
     for attempt in range(3):
         try:
-            runpod_module.terminate_pod(pod_id)
+            api("DELETE", f"/pods/{pod_id}", api_key)
             print(f"[runpod] pod {pod_id} terminated")
             return
         except Exception as e:  # noqa: BLE001
@@ -105,17 +260,10 @@ def main() -> int:
         print(f"ERROR: --commit must be a full 40-char sha (got {len(args.commit)} chars)")
         return 2
 
-    startup_cmd = build_startup_cmd(args)
-    pod_name = args.run_tag
-
     if args.dry_run:
-        print(f"pod_name:    {pod_name}")
-        print(f"image:       {args.image}")
-        print(f"gpu:         {args.gpu} ({args.cloud_type})")
-        print(f"disk:        {args.disk_gb} GB, no network volume")
-        print(f"timeout:     {args.timeout_min} min")
-        print(f"env keys:    {sorted(build_pod_env(args))}")
-        print(f"docker_args: {startup_cmd}")
+        spec = build_pod_spec(args)
+        redacted = dict(spec, env={k: "***" for k in spec["env"]})
+        print(json.dumps(redacted, indent=2))
         return 0
 
     api_key = os.environ.get("RUNPOD_API_KEY")
@@ -123,65 +271,71 @@ def main() -> int:
         print("ERROR: RUNPOD_API_KEY is not set")
         return 2
 
-    import runpod
+    for attempt in range(1, args.max_hosts + 1):
+        result = run_once(args, api_key, attempt)
+        if result != "boot_fail":
+            return result
+        # Boot failure means THIS HOST never started the container (stalled
+        # image pull); the workload never ran, so a fresh pod is a clean retry,
+        # not a re-run. Anything after boot (job error, timeout) is final.
+        if attempt < args.max_hosts:
+            print(f"[runpod] recycling host ({attempt}/{args.max_hosts} attempts used)")
+    print(f"[runpod] giving up after {args.max_hosts} boot failures")
+    return 1
 
-    runpod.api_key = api_key
 
+def run_once(args: argparse.Namespace, api_key: str, attempt: int) -> int | str:
+    """One pod lifecycle. Returns an exit code, or 'boot_fail' (container
+    never started before BOOT_TIMEOUT_S -> caller may recycle onto a new host).
+    """
     pod_id = None
     try:
-        pod = runpod.create_pod(
-            name=pod_name,
-            image_name=args.image,
-            gpu_type_id=args.gpu,
-            gpu_count=1,
-            container_disk_in_gb=args.disk_gb,
-            cloud_type=args.cloud_type,
-            env=build_pod_env(args),
-            docker_args=startup_cmd,
-        )
+        pod = api("POST", "/pods", api_key, build_pod_spec(args))
         pod_id = pod.get("id")
         if not pod_id:
-            print(f"ERROR: create_pod returned no id: {pod}")
+            print(f"ERROR: create pod returned no id: {pod}")
             return 1
-        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr)")
+        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr, attempt {attempt})")
         print(f"[runpod] console: https://www.runpod.io/console/pods/{pod_id}")
 
-        # Boot wait, then completion poll. EXITED == the wrapper finished and
-        # its outputs are already wherever the wrapper uploads them.
+        # Boot wait, then completion poll. EXITED == the job command finished
+        # and its outputs are already wherever the wrapper uploads them.
         start = time.time()
         deadline = start + args.timeout_min * 60
         booted = False
         while time.time() < deadline:
             try:
-                info = runpod.get_pod(pod_id)
+                info = poll_pod(api_key, pod_id)
             except Exception as e:  # noqa: BLE001
                 print(f"[runpod] poll error (retrying): {e}")
                 time.sleep(POLL_INTERVAL_S)
                 continue
-            status = (info or {}).get("desiredStatus", "UNKNOWN")
-            runtime = (info or {}).get("runtime") or {}
-            if status == "RUNNING" and runtime:
+            status = info["status"]
+            uptime = info["uptime"]
+            # RUNNING with uptime 0 means the image is still pulling or the
+            # container is crash-looping; it has NOT booted. Only real uptime
+            # counts, so the boot timeout stays armed through a stalled pull.
+            if status == "RUNNING" and uptime > 0:
                 if not booted:
-                    print("[runpod] pod is RUNNING")
+                    print("[runpod] container started")
                     booted = True
-                gpus = runtime.get("gpus") or [{}]
-                print(
-                    f"[runpod] up {runtime.get('uptimeInSeconds', 0)}s"
-                    f" | gpu {gpus[0].get('gpuUtilPercent', 0)}%"
-                    f" | vram {gpus[0].get('memoryUtilPercent', 0)}%"
-                )
+                    if args.probe_only:
+                        # boot observed = probe answered; don't bill the sleep out
+                        print(f"[runpod] PROBE BOOT OK (uptime {uptime}s)")
+                        return 0
+                print(f"[runpod] up {uptime}s")
             elif status in ("EXITED", "TERMINATED", "STOPPED"):
                 print(f"[runpod] pod finished (status {status})")
                 return 0 if status == "EXITED" else 1
             elif not booted and time.time() - start > BOOT_TIMEOUT_S:
                 print(f"[runpod] pod failed to boot within {BOOT_TIMEOUT_S}s (status {status})")
-                return 1
+                return "boot_fail"
             time.sleep(POLL_INTERVAL_S)
         print(f"[runpod] TIMEOUT after {args.timeout_min} min")
         return 1
     finally:
         if pod_id:
-            terminate(runpod, pod_id)
+            terminate(api_key, pod_id)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.agents/skills/fine-tuning/scripts/runpod_run_job.py
@@ -82,7 +82,10 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
-                    help="extra pod env var (repeatable)")
+                    help="extra pod env var (repeatable). HF_HUB_DISABLE_XET=1 "
+                         "and HF_HUB_ENABLE_HF_TRANSFER=0 are set by default "
+                         "(the hf_xet backend hangs on large model pulls); pass "
+                         "them here to override.")
     ap.add_argument("--probe-only", action="store_true",
                     help="skip clone+wrapper; just print GPU info and exit "
                          "(boot-reliability isolation test)")
@@ -158,6 +161,15 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     hf_token = os.environ.get("HF_TOKEN")
     if hf_token:
         env["HF_TOKEN"] = hf_token
+    # Force the classic resolve-endpoint HTTP download path. The hf_xet CAS
+    # backend hangs without timeout on multi-GB pulls of some model repos
+    # (py-spy showed workers frozen in xet_get at file_download.py:626; killed
+    # RunPod r6/r7/r8 and two Modal A0 attempts, 2026-07-05). It supersedes
+    # hf_transfer, so DISABLE_XET is the load-bearing one; hf_transfer is turned
+    # off too so the fallback is the plain, speed-tested path. Set as defaults
+    # BEFORE the --env loop so an explicit --env can still override either.
+    env["HF_HUB_DISABLE_XET"] = "1"
+    env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
     for pair in args.env:
         if "=" not in pair:
             raise SystemExit(f"--env expects KEY=VALUE, got: {pair}")

--- a/.claude/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.claude/skills/fine-tuning/reference/runpod-jobs.md
@@ -141,6 +141,26 @@ to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
 Because there is no log API, a wrapper that wants diagnostics from a failed run
 must upload them itself before it exits -- see "Failure telemetry" below.
 
+### 5. hf_xet download hang (cross-provider, not RunPod-specific)
+
+Symptom: the job freezes right after unsloth's "Fast downloading is enabled"
+banner. Uptime keeps climbing (the container is alive), but network RX is zero
+and the model download never completes; the job eventually hits the wall-clock
+timeout. Killed RunPod r6/r7/r8 and two Modal A0 attempts (2026-07-05).
+
+Diagnosis: attach `py-spy dump --pid <worker>` to a live hung process; the stack
+sits in `xet_get` (`huggingface_hub/file_download.py:626`). The hf_xet CAS
+backend hangs without a timeout on multi-GB pulls of some model repos. It
+SUPERSEDES hf_transfer, so `HF_HUB_ENABLE_HF_TRANSFER=0` alone does nothing
+(verified in the hung process env).
+
+Fix: `HF_HUB_DISABLE_XET=1` forces the classic resolve-endpoint HTTP path, which
+speed-tested healthy. The launcher sets `HF_HUB_DISABLE_XET=1` and
+`HF_HUB_ENABLE_HF_TRANSFER=0` as default pod env (override via `--env`). This
+applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
+INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
+(set them in the `@app.function` secrets or the container env).
+
 ---
 
 ## Outputs and the Artifact Contract
@@ -170,6 +190,10 @@ runs/modal/<tag>/      # Modal training runs
   `--publish-target-repo`) so the final model lands on the Hub, not just the
   Modal output Volume. The code default is off (a bare `modal run` should not
   silently publish); a real run always opts in.
+- **Modal runs need the hf_xet mitigation too.** The download hang in gotcha #5
+  is a `huggingface_hub` issue, not a RunPod one; a Modal run pulling a large
+  model repo must set `HF_HUB_DISABLE_XET=1` (and `HF_HUB_ENABLE_HF_TRANSFER=0`)
+  in the container env or it will freeze the same way.
 
 ### Failure telemetry
 

--- a/.claude/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.claude/skills/fine-tuning/reference/runpod-jobs.md
@@ -11,6 +11,11 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
 (`tuner/backends/training/cloud/runpod_backend.py`); see
 `reference/cloud-training.md`.
 
+The launcher (`scripts/runpod_run_job.py`) talks to the RunPod REST API
+(`https://rest.runpod.io/v1`) for pod create/terminate and to the GraphQL API
+for runtime polling. It does NOT use the `runpod` Python SDK. This split was
+forced by hard debugging (2026-07-05, 4 dead pods); see the gotchas below.
+
 ---
 
 ## Requirements
@@ -23,10 +28,8 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
   the wrapper).
 - `--commit` must be a FULL 40-char sha (derive with `git rev-parse`, never
   hand-expand a short sha; the script enforces the length).
-- The `runpod` SDK installed where you launch from (`pip install runpod`).
-  Gotcha: importing the SDK crashes if the current working directory is on a
-  dead/unstattable mount (its state dir uses a cwd-relative path) -- launch
-  from a healthy directory.
+- No SDK install needed: the launcher uses only the Python standard library
+  (`urllib`), so it runs from any environment with `RUNPOD_API_KEY` set.
 
 ---
 
@@ -39,13 +42,13 @@ python3 scripts/runpod_run_job.py \
   --commit <full-40-char-sha> \
   --wrapper path/inside/repo/job.sh \
   --wrapper-args "--stage extract --surface holdout" \
-  --gpu "NVIDIA GeForce RTX 4090" \
+  --gpu "NVIDIA GeForce RTX 3090" \
   --timeout-min 180
 ```
 
-Always validate with `--dry-run` first: it prints the resolved pod spec
-(image digest, GPU, disk, env keys, full `docker_args` chain) without any API
-call or cost.
+Always validate with `--dry-run` first: it prints the resolved pod spec as JSON
+(image digest, GPU, disk, env keys redacted, the full `dockerEntrypoint` chain)
+without any API call or cost.
 
 Key flags:
 
@@ -56,24 +59,125 @@ Key flags:
 - `--cloud-type` -- `COMMUNITY` (default, cheaper) or `SECURE`.
 - `--env KEY=VALUE` -- extra pod env vars, repeatable.
 - `--timeout-min` -- hard wall-clock cap; the pod is terminated at timeout.
+- `--min-download` -- minimum host download speed (Mbps, default 700). Community
+  hosts below this stall for tens of minutes pulling a large image; the boot
+  timeout then recycles onto a better host (see `--max-hosts`).
+- `--allowed-cuda "12.8,12.9,13.0"` -- CUDA versions the host driver must offer;
+  a host whose driver is older than the image's CUDA fails container start
+  silently.
+- `--max-hosts N` -- pods to try before giving up. A community host that never
+  starts the container within the boot timeout (stalled image pull) is
+  terminated and a fresh pod is created, up to N attempts (~$0.05/boot-fail at
+  3090 rates). Anything after boot (job error, timeout) is final, not retried.
+- `--probe-only` -- skip clone+wrapper; boot the image, print `nvidia-smi`, and
+  exit as soon as real container uptime is observed. Use this to isolate
+  boot/image reliability from wrapper logic before spending on a real run.
+- `--no-entrypoint-override` -- do not set `dockerEntrypoint`; let the image's
+  own ENTRYPOINT/CMD run (diagnostic: isolates whether the override itself
+  prevents container start).
 
 ---
 
 ## Lifecycle and Billing Safety
 
-The script owns the full pod lifecycle: `create_pod` -> wait for RUNNING ->
-poll every 30s (uptime, GPU/VRAM utilization) -> exit on pod EXITED -> and
-ALWAYS `terminate_pod` in a `finally` block, with 3 retries. A wedged or
-timed-out run cannot silently keep billing. If termination fails after
-retries, the script prints the console URL
-(https://www.runpod.io/console/pods) for a manual kill -- verify.
+The script owns the full pod lifecycle: REST `POST /pods` -> wait for REAL
+container uptime -> poll every 30s -> exit on pod EXITED -> and ALWAYS
+`DELETE /pods/{id}` in a `finally` block, with 3 retries. A wedged or timed-out
+run cannot silently keep billing. If termination fails after retries, the
+script prints the console URL (https://www.runpod.io/console/pods) for a manual
+kill -- verify.
 
-Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout
-(600s) / wall-clock timeout, 2 = bad arguments or missing credentials.
+Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout /
+wall-clock timeout / all `--max-hosts` boot attempts exhausted, 2 = bad
+arguments or missing credentials.
 
-## Outputs
+---
+
+## Gotchas (all adjudicated 2026-07-05 by local docker repro on the unsloth image)
+
+### 1. Non-root image + `cd /root` crash-loop (the r5/edrt9x saga)
+
+The wrapper command runs as the image's default container user, which is NOT
+necessarily root: the unsloth image runs as `unsloth:runtimeusers` with
+`HOME=/home/unsloth` and no write access to `/root`. A `cd /root` there fails
+"Permission denied", and under `set -e` that aborts in <1s, so RunPod
+restart-loops the container with uptime pinned at 1-2s -- indistinguishable from
+a boot failure over the API. The launcher uses an image-agnostic writable
+workdir instead:
+
+```
+{ cd ${WORKDIR:-/workspace} 2>/dev/null || cd "$HOME"; }
+```
+
+The braces matter: a bare `cd A || cd B && clone` parses as
+`cd A || (cd B && clone)` and SKIPS the clone whenever `cd A` succeeds.
+
+### 2. dockerEntrypoint override (why REST, not the SDK)
+
+Images that ship an ENTRYPOINT (unsloth's `/usr/local/bin/entrypoint.sh`)
+receive GraphQL `dockerArgs` as *arguments to the entrypoint*, which can
+crash-loop the container forever with uptime pinned at 0 while it bills as
+RUNNING. The REST `dockerEntrypoint` field REPLACES the ENTRYPOINT so the job
+command actually runs. The SDK also embeds `docker_args` into its GraphQL
+mutation with zero escaping, so any double quote corrupts the API call. REST
+takes a JSON body: no quoting restrictions.
+
+### 3. REST has no uptime; poll GraphQL
+
+The REST pod object carries no uptime field (only `desiredStatus`,
+`lastStartedAt`), so an uptime check against REST reads every pod as
+never-booted forever (six healthy-or-not pods were killed at the boot timeout by
+exactly that bug). Actual container runtime lives only in the GraphQL
+`pod.runtime.uptimeInSeconds`. GraphQL auth is the `?api_key=` query param (a
+Bearer header alone 403s), and `api.runpod.io` 403s the default urllib
+User-Agent (Cloudflare), so the poller sends an explicit UA.
+
+### 4. Fail-hold: "ran and failed" vs "never booted"
+
+RunPod has no logs API (`runpod-python#400`). On nonzero exit the job command
+prints the code and holds the container alive for `FAIL_HOLD_S` (300s) before
+exiting nonzero, so the uptime poller can tell "ran and failed" (uptime climbs
+to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
+Because there is no log API, a wrapper that wants diagnostics from a failed run
+must upload them itself before it exits -- see "Failure telemetry" below.
+
+---
+
+## Outputs and the Artifact Contract
 
 There is no network volume. The wrapper is responsible for uploading its own
-outputs (e.g. to a HuggingFace repo) before it exits; when the pod reports
-EXITED the outputs are already wherever the wrapper put them. Design wrappers
-so a preempted or re-run pod is safe (idempotent uploads, resumable work).
+outputs before it exits; when the pod reports EXITED the outputs are already
+wherever the wrapper put them. Design wrappers so a preempted or re-run pod is
+safe (idempotent uploads, resumable work).
+
+Every cloud job (RunPod or Modal) uploads its results + manifest + logs to an
+HF staging repo under a provider-tagged path, with the producing repo commit
+recorded:
+
+```
+runs/runpod/<tag>/     # RunPod wrapper jobs
+runs/modal/<tag>/      # Modal training runs
+```
+
+- **HF Hub is the durable system of record.** Provider-native storage (Modal
+  Volumes, a RunPod pod's local disk) is scratch / checkpoint space only; it is
+  ephemeral and must never be the sole copy of a result.
+- **The producing repo commit is recorded** in the manifest so any artifact
+  traces back to the exact code that made it. For the training scripts this is
+  the `repo_commit` field in `manifest.json`; for RunPod wrapper jobs, pass
+  `--commit <full-sha>` and stamp the same sha into whatever the wrapper writes.
+- **Modal real runs must pass `--publish-final-model`** (and
+  `--publish-target-repo`) so the final model lands on the Hub, not just the
+  Modal output Volume. The code default is off (a bare `modal run` should not
+  silently publish); a real run always opts in.
+
+### Failure telemetry
+
+Because RunPod has no log API, a failed wrapper leaves zero diagnostics unless
+it uploads them itself. The recommended pattern (see the Epistemic-Humility AL
+wrapper for a worked example): capture the wrapper's own stdout+stderr to a file
+from the first line (`exec > >(tee logfile) 2>&1`), and on ANY nonzero exit
+(bash `trap ... EXIT`) upload a failure marker plus the tail of that log to
+`<run_tag>/_failure/` in the staging repo. Make it best-effort (telemetry
+failure must not mask the original exit code) and redact `hf_`/`rpa_` secret
+patterns before upload.

--- a/.claude/skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.claude/skills/fine-tuning/scripts/runpod_run_job.py
@@ -6,26 +6,44 @@ repo at a pinned commit, execute a wrapper script inside a pinned container
 image, then terminate the pod. Generic by design -- the repo, commit, wrapper,
 and image are all arguments; nothing here is project-specific.
 
-Complements tuner/backends/training/cloud/runpod_backend.py (which is
-training-lane-only); this runs arbitrary wrapper scripts. Lifecycle is the
-same: create_pod -> wait RUNNING -> poll until EXITED -> ALWAYS terminate in
-finally (billing safety). No network volume: the wrapper is responsible for
-uploading its own outputs (e.g. to a HuggingFace repo).
+Uses the RunPod REST API (https://rest.runpod.io/v1) rather than the GraphQL
+SDK, for two hard-won reasons (2026-07-05 lane debugging, 4 dead pods):
+  1. dockerEntrypoint override. Images that ship an ENTRYPOINT (e.g.
+     unsloth/unsloth's /usr/local/bin/entrypoint.sh) receive GraphQL
+     dockerArgs as *arguments to the entrypoint*, which can crash-loop the
+     container forever with uptime pinned at 0 while the pod bills as
+     RUNNING. The REST field dockerEntrypoint replaces the ENTRYPOINT so the
+     job command actually runs.
+  2. The SDK embeds docker_args into its GraphQL mutation with zero escaping
+     (dockerArgs: "{docker_args}"), so any double quote corrupts the API
+     call. REST takes a JSON body; no quoting restrictions.
+
+Lifecycle: create pod -> wait for real container uptime (a stalled image
+pull or crash-looping entrypoint shows RUNNING with uptime 0 and must NOT
+disarm the boot timeout) -> poll until EXITED -> ALWAYS terminate in finally
+(billing safety). No network volume: the wrapper uploads its own outputs
+(e.g. to a HuggingFace repo).
 
 Env: RUNPOD_API_KEY (required); HF_TOKEN forwarded to the pod when set.
 Usage:
   python scripts/runpod_run_job.py --run-tag my-job \
       --repo-url https://github.com/org/repo.git --commit <full-40-char-sha> \
       --wrapper path/inside/repo/job.sh --wrapper-args "--stage extract" \
-      [--gpu "NVIDIA GeForce RTX 4090"] [--image <img@sha256:...>] \
-      [--timeout-min 180] [--dry-run]
+      [--gpu "NVIDIA GeForce RTX 3090"] [--image <img@sha256:...>] \
+      [--min-download 700] [--allowed-cuda "12.8,12.9,13.0"] \
+      [--timeout-min 180] [--probe-only] [--dry-run]
 """
 
 import argparse
+import json
 import os
 import shlex
 import sys
 import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://rest.runpod.io/v1"
 
 # Default image matches the tuner's runpod training backend pin.
 DEFAULT_IMAGE = (
@@ -33,7 +51,15 @@ DEFAULT_IMAGE = (
     "@sha256:5266c57be21059bfb407d80dc2f448868a5c2e2dbe7b2aa27780f48b48cbec39"
 )
 POLL_INTERVAL_S = 30
-BOOT_TIMEOUT_S = 600
+# Covers image pull + container start on a host passing --min-download;
+# a ~20GB image at 700 Mbps pulls in ~4-5 min, so 15 min is generous and
+# anything slower means we picked a bad host and should recycle.
+BOOT_TIMEOUT_S = 900
+# How long a failed job holds the container alive before exiting nonzero, so
+# the uptime poller can distinguish "ran and failed" (uptime climbs to this
+# then EXITED) from a sub-2s crash-loop (uptime never leaves 1-2s). One poll
+# interval plus margin.
+FAIL_HOLD_S = 300
 
 
 def parse_args() -> argparse.Namespace:
@@ -46,27 +72,85 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--image", default=DEFAULT_IMAGE, help="container image (pin by digest)")
     ap.add_argument("--gpu", default="NVIDIA GeForce RTX 4090", help="RunPod gpu_type_id")
     ap.add_argument("--cloud-type", default="COMMUNITY", choices=["COMMUNITY", "SECURE"])
+    ap.add_argument("--min-download", type=int, default=700,
+                    help="minimum host download speed in Mbps; community hosts "
+                         "below this stall for tens of minutes pulling large images")
+    ap.add_argument("--allowed-cuda", default="",
+                    help="comma-separated CUDA versions the host must offer "
+                         "(e.g. '12.8,12.9,13.0'); a host whose driver is older "
+                         "than the image's CUDA fails container start silently")
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
                     help="extra pod env var (repeatable)")
+    ap.add_argument("--probe-only", action="store_true",
+                    help="skip clone+wrapper; just print GPU info and exit "
+                         "(boot-reliability isolation test)")
+    ap.add_argument("--no-entrypoint-override", action="store_true",
+                    help="do not set dockerEntrypoint; let the image's own "
+                         "ENTRYPOINT/CMD run (isolates whether the override "
+                         "itself prevents container start)")
+    ap.add_argument("--max-hosts", type=int, default=3,
+                    help="pods to try before giving up: a community host that "
+                         "does not start the container within the boot timeout "
+                         "(stalled image pull) is terminated and a fresh pod "
+                         "is created, up to this many attempts (boot-fail "
+                         "cost is ~$0.05/attempt at 3090 rates)")
     ap.add_argument("--dry-run", action="store_true", help="print the pod spec and exit")
     return ap.parse_args()
 
 
-def build_startup_cmd(args: argparse.Namespace) -> str:
-    """Clone at the pinned commit and exec the wrapper as the pod's docker_args."""
+def build_job_command(args: argparse.Namespace) -> str:
+    """The shell command the container runs (via dockerEntrypoint bash -lc).
+
+    The command runs as the image's default container user, which is NOT
+    necessarily root: the unsloth image runs as unsloth:runtimeusers with
+    HOME=/home/unsloth and no write access to /root. A `cd /root` there fails
+    "Permission denied", and under `set -e` that aborts in <1s, so RunPod
+    restart-loops the container with uptime pinned at 1-2s -- exactly the
+    r5/edrt9x crash-loop (adjudicated by a local docker repro on the same
+    image family, 2026-07-05). Use a writable, image-agnostic workdir instead
+    of assuming root's home is available or writable.
+    """
+    if args.probe_only:
+        # Stay alive long enough for uptime polling to observe the container:
+        # a command that exits immediately gets restart-looped by RunPod and
+        # is indistinguishable from a boot failure via the API (no log API,
+        # runpod-python#400). Uptime > 0 IS the probe signal.
+        return "nvidia-smi; echo PROBE_OK; sleep 240"
+    # /workspace is the unsloth image's WORKDIR and is writable by the
+    # container user; runpod/pytorch images also provide it. Falling back to
+    # $HOME keeps this working on any image whose user can write there.
+    workdir = "${WORKDIR:-/workspace}"
     inner = " && ".join(
         [
             "set -euo pipefail",
-            "cd /root",
+            # Grouped so the fallback binds only to the cd, not to the rest of
+            # the && chain: a bare `cd A || cd B && clone` parses as
+            # `cd A || (cd B && clone)` and SKIPS the clone whenever cd A
+            # succeeds (equal-precedence left-associative && / ||).
+            f'{{ cd {workdir} 2>/dev/null || cd "$HOME"; }}',
+            # Idempotent: RunPod restarts an exited container against the SAME
+            # writable layer, so a stale ./repo from a prior life would make
+            # `git clone ... repo` die "destination path exists" every restart.
+            "rm -rf repo",
             f"git clone --filter=blob:none {shlex.quote(args.repo_url)} repo",
             "cd repo",
             f"git checkout {shlex.quote(args.commit)}",
             f"bash {shlex.quote(args.wrapper)} {args.wrapper_args}",
         ]
     )
-    return f"bash -lc {shlex.quote(inner)}"
+    # Failure persistence: on nonzero exit, print the code and hold the
+    # container alive past one poll interval so the uptime poller can tell
+    # "ran and failed" (uptime climbs to FAIL_HOLD_S then EXITED) apart from a
+    # crash-loop (uptime stuck at 1-2s). Without this, every fast failure is
+    # invisibly indistinguishable from a boot failure over the API.
+    return (
+        f"( {inner} ); rc=$?; "
+        'if [ "$rc" -ne 0 ]; then '
+        'echo "[runpod-job] JOB FAILED rc=$rc; holding for diagnosis"; '
+        f"sleep {FAIL_HOLD_S}; fi; exit $rc"
+    )
 
 
 def build_pod_env(args: argparse.Namespace) -> dict:
@@ -82,11 +166,82 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     return env
 
 
-def terminate(runpod_module, pod_id: str) -> None:
+def api(method: str, path: str, api_key: str, body: dict | None = None) -> dict:
+    req = urllib.request.Request(
+        f"{API_BASE}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "runpod-run-job/1.0",
+        },
+        data=json.dumps(body).encode() if body is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:500]
+        raise RuntimeError(f"{method} {path} -> HTTP {e.code}: {detail}") from e
+
+
+def poll_pod(api_key: str, pod_id: str) -> dict:
+    """Return {status, uptime} for a pod.
+
+    Create/terminate go through REST, but boot polling CANNOT: the REST pod
+    object carries no uptime field at all (only desiredStatus/lastStartedAt),
+    so an uptime check against REST reads every pod as never-booted forever
+    (2026-07-05: six healthy-or-not pods were killed at the boot timeout by
+    exactly that bug). Actual container runtime lives only in the GraphQL
+    pod.runtime.uptimeInSeconds.
+    """
+    query = ('query{pod(input:{podId:"%s"}){desiredStatus '
+             "runtime{uptimeInSeconds}}}" % pod_id)
+    # GraphQL auth is the SDK-style api_key query param; a Bearer header
+    # alone gets 403. api.runpod.io also 403s the default Python-urllib
+    # User-Agent (Cloudflare), so send an explicit UA (both observed
+    # 2026-07-05).
+    req = urllib.request.Request(
+        f"https://api.runpod.io/graphql?api_key={api_key}",
+        method="POST",
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "runpod-run-job/1.0"},
+        data=json.dumps({"query": query}).encode(),
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    pod = (data.get("data") or {}).get("pod") or {}
+    runtime = pod.get("runtime") or {}
+    return {"status": pod.get("desiredStatus", "UNKNOWN"),
+            "uptime": int(runtime.get("uptimeInSeconds") or 0)}
+
+
+def build_pod_spec(args: argparse.Namespace) -> dict:
+    spec = {
+        "name": args.run_tag,
+        "imageName": args.image,
+        "gpuTypeIds": [args.gpu],
+        "gpuCount": 1,
+        "cloudType": args.cloud_type,
+        "containerDiskInGb": args.disk_gb,
+        "minDownloadMbps": args.min_download,
+        "env": build_pod_env(args),
+    }
+    if not args.no_entrypoint_override:
+        # Full ENTRYPOINT replacement: the image's own entrypoint never runs.
+        spec["dockerEntrypoint"] = ["bash", "-lc", build_job_command(args)]
+    cuda = [v.strip() for v in args.allowed_cuda.split(",") if v.strip()]
+    if cuda:
+        spec["allowedCudaVersions"] = cuda
+    return spec
+
+
+def terminate(api_key: str, pod_id: str) -> None:
     """Terminate with retry; the one call that must never be skipped."""
     for attempt in range(3):
         try:
-            runpod_module.terminate_pod(pod_id)
+            api("DELETE", f"/pods/{pod_id}", api_key)
             print(f"[runpod] pod {pod_id} terminated")
             return
         except Exception as e:  # noqa: BLE001
@@ -105,17 +260,10 @@ def main() -> int:
         print(f"ERROR: --commit must be a full 40-char sha (got {len(args.commit)} chars)")
         return 2
 
-    startup_cmd = build_startup_cmd(args)
-    pod_name = args.run_tag
-
     if args.dry_run:
-        print(f"pod_name:    {pod_name}")
-        print(f"image:       {args.image}")
-        print(f"gpu:         {args.gpu} ({args.cloud_type})")
-        print(f"disk:        {args.disk_gb} GB, no network volume")
-        print(f"timeout:     {args.timeout_min} min")
-        print(f"env keys:    {sorted(build_pod_env(args))}")
-        print(f"docker_args: {startup_cmd}")
+        spec = build_pod_spec(args)
+        redacted = dict(spec, env={k: "***" for k in spec["env"]})
+        print(json.dumps(redacted, indent=2))
         return 0
 
     api_key = os.environ.get("RUNPOD_API_KEY")
@@ -123,65 +271,71 @@ def main() -> int:
         print("ERROR: RUNPOD_API_KEY is not set")
         return 2
 
-    import runpod
+    for attempt in range(1, args.max_hosts + 1):
+        result = run_once(args, api_key, attempt)
+        if result != "boot_fail":
+            return result
+        # Boot failure means THIS HOST never started the container (stalled
+        # image pull); the workload never ran, so a fresh pod is a clean retry,
+        # not a re-run. Anything after boot (job error, timeout) is final.
+        if attempt < args.max_hosts:
+            print(f"[runpod] recycling host ({attempt}/{args.max_hosts} attempts used)")
+    print(f"[runpod] giving up after {args.max_hosts} boot failures")
+    return 1
 
-    runpod.api_key = api_key
 
+def run_once(args: argparse.Namespace, api_key: str, attempt: int) -> int | str:
+    """One pod lifecycle. Returns an exit code, or 'boot_fail' (container
+    never started before BOOT_TIMEOUT_S -> caller may recycle onto a new host).
+    """
     pod_id = None
     try:
-        pod = runpod.create_pod(
-            name=pod_name,
-            image_name=args.image,
-            gpu_type_id=args.gpu,
-            gpu_count=1,
-            container_disk_in_gb=args.disk_gb,
-            cloud_type=args.cloud_type,
-            env=build_pod_env(args),
-            docker_args=startup_cmd,
-        )
+        pod = api("POST", "/pods", api_key, build_pod_spec(args))
         pod_id = pod.get("id")
         if not pod_id:
-            print(f"ERROR: create_pod returned no id: {pod}")
+            print(f"ERROR: create pod returned no id: {pod}")
             return 1
-        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr)")
+        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr, attempt {attempt})")
         print(f"[runpod] console: https://www.runpod.io/console/pods/{pod_id}")
 
-        # Boot wait, then completion poll. EXITED == the wrapper finished and
-        # its outputs are already wherever the wrapper uploads them.
+        # Boot wait, then completion poll. EXITED == the job command finished
+        # and its outputs are already wherever the wrapper uploads them.
         start = time.time()
         deadline = start + args.timeout_min * 60
         booted = False
         while time.time() < deadline:
             try:
-                info = runpod.get_pod(pod_id)
+                info = poll_pod(api_key, pod_id)
             except Exception as e:  # noqa: BLE001
                 print(f"[runpod] poll error (retrying): {e}")
                 time.sleep(POLL_INTERVAL_S)
                 continue
-            status = (info or {}).get("desiredStatus", "UNKNOWN")
-            runtime = (info or {}).get("runtime") or {}
-            if status == "RUNNING" and runtime:
+            status = info["status"]
+            uptime = info["uptime"]
+            # RUNNING with uptime 0 means the image is still pulling or the
+            # container is crash-looping; it has NOT booted. Only real uptime
+            # counts, so the boot timeout stays armed through a stalled pull.
+            if status == "RUNNING" and uptime > 0:
                 if not booted:
-                    print("[runpod] pod is RUNNING")
+                    print("[runpod] container started")
                     booted = True
-                gpus = runtime.get("gpus") or [{}]
-                print(
-                    f"[runpod] up {runtime.get('uptimeInSeconds', 0)}s"
-                    f" | gpu {gpus[0].get('gpuUtilPercent', 0)}%"
-                    f" | vram {gpus[0].get('memoryUtilPercent', 0)}%"
-                )
+                    if args.probe_only:
+                        # boot observed = probe answered; don't bill the sleep out
+                        print(f"[runpod] PROBE BOOT OK (uptime {uptime}s)")
+                        return 0
+                print(f"[runpod] up {uptime}s")
             elif status in ("EXITED", "TERMINATED", "STOPPED"):
                 print(f"[runpod] pod finished (status {status})")
                 return 0 if status == "EXITED" else 1
             elif not booted and time.time() - start > BOOT_TIMEOUT_S:
                 print(f"[runpod] pod failed to boot within {BOOT_TIMEOUT_S}s (status {status})")
-                return 1
+                return "boot_fail"
             time.sleep(POLL_INTERVAL_S)
         print(f"[runpod] TIMEOUT after {args.timeout_min} min")
         return 1
     finally:
         if pod_id:
-            terminate(runpod, pod_id)
+            terminate(api_key, pod_id)
 
 
 if __name__ == "__main__":

--- a/.claude/skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.claude/skills/fine-tuning/scripts/runpod_run_job.py
@@ -82,7 +82,10 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
-                    help="extra pod env var (repeatable)")
+                    help="extra pod env var (repeatable). HF_HUB_DISABLE_XET=1 "
+                         "and HF_HUB_ENABLE_HF_TRANSFER=0 are set by default "
+                         "(the hf_xet backend hangs on large model pulls); pass "
+                         "them here to override.")
     ap.add_argument("--probe-only", action="store_true",
                     help="skip clone+wrapper; just print GPU info and exit "
                          "(boot-reliability isolation test)")
@@ -158,6 +161,15 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     hf_token = os.environ.get("HF_TOKEN")
     if hf_token:
         env["HF_TOKEN"] = hf_token
+    # Force the classic resolve-endpoint HTTP download path. The hf_xet CAS
+    # backend hangs without timeout on multi-GB pulls of some model repos
+    # (py-spy showed workers frozen in xet_get at file_download.py:626; killed
+    # RunPod r6/r7/r8 and two Modal A0 attempts, 2026-07-05). It supersedes
+    # hf_transfer, so DISABLE_XET is the load-bearing one; hf_transfer is turned
+    # off too so the fallback is the plain, speed-tested path. Set as defaults
+    # BEFORE the --env loop so an explicit --env can still override either.
+    env["HF_HUB_DISABLE_XET"] = "1"
+    env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
     for pair in args.env:
         if "=" not in pair:
             raise SystemExit(f"--env expects KEY=VALUE, got: {pair}")

--- a/.skills/fine-tuning/reference/runpod-jobs.md
+++ b/.skills/fine-tuning/reference/runpod-jobs.md
@@ -141,6 +141,26 @@ to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
 Because there is no log API, a wrapper that wants diagnostics from a failed run
 must upload them itself before it exits -- see "Failure telemetry" below.
 
+### 5. hf_xet download hang (cross-provider, not RunPod-specific)
+
+Symptom: the job freezes right after unsloth's "Fast downloading is enabled"
+banner. Uptime keeps climbing (the container is alive), but network RX is zero
+and the model download never completes; the job eventually hits the wall-clock
+timeout. Killed RunPod r6/r7/r8 and two Modal A0 attempts (2026-07-05).
+
+Diagnosis: attach `py-spy dump --pid <worker>` to a live hung process; the stack
+sits in `xet_get` (`huggingface_hub/file_download.py:626`). The hf_xet CAS
+backend hangs without a timeout on multi-GB pulls of some model repos. It
+SUPERSEDES hf_transfer, so `HF_HUB_ENABLE_HF_TRANSFER=0` alone does nothing
+(verified in the hung process env).
+
+Fix: `HF_HUB_DISABLE_XET=1` forces the classic resolve-endpoint HTTP path, which
+speed-tested healthy. The launcher sets `HF_HUB_DISABLE_XET=1` and
+`HF_HUB_ENABLE_HF_TRANSFER=0` as default pod env (override via `--env`). This
+applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
+INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
+(set them in the `@app.function` secrets or the container env).
+
 ---
 
 ## Outputs and the Artifact Contract
@@ -170,6 +190,10 @@ runs/modal/<tag>/      # Modal training runs
   `--publish-target-repo`) so the final model lands on the Hub, not just the
   Modal output Volume. The code default is off (a bare `modal run` should not
   silently publish); a real run always opts in.
+- **Modal runs need the hf_xet mitigation too.** The download hang in gotcha #5
+  is a `huggingface_hub` issue, not a RunPod one; a Modal run pulling a large
+  model repo must set `HF_HUB_DISABLE_XET=1` (and `HF_HUB_ENABLE_HF_TRANSFER=0`)
+  in the container env or it will freeze the same way.
 
 ### Failure telemetry
 

--- a/.skills/fine-tuning/reference/runpod-jobs.md
+++ b/.skills/fine-tuning/reference/runpod-jobs.md
@@ -11,6 +11,11 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
 (`tuner/backends/training/cloud/runpod_backend.py`); see
 `reference/cloud-training.md`.
 
+The launcher (`scripts/runpod_run_job.py`) talks to the RunPod REST API
+(`https://rest.runpod.io/v1`) for pod create/terminate and to the GraphQL API
+for runtime polling. It does NOT use the `runpod` Python SDK. This split was
+forced by hard debugging (2026-07-05, 4 dead pods); see the gotchas below.
+
 ---
 
 ## Requirements
@@ -23,10 +28,8 @@ This lane is for arbitrary wrapper jobs. Cloud TRAINING stays on the
   the wrapper).
 - `--commit` must be a FULL 40-char sha (derive with `git rev-parse`, never
   hand-expand a short sha; the script enforces the length).
-- The `runpod` SDK installed where you launch from (`pip install runpod`).
-  Gotcha: importing the SDK crashes if the current working directory is on a
-  dead/unstattable mount (its state dir uses a cwd-relative path) -- launch
-  from a healthy directory.
+- No SDK install needed: the launcher uses only the Python standard library
+  (`urllib`), so it runs from any environment with `RUNPOD_API_KEY` set.
 
 ---
 
@@ -39,13 +42,13 @@ python3 scripts/runpod_run_job.py \
   --commit <full-40-char-sha> \
   --wrapper path/inside/repo/job.sh \
   --wrapper-args "--stage extract --surface holdout" \
-  --gpu "NVIDIA GeForce RTX 4090" \
+  --gpu "NVIDIA GeForce RTX 3090" \
   --timeout-min 180
 ```
 
-Always validate with `--dry-run` first: it prints the resolved pod spec
-(image digest, GPU, disk, env keys, full `docker_args` chain) without any API
-call or cost.
+Always validate with `--dry-run` first: it prints the resolved pod spec as JSON
+(image digest, GPU, disk, env keys redacted, the full `dockerEntrypoint` chain)
+without any API call or cost.
 
 Key flags:
 
@@ -56,24 +59,125 @@ Key flags:
 - `--cloud-type` -- `COMMUNITY` (default, cheaper) or `SECURE`.
 - `--env KEY=VALUE` -- extra pod env vars, repeatable.
 - `--timeout-min` -- hard wall-clock cap; the pod is terminated at timeout.
+- `--min-download` -- minimum host download speed (Mbps, default 700). Community
+  hosts below this stall for tens of minutes pulling a large image; the boot
+  timeout then recycles onto a better host (see `--max-hosts`).
+- `--allowed-cuda "12.8,12.9,13.0"` -- CUDA versions the host driver must offer;
+  a host whose driver is older than the image's CUDA fails container start
+  silently.
+- `--max-hosts N` -- pods to try before giving up. A community host that never
+  starts the container within the boot timeout (stalled image pull) is
+  terminated and a fresh pod is created, up to N attempts (~$0.05/boot-fail at
+  3090 rates). Anything after boot (job error, timeout) is final, not retried.
+- `--probe-only` -- skip clone+wrapper; boot the image, print `nvidia-smi`, and
+  exit as soon as real container uptime is observed. Use this to isolate
+  boot/image reliability from wrapper logic before spending on a real run.
+- `--no-entrypoint-override` -- do not set `dockerEntrypoint`; let the image's
+  own ENTRYPOINT/CMD run (diagnostic: isolates whether the override itself
+  prevents container start).
 
 ---
 
 ## Lifecycle and Billing Safety
 
-The script owns the full pod lifecycle: `create_pod` -> wait for RUNNING ->
-poll every 30s (uptime, GPU/VRAM utilization) -> exit on pod EXITED -> and
-ALWAYS `terminate_pod` in a `finally` block, with 3 retries. A wedged or
-timed-out run cannot silently keep billing. If termination fails after
-retries, the script prints the console URL
-(https://www.runpod.io/console/pods) for a manual kill -- verify.
+The script owns the full pod lifecycle: REST `POST /pods` -> wait for REAL
+container uptime -> poll every 30s -> exit on pod EXITED -> and ALWAYS
+`DELETE /pods/{id}` in a `finally` block, with 3 retries. A wedged or timed-out
+run cannot silently keep billing. If termination fails after retries, the
+script prints the console URL (https://www.runpod.io/console/pods) for a manual
+kill -- verify.
 
-Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout
-(600s) / wall-clock timeout, 2 = bad arguments or missing credentials.
+Exit codes: 0 = wrapper finished (pod EXITED), 1 = pod failed / boot timeout /
+wall-clock timeout / all `--max-hosts` boot attempts exhausted, 2 = bad
+arguments or missing credentials.
 
-## Outputs
+---
+
+## Gotchas (all adjudicated 2026-07-05 by local docker repro on the unsloth image)
+
+### 1. Non-root image + `cd /root` crash-loop (the r5/edrt9x saga)
+
+The wrapper command runs as the image's default container user, which is NOT
+necessarily root: the unsloth image runs as `unsloth:runtimeusers` with
+`HOME=/home/unsloth` and no write access to `/root`. A `cd /root` there fails
+"Permission denied", and under `set -e` that aborts in <1s, so RunPod
+restart-loops the container with uptime pinned at 1-2s -- indistinguishable from
+a boot failure over the API. The launcher uses an image-agnostic writable
+workdir instead:
+
+```
+{ cd ${WORKDIR:-/workspace} 2>/dev/null || cd "$HOME"; }
+```
+
+The braces matter: a bare `cd A || cd B && clone` parses as
+`cd A || (cd B && clone)` and SKIPS the clone whenever `cd A` succeeds.
+
+### 2. dockerEntrypoint override (why REST, not the SDK)
+
+Images that ship an ENTRYPOINT (unsloth's `/usr/local/bin/entrypoint.sh`)
+receive GraphQL `dockerArgs` as *arguments to the entrypoint*, which can
+crash-loop the container forever with uptime pinned at 0 while it bills as
+RUNNING. The REST `dockerEntrypoint` field REPLACES the ENTRYPOINT so the job
+command actually runs. The SDK also embeds `docker_args` into its GraphQL
+mutation with zero escaping, so any double quote corrupts the API call. REST
+takes a JSON body: no quoting restrictions.
+
+### 3. REST has no uptime; poll GraphQL
+
+The REST pod object carries no uptime field (only `desiredStatus`,
+`lastStartedAt`), so an uptime check against REST reads every pod as
+never-booted forever (six healthy-or-not pods were killed at the boot timeout by
+exactly that bug). Actual container runtime lives only in the GraphQL
+`pod.runtime.uptimeInSeconds`. GraphQL auth is the `?api_key=` query param (a
+Bearer header alone 403s), and `api.runpod.io` 403s the default urllib
+User-Agent (Cloudflare), so the poller sends an explicit UA.
+
+### 4. Fail-hold: "ran and failed" vs "never booted"
+
+RunPod has no logs API (`runpod-python#400`). On nonzero exit the job command
+prints the code and holds the container alive for `FAIL_HOLD_S` (300s) before
+exiting nonzero, so the uptime poller can tell "ran and failed" (uptime climbs
+to ~300s then EXITED) apart from a boot crash-loop (uptime stuck at 1-2s).
+Because there is no log API, a wrapper that wants diagnostics from a failed run
+must upload them itself before it exits -- see "Failure telemetry" below.
+
+---
+
+## Outputs and the Artifact Contract
 
 There is no network volume. The wrapper is responsible for uploading its own
-outputs (e.g. to a HuggingFace repo) before it exits; when the pod reports
-EXITED the outputs are already wherever the wrapper put them. Design wrappers
-so a preempted or re-run pod is safe (idempotent uploads, resumable work).
+outputs before it exits; when the pod reports EXITED the outputs are already
+wherever the wrapper put them. Design wrappers so a preempted or re-run pod is
+safe (idempotent uploads, resumable work).
+
+Every cloud job (RunPod or Modal) uploads its results + manifest + logs to an
+HF staging repo under a provider-tagged path, with the producing repo commit
+recorded:
+
+```
+runs/runpod/<tag>/     # RunPod wrapper jobs
+runs/modal/<tag>/      # Modal training runs
+```
+
+- **HF Hub is the durable system of record.** Provider-native storage (Modal
+  Volumes, a RunPod pod's local disk) is scratch / checkpoint space only; it is
+  ephemeral and must never be the sole copy of a result.
+- **The producing repo commit is recorded** in the manifest so any artifact
+  traces back to the exact code that made it. For the training scripts this is
+  the `repo_commit` field in `manifest.json`; for RunPod wrapper jobs, pass
+  `--commit <full-sha>` and stamp the same sha into whatever the wrapper writes.
+- **Modal real runs must pass `--publish-final-model`** (and
+  `--publish-target-repo`) so the final model lands on the Hub, not just the
+  Modal output Volume. The code default is off (a bare `modal run` should not
+  silently publish); a real run always opts in.
+
+### Failure telemetry
+
+Because RunPod has no log API, a failed wrapper leaves zero diagnostics unless
+it uploads them itself. The recommended pattern (see the Epistemic-Humility AL
+wrapper for a worked example): capture the wrapper's own stdout+stderr to a file
+from the first line (`exec > >(tee logfile) 2>&1`), and on ANY nonzero exit
+(bash `trap ... EXIT`) upload a failure marker plus the tail of that log to
+`<run_tag>/_failure/` in the staging repo. Make it best-effort (telemetry
+failure must not mask the original exit code) and redact `hf_`/`rpa_` secret
+patterns before upload.

--- a/.skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.skills/fine-tuning/scripts/runpod_run_job.py
@@ -6,26 +6,44 @@ repo at a pinned commit, execute a wrapper script inside a pinned container
 image, then terminate the pod. Generic by design -- the repo, commit, wrapper,
 and image are all arguments; nothing here is project-specific.
 
-Complements tuner/backends/training/cloud/runpod_backend.py (which is
-training-lane-only); this runs arbitrary wrapper scripts. Lifecycle is the
-same: create_pod -> wait RUNNING -> poll until EXITED -> ALWAYS terminate in
-finally (billing safety). No network volume: the wrapper is responsible for
-uploading its own outputs (e.g. to a HuggingFace repo).
+Uses the RunPod REST API (https://rest.runpod.io/v1) rather than the GraphQL
+SDK, for two hard-won reasons (2026-07-05 lane debugging, 4 dead pods):
+  1. dockerEntrypoint override. Images that ship an ENTRYPOINT (e.g.
+     unsloth/unsloth's /usr/local/bin/entrypoint.sh) receive GraphQL
+     dockerArgs as *arguments to the entrypoint*, which can crash-loop the
+     container forever with uptime pinned at 0 while the pod bills as
+     RUNNING. The REST field dockerEntrypoint replaces the ENTRYPOINT so the
+     job command actually runs.
+  2. The SDK embeds docker_args into its GraphQL mutation with zero escaping
+     (dockerArgs: "{docker_args}"), so any double quote corrupts the API
+     call. REST takes a JSON body; no quoting restrictions.
+
+Lifecycle: create pod -> wait for real container uptime (a stalled image
+pull or crash-looping entrypoint shows RUNNING with uptime 0 and must NOT
+disarm the boot timeout) -> poll until EXITED -> ALWAYS terminate in finally
+(billing safety). No network volume: the wrapper uploads its own outputs
+(e.g. to a HuggingFace repo).
 
 Env: RUNPOD_API_KEY (required); HF_TOKEN forwarded to the pod when set.
 Usage:
   python scripts/runpod_run_job.py --run-tag my-job \
       --repo-url https://github.com/org/repo.git --commit <full-40-char-sha> \
       --wrapper path/inside/repo/job.sh --wrapper-args "--stage extract" \
-      [--gpu "NVIDIA GeForce RTX 4090"] [--image <img@sha256:...>] \
-      [--timeout-min 180] [--dry-run]
+      [--gpu "NVIDIA GeForce RTX 3090"] [--image <img@sha256:...>] \
+      [--min-download 700] [--allowed-cuda "12.8,12.9,13.0"] \
+      [--timeout-min 180] [--probe-only] [--dry-run]
 """
 
 import argparse
+import json
 import os
 import shlex
 import sys
 import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://rest.runpod.io/v1"
 
 # Default image matches the tuner's runpod training backend pin.
 DEFAULT_IMAGE = (
@@ -33,7 +51,15 @@ DEFAULT_IMAGE = (
     "@sha256:5266c57be21059bfb407d80dc2f448868a5c2e2dbe7b2aa27780f48b48cbec39"
 )
 POLL_INTERVAL_S = 30
-BOOT_TIMEOUT_S = 600
+# Covers image pull + container start on a host passing --min-download;
+# a ~20GB image at 700 Mbps pulls in ~4-5 min, so 15 min is generous and
+# anything slower means we picked a bad host and should recycle.
+BOOT_TIMEOUT_S = 900
+# How long a failed job holds the container alive before exiting nonzero, so
+# the uptime poller can distinguish "ran and failed" (uptime climbs to this
+# then EXITED) from a sub-2s crash-loop (uptime never leaves 1-2s). One poll
+# interval plus margin.
+FAIL_HOLD_S = 300
 
 
 def parse_args() -> argparse.Namespace:
@@ -46,27 +72,85 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--image", default=DEFAULT_IMAGE, help="container image (pin by digest)")
     ap.add_argument("--gpu", default="NVIDIA GeForce RTX 4090", help="RunPod gpu_type_id")
     ap.add_argument("--cloud-type", default="COMMUNITY", choices=["COMMUNITY", "SECURE"])
+    ap.add_argument("--min-download", type=int, default=700,
+                    help="minimum host download speed in Mbps; community hosts "
+                         "below this stall for tens of minutes pulling large images")
+    ap.add_argument("--allowed-cuda", default="",
+                    help="comma-separated CUDA versions the host must offer "
+                         "(e.g. '12.8,12.9,13.0'); a host whose driver is older "
+                         "than the image's CUDA fails container start silently")
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
                     help="extra pod env var (repeatable)")
+    ap.add_argument("--probe-only", action="store_true",
+                    help="skip clone+wrapper; just print GPU info and exit "
+                         "(boot-reliability isolation test)")
+    ap.add_argument("--no-entrypoint-override", action="store_true",
+                    help="do not set dockerEntrypoint; let the image's own "
+                         "ENTRYPOINT/CMD run (isolates whether the override "
+                         "itself prevents container start)")
+    ap.add_argument("--max-hosts", type=int, default=3,
+                    help="pods to try before giving up: a community host that "
+                         "does not start the container within the boot timeout "
+                         "(stalled image pull) is terminated and a fresh pod "
+                         "is created, up to this many attempts (boot-fail "
+                         "cost is ~$0.05/attempt at 3090 rates)")
     ap.add_argument("--dry-run", action="store_true", help="print the pod spec and exit")
     return ap.parse_args()
 
 
-def build_startup_cmd(args: argparse.Namespace) -> str:
-    """Clone at the pinned commit and exec the wrapper as the pod's docker_args."""
+def build_job_command(args: argparse.Namespace) -> str:
+    """The shell command the container runs (via dockerEntrypoint bash -lc).
+
+    The command runs as the image's default container user, which is NOT
+    necessarily root: the unsloth image runs as unsloth:runtimeusers with
+    HOME=/home/unsloth and no write access to /root. A `cd /root` there fails
+    "Permission denied", and under `set -e` that aborts in <1s, so RunPod
+    restart-loops the container with uptime pinned at 1-2s -- exactly the
+    r5/edrt9x crash-loop (adjudicated by a local docker repro on the same
+    image family, 2026-07-05). Use a writable, image-agnostic workdir instead
+    of assuming root's home is available or writable.
+    """
+    if args.probe_only:
+        # Stay alive long enough for uptime polling to observe the container:
+        # a command that exits immediately gets restart-looped by RunPod and
+        # is indistinguishable from a boot failure via the API (no log API,
+        # runpod-python#400). Uptime > 0 IS the probe signal.
+        return "nvidia-smi; echo PROBE_OK; sleep 240"
+    # /workspace is the unsloth image's WORKDIR and is writable by the
+    # container user; runpod/pytorch images also provide it. Falling back to
+    # $HOME keeps this working on any image whose user can write there.
+    workdir = "${WORKDIR:-/workspace}"
     inner = " && ".join(
         [
             "set -euo pipefail",
-            "cd /root",
+            # Grouped so the fallback binds only to the cd, not to the rest of
+            # the && chain: a bare `cd A || cd B && clone` parses as
+            # `cd A || (cd B && clone)` and SKIPS the clone whenever cd A
+            # succeeds (equal-precedence left-associative && / ||).
+            f'{{ cd {workdir} 2>/dev/null || cd "$HOME"; }}',
+            # Idempotent: RunPod restarts an exited container against the SAME
+            # writable layer, so a stale ./repo from a prior life would make
+            # `git clone ... repo` die "destination path exists" every restart.
+            "rm -rf repo",
             f"git clone --filter=blob:none {shlex.quote(args.repo_url)} repo",
             "cd repo",
             f"git checkout {shlex.quote(args.commit)}",
             f"bash {shlex.quote(args.wrapper)} {args.wrapper_args}",
         ]
     )
-    return f"bash -lc {shlex.quote(inner)}"
+    # Failure persistence: on nonzero exit, print the code and hold the
+    # container alive past one poll interval so the uptime poller can tell
+    # "ran and failed" (uptime climbs to FAIL_HOLD_S then EXITED) apart from a
+    # crash-loop (uptime stuck at 1-2s). Without this, every fast failure is
+    # invisibly indistinguishable from a boot failure over the API.
+    return (
+        f"( {inner} ); rc=$?; "
+        'if [ "$rc" -ne 0 ]; then '
+        'echo "[runpod-job] JOB FAILED rc=$rc; holding for diagnosis"; '
+        f"sleep {FAIL_HOLD_S}; fi; exit $rc"
+    )
 
 
 def build_pod_env(args: argparse.Namespace) -> dict:
@@ -82,11 +166,82 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     return env
 
 
-def terminate(runpod_module, pod_id: str) -> None:
+def api(method: str, path: str, api_key: str, body: dict | None = None) -> dict:
+    req = urllib.request.Request(
+        f"{API_BASE}{path}",
+        method=method,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "runpod-run-job/1.0",
+        },
+        data=json.dumps(body).encode() if body is not None else None,
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw.strip() else {}
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")[:500]
+        raise RuntimeError(f"{method} {path} -> HTTP {e.code}: {detail}") from e
+
+
+def poll_pod(api_key: str, pod_id: str) -> dict:
+    """Return {status, uptime} for a pod.
+
+    Create/terminate go through REST, but boot polling CANNOT: the REST pod
+    object carries no uptime field at all (only desiredStatus/lastStartedAt),
+    so an uptime check against REST reads every pod as never-booted forever
+    (2026-07-05: six healthy-or-not pods were killed at the boot timeout by
+    exactly that bug). Actual container runtime lives only in the GraphQL
+    pod.runtime.uptimeInSeconds.
+    """
+    query = ('query{pod(input:{podId:"%s"}){desiredStatus '
+             "runtime{uptimeInSeconds}}}" % pod_id)
+    # GraphQL auth is the SDK-style api_key query param; a Bearer header
+    # alone gets 403. api.runpod.io also 403s the default Python-urllib
+    # User-Agent (Cloudflare), so send an explicit UA (both observed
+    # 2026-07-05).
+    req = urllib.request.Request(
+        f"https://api.runpod.io/graphql?api_key={api_key}",
+        method="POST",
+        headers={"Content-Type": "application/json",
+                 "User-Agent": "runpod-run-job/1.0"},
+        data=json.dumps({"query": query}).encode(),
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+    pod = (data.get("data") or {}).get("pod") or {}
+    runtime = pod.get("runtime") or {}
+    return {"status": pod.get("desiredStatus", "UNKNOWN"),
+            "uptime": int(runtime.get("uptimeInSeconds") or 0)}
+
+
+def build_pod_spec(args: argparse.Namespace) -> dict:
+    spec = {
+        "name": args.run_tag,
+        "imageName": args.image,
+        "gpuTypeIds": [args.gpu],
+        "gpuCount": 1,
+        "cloudType": args.cloud_type,
+        "containerDiskInGb": args.disk_gb,
+        "minDownloadMbps": args.min_download,
+        "env": build_pod_env(args),
+    }
+    if not args.no_entrypoint_override:
+        # Full ENTRYPOINT replacement: the image's own entrypoint never runs.
+        spec["dockerEntrypoint"] = ["bash", "-lc", build_job_command(args)]
+    cuda = [v.strip() for v in args.allowed_cuda.split(",") if v.strip()]
+    if cuda:
+        spec["allowedCudaVersions"] = cuda
+    return spec
+
+
+def terminate(api_key: str, pod_id: str) -> None:
     """Terminate with retry; the one call that must never be skipped."""
     for attempt in range(3):
         try:
-            runpod_module.terminate_pod(pod_id)
+            api("DELETE", f"/pods/{pod_id}", api_key)
             print(f"[runpod] pod {pod_id} terminated")
             return
         except Exception as e:  # noqa: BLE001
@@ -105,17 +260,10 @@ def main() -> int:
         print(f"ERROR: --commit must be a full 40-char sha (got {len(args.commit)} chars)")
         return 2
 
-    startup_cmd = build_startup_cmd(args)
-    pod_name = args.run_tag
-
     if args.dry_run:
-        print(f"pod_name:    {pod_name}")
-        print(f"image:       {args.image}")
-        print(f"gpu:         {args.gpu} ({args.cloud_type})")
-        print(f"disk:        {args.disk_gb} GB, no network volume")
-        print(f"timeout:     {args.timeout_min} min")
-        print(f"env keys:    {sorted(build_pod_env(args))}")
-        print(f"docker_args: {startup_cmd}")
+        spec = build_pod_spec(args)
+        redacted = dict(spec, env={k: "***" for k in spec["env"]})
+        print(json.dumps(redacted, indent=2))
         return 0
 
     api_key = os.environ.get("RUNPOD_API_KEY")
@@ -123,65 +271,71 @@ def main() -> int:
         print("ERROR: RUNPOD_API_KEY is not set")
         return 2
 
-    import runpod
+    for attempt in range(1, args.max_hosts + 1):
+        result = run_once(args, api_key, attempt)
+        if result != "boot_fail":
+            return result
+        # Boot failure means THIS HOST never started the container (stalled
+        # image pull); the workload never ran, so a fresh pod is a clean retry,
+        # not a re-run. Anything after boot (job error, timeout) is final.
+        if attempt < args.max_hosts:
+            print(f"[runpod] recycling host ({attempt}/{args.max_hosts} attempts used)")
+    print(f"[runpod] giving up after {args.max_hosts} boot failures")
+    return 1
 
-    runpod.api_key = api_key
 
+def run_once(args: argparse.Namespace, api_key: str, attempt: int) -> int | str:
+    """One pod lifecycle. Returns an exit code, or 'boot_fail' (container
+    never started before BOOT_TIMEOUT_S -> caller may recycle onto a new host).
+    """
     pod_id = None
     try:
-        pod = runpod.create_pod(
-            name=pod_name,
-            image_name=args.image,
-            gpu_type_id=args.gpu,
-            gpu_count=1,
-            container_disk_in_gb=args.disk_gb,
-            cloud_type=args.cloud_type,
-            env=build_pod_env(args),
-            docker_args=startup_cmd,
-        )
+        pod = api("POST", "/pods", api_key, build_pod_spec(args))
         pod_id = pod.get("id")
         if not pod_id:
-            print(f"ERROR: create_pod returned no id: {pod}")
+            print(f"ERROR: create pod returned no id: {pod}")
             return 1
-        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr)")
+        print(f"[runpod] pod {pod_id} created (${pod.get('costPerHr', '?')}/hr, attempt {attempt})")
         print(f"[runpod] console: https://www.runpod.io/console/pods/{pod_id}")
 
-        # Boot wait, then completion poll. EXITED == the wrapper finished and
-        # its outputs are already wherever the wrapper uploads them.
+        # Boot wait, then completion poll. EXITED == the job command finished
+        # and its outputs are already wherever the wrapper uploads them.
         start = time.time()
         deadline = start + args.timeout_min * 60
         booted = False
         while time.time() < deadline:
             try:
-                info = runpod.get_pod(pod_id)
+                info = poll_pod(api_key, pod_id)
             except Exception as e:  # noqa: BLE001
                 print(f"[runpod] poll error (retrying): {e}")
                 time.sleep(POLL_INTERVAL_S)
                 continue
-            status = (info or {}).get("desiredStatus", "UNKNOWN")
-            runtime = (info or {}).get("runtime") or {}
-            if status == "RUNNING" and runtime:
+            status = info["status"]
+            uptime = info["uptime"]
+            # RUNNING with uptime 0 means the image is still pulling or the
+            # container is crash-looping; it has NOT booted. Only real uptime
+            # counts, so the boot timeout stays armed through a stalled pull.
+            if status == "RUNNING" and uptime > 0:
                 if not booted:
-                    print("[runpod] pod is RUNNING")
+                    print("[runpod] container started")
                     booted = True
-                gpus = runtime.get("gpus") or [{}]
-                print(
-                    f"[runpod] up {runtime.get('uptimeInSeconds', 0)}s"
-                    f" | gpu {gpus[0].get('gpuUtilPercent', 0)}%"
-                    f" | vram {gpus[0].get('memoryUtilPercent', 0)}%"
-                )
+                    if args.probe_only:
+                        # boot observed = probe answered; don't bill the sleep out
+                        print(f"[runpod] PROBE BOOT OK (uptime {uptime}s)")
+                        return 0
+                print(f"[runpod] up {uptime}s")
             elif status in ("EXITED", "TERMINATED", "STOPPED"):
                 print(f"[runpod] pod finished (status {status})")
                 return 0 if status == "EXITED" else 1
             elif not booted and time.time() - start > BOOT_TIMEOUT_S:
                 print(f"[runpod] pod failed to boot within {BOOT_TIMEOUT_S}s (status {status})")
-                return 1
+                return "boot_fail"
             time.sleep(POLL_INTERVAL_S)
         print(f"[runpod] TIMEOUT after {args.timeout_min} min")
         return 1
     finally:
         if pod_id:
-            terminate(runpod, pod_id)
+            terminate(api_key, pod_id)
 
 
 if __name__ == "__main__":

--- a/.skills/fine-tuning/scripts/runpod_run_job.py
+++ b/.skills/fine-tuning/scripts/runpod_run_job.py
@@ -82,7 +82,10 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--disk-gb", type=int, default=60)
     ap.add_argument("--timeout-min", type=int, default=180)
     ap.add_argument("--env", action="append", default=[], metavar="KEY=VALUE",
-                    help="extra pod env var (repeatable)")
+                    help="extra pod env var (repeatable). HF_HUB_DISABLE_XET=1 "
+                         "and HF_HUB_ENABLE_HF_TRANSFER=0 are set by default "
+                         "(the hf_xet backend hangs on large model pulls); pass "
+                         "them here to override.")
     ap.add_argument("--probe-only", action="store_true",
                     help="skip clone+wrapper; just print GPU info and exit "
                          "(boot-reliability isolation test)")
@@ -158,6 +161,15 @@ def build_pod_env(args: argparse.Namespace) -> dict:
     hf_token = os.environ.get("HF_TOKEN")
     if hf_token:
         env["HF_TOKEN"] = hf_token
+    # Force the classic resolve-endpoint HTTP download path. The hf_xet CAS
+    # backend hangs without timeout on multi-GB pulls of some model repos
+    # (py-spy showed workers frozen in xet_get at file_download.py:626; killed
+    # RunPod r6/r7/r8 and two Modal A0 attempts, 2026-07-05). It supersedes
+    # hf_transfer, so DISABLE_XET is the load-bearing one; hf_transfer is turned
+    # off too so the fallback is the plain, speed-tested path. Set as defaults
+    # BEFORE the --env loop so an explicit --env can still override either.
+    env["HF_HUB_DISABLE_XET"] = "1"
+    env["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
     for pair in args.env:
         if "=" not in pair:
             raise SystemExit(f"--env expects KEY=VALUE, got: {pair}")

--- a/Trainers/cloud/train_modal.py
+++ b/Trainers/cloud/train_modal.py
@@ -140,6 +140,28 @@ VALID_GPU_TYPES = ["T4", "L4", "A10G", "L40S", "A100", "A100-80GB", "H100"]
 DEFAULT_GPU = "L40S"
 
 
+# The hf_xet CAS backend hangs without timeout on multi-GB model pulls (py-spy:
+# workers frozen in xet_get at file_download.py:626), which froze two Modal A0
+# attempts on 2026-07-05. It supersedes hf_transfer, so DISABLE_XET is the
+# load-bearing one; hf_transfer is turned off too so the fallback is the plain
+# resolve-endpoint HTTP path.
+HF_XET_MITIGATION = {"HF_HUB_DISABLE_XET": "1", "HF_HUB_ENABLE_HF_TRANSFER": "0"}
+
+
+def apply_hf_xet_mitigation(env) -> None:
+    """Set the hf_xet-hang mitigation defaults on a mutable env mapping.
+
+    Treats empty as unset: the @app.function secrets dict forwards these as ""
+    when they are absent from the local launch env, and an empty value would
+    neither disable xet nor trip a plain setdefault. So an explicit local value
+    (e.g. "0") is preserved, while an unset-or-empty var falls through to the
+    mitigation default -- the fix applies even on a bare `modal run`.
+    """
+    for key, default in HF_XET_MITIGATION.items():
+        if not env.get(key):
+            env[key] = default
+
+
 # ---------------------------------------------------------------------------
 # Training Function (runs remotely on Modal)
 # ---------------------------------------------------------------------------
@@ -158,10 +180,18 @@ DEFAULT_GPU = "L40S"
     # off the fused cut_cross_entropy Triton kernel, which fails to compile
     # there ("PassManager::run failed"). Forwarded only when set locally; empty
     # by default so it is inert on modern cards.
+    #
+    # HF_HUB_DISABLE_XET / HF_HUB_ENABLE_HF_TRANSFER: forwarded so a local
+    # override reaches the container; run_training also sets them via setdefault
+    # so the xet-hang mitigation applies even on a bare `modal run` (see there).
+    # An empty string here does NOT override the setdefault (only a real value
+    # forwarded from the local env does).
     secrets=[modal.Secret.from_dict({
         "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
         "WANDB_API_KEY": os.environ.get("WANDB_API_KEY", ""),
         "UNSLOTH_COMPILE_DISABLE": os.environ.get("UNSLOTH_COMPILE_DISABLE", ""),
+        "HF_HUB_DISABLE_XET": os.environ.get("HF_HUB_DISABLE_XET", ""),
+        "HF_HUB_ENABLE_HF_TRANSFER": os.environ.get("HF_HUB_ENABLE_HF_TRANSFER", ""),
     })],
 )
 def run_training(
@@ -205,6 +235,9 @@ def run_training(
     # Point HuggingFace cache at the persistent volume to avoid re-downloading models
     os.environ["HF_HOME"] = "/cache/huggingface"
     os.environ["TRANSFORMERS_CACHE"] = "/cache/huggingface"
+
+    # Dodge the hf_xet download hang (see apply_hf_xet_mitigation).
+    apply_hf_xet_mitigation(os.environ)
 
     # Bridge the repo provenance into the env contract the training scripts read
     # (train_sft/train_kto/train_dpo consume CLOUD_REPO_BRANCH / CLOUD_REPO_COMMIT

--- a/Trainers/cloud/train_modal.py
+++ b/Trainers/cloud/train_modal.py
@@ -206,6 +206,20 @@ def run_training(
     os.environ["HF_HOME"] = "/cache/huggingface"
     os.environ["TRANSFORMERS_CACHE"] = "/cache/huggingface"
 
+    # Bridge the repo provenance into the env contract the training scripts read
+    # (train_sft/train_kto/train_dpo consume CLOUD_REPO_BRANCH / CLOUD_REPO_COMMIT
+    # from os.environ to stamp manifest.json and name the run dir). The
+    # ModalBackend sets these in the LOCAL `modal run` process env, but Modal
+    # only forwards explicitly-declared secrets into the remote container, so
+    # the local env never reaches this function -- without this bridge the
+    # manifest records repo_commit=null and the run dir is stamped "-local".
+    # These args are the exact commit this container checked out above, so they
+    # are the authoritative provenance regardless of provider.
+    if repo_branch:
+        os.environ["CLOUD_REPO_BRANCH"] = repo_branch
+    if repo_commit:
+        os.environ["CLOUD_REPO_COMMIT"] = repo_commit
+
     # Clone the repo
     workspace = "/workspace/toolset-training"
     if repo_url:

--- a/Trainers/dpo/train_dpo.py
+++ b/Trainers/dpo/train_dpo.py
@@ -397,10 +397,17 @@ def main():
 
     # Cloud-artifact run layout
     from datetime import datetime
-    from shared.cloud_artifacts import build_manifest, build_run_paths, write_manifest
+    from shared.cloud_artifacts import (
+        build_manifest,
+        build_run_paths,
+        resolve_repo_provenance,
+        write_manifest,
+    )
 
-    repo_branch = os.environ.get("CLOUD_REPO_BRANCH")
-    repo_commit = os.environ.get("CLOUD_REPO_COMMIT")
+    # Prefer the launch-time env contract; fall back to the git checkout so a
+    # provider whose wrapper does not forward the env vars still records the
+    # exact commit that ran (see resolve_repo_provenance).
+    repo_branch, repo_commit = resolve_repo_provenance()
     artifact_identifier = args.artifact_bucket or os.environ.get("CLOUD_ARTIFACT_IDENTIFIER")
 
     timestamp = args.run_timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")

--- a/Trainers/kto/train_kto.py
+++ b/Trainers/kto/train_kto.py
@@ -56,6 +56,7 @@ from shared.cloud_artifacts import (
     build_manifest,
     build_run_paths,
     publish_final_model_to_hub,
+    resolve_repo_provenance,
     sync_directory_to_hf_bucket,
     write_manifest,
 )
@@ -475,8 +476,10 @@ def main():
     print("Loading configuration from configs/config.yaml\n")
     config = load_config()
 
-    repo_branch = os.environ.get("CLOUD_REPO_BRANCH")
-    repo_commit = os.environ.get("CLOUD_REPO_COMMIT")
+    # Prefer the launch-time env contract; fall back to the git checkout so a
+    # provider whose wrapper does not forward the env vars still records the
+    # exact commit that ran (see resolve_repo_provenance).
+    repo_branch, repo_commit = resolve_repo_provenance()
     artifact_identifier = args.artifact_bucket or os.environ.get("CLOUD_ARTIFACT_IDENTIFIER")
 
     # Create timestamped run directory

--- a/Trainers/sft/train_sft.py
+++ b/Trainers/sft/train_sft.py
@@ -63,6 +63,7 @@ from shared.cloud_artifacts import (
     build_manifest,
     build_run_paths,
     publish_final_model_to_hub,
+    resolve_repo_provenance,
     sync_directory_to_hf_bucket,
     write_manifest,
 )
@@ -806,8 +807,10 @@ def run(args: argparse.Namespace):
     # Validate model compatibility BEFORE loading model
     validate_model_compatibility(config)
 
-    repo_branch = os.environ.get("CLOUD_REPO_BRANCH")
-    repo_commit = os.environ.get("CLOUD_REPO_COMMIT")
+    # Prefer the launch-time env contract; fall back to the git checkout so a
+    # provider whose wrapper does not forward the env vars still records the
+    # exact commit that ran (see resolve_repo_provenance).
+    repo_branch, repo_commit = resolve_repo_provenance()
     artifact_identifier = args.artifact_bucket or os.environ.get("CLOUD_ARTIFACT_IDENTIFIER")
 
     # Create timestamped run directory (following KTO pattern)

--- a/shared/cloud_artifacts.py
+++ b/shared/cloud_artifacts.py
@@ -69,6 +69,59 @@ def normalize_hf_bucket_id(bucket_id: str) -> str:
     return normalized.strip("/")
 
 
+def resolve_repo_provenance(
+    repo_dir: Optional[Path] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Resolve (repo_branch, repo_commit) for a cloud run, robustly.
+
+    Every cloud provider clones the repo at a pinned commit inside its
+    container, so the checked-out working tree is itself the authoritative
+    provenance. The launch-time contract is the CLOUD_REPO_BRANCH /
+    CLOUD_REPO_COMMIT env vars, but a provider whose wrapper forgets to
+    forward them into the remote training env would otherwise stamp
+    repo_commit=null and a "-local" run dir. Falling back to `git rev-parse`
+    against the actual checkout closes that gap provider-generically: the
+    manifest records the exact commit that ran regardless of which provider
+    launched it.
+
+    Order: explicit env var (the pinned request) wins; git of the checkout is
+    the fallback; None only when neither is available (a genuine non-cloud or
+    non-git run).
+    """
+    branch = os.environ.get("CLOUD_REPO_BRANCH") or None
+    commit = os.environ.get("CLOUD_REPO_COMMIT") or None
+    if branch and commit:
+        return branch, commit
+
+    cwd = str(repo_dir) if repo_dir is not None else None
+    if commit is None:
+        commit = _git_output(["rev-parse", "HEAD"], cwd)
+    if branch is None:
+        derived = _git_output(["rev-parse", "--abbrev-ref", "HEAD"], cwd)
+        # A detached HEAD (the usual state after `git checkout <sha>`) reports
+        # "HEAD"; that is not a useful branch label, so leave it unset.
+        branch = derived if derived and derived != "HEAD" else branch
+    return branch, commit
+
+
+def _git_output(args: list, cwd: Optional[str]) -> Optional[str]:
+    """Run a read-only git command; return stripped stdout or None on failure."""
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    out = result.stdout.strip()
+    return out or None
+
+
 def build_run_paths(base_output_dir: Path, provider: str, method: str, timestamp: str, commit: str) -> RunPaths:
     """Build the canonical run layout used by cloud providers."""
     short_sha = (commit or "local")[:8]

--- a/tests/cloud/test_cloud_artifacts.py
+++ b/tests/cloud/test_cloud_artifacts.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import patch
@@ -10,10 +11,56 @@ from shared.cloud_artifacts import (
     build_run_paths,
     ensure_hf_bucket,
     normalize_hf_bucket_id,
+    resolve_repo_provenance,
     sync_file_to_hf_bucket,
     sync_directory_to_hf_bucket,
     write_manifest,
 )
+
+
+@pytest.fixture
+def _no_repo_env(monkeypatch):
+    monkeypatch.delenv("CLOUD_REPO_BRANCH", raising=False)
+    monkeypatch.delenv("CLOUD_REPO_COMMIT", raising=False)
+
+
+def _init_repo(path):
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "--allow-empty", "-m", "init"], check=True)
+    return subprocess.run(
+        ["git", "-C", str(path), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def test_resolve_repo_provenance_env_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("CLOUD_REPO_BRANCH", "feature/x")
+    monkeypatch.setenv("CLOUD_REPO_COMMIT", "deadbeef")
+    # Even with a real repo dir, the pinned env request is authoritative.
+    assert resolve_repo_provenance(tmp_path) == ("feature/x", "deadbeef")
+
+
+def test_resolve_repo_provenance_git_fallback(_no_repo_env, tmp_path):
+    expected = _init_repo(tmp_path)
+    branch, commit = resolve_repo_provenance(tmp_path)
+    assert commit == expected
+    assert branch not in (None, "HEAD")  # a real branch name, not detached-HEAD
+
+
+def test_resolve_repo_provenance_detached_head_leaves_branch_unset(_no_repo_env, tmp_path):
+    sha = _init_repo(tmp_path)
+    # Detaching HEAD is the usual state after `git checkout <sha>` in a cloud clone.
+    subprocess.run(["git", "-C", str(tmp_path), "checkout", "-q", sha], check=True)
+    branch, commit = resolve_repo_provenance(tmp_path)
+    assert commit == sha
+    assert branch is None  # "HEAD" is not a useful branch label
+
+
+def test_resolve_repo_provenance_non_git_returns_none(_no_repo_env, tmp_path):
+    # A directory that is not a git repo and no env contract -> nothing to record.
+    assert resolve_repo_provenance(tmp_path) == (None, None)
 
 
 def test_build_run_paths_uses_canonical_layout(tmp_path):

--- a/tests/cloud/test_train_modal_env.py
+++ b/tests/cloud/test_train_modal_env.py
@@ -1,0 +1,44 @@
+"""Tests for the remote-container env defaults in Trainers/cloud/train_modal.py.
+
+Focus: apply_hf_xet_mitigation, which sets the hf_xet-hang workaround defaults
+on the remote training container while still honoring an explicit override
+forwarded from the local launch env.
+"""
+
+import pytest
+
+# train_modal defines a Modal @app.function, so importing it needs the modal
+# package; skip cleanly where modal is unavailable rather than erroring.
+modal = pytest.importorskip("modal")
+
+from Trainers.cloud.train_modal import (  # noqa: E402
+    HF_XET_MITIGATION,
+    apply_hf_xet_mitigation,
+)
+
+
+def test_mitigation_applied_when_unset():
+    env = {}
+    apply_hf_xet_mitigation(env)
+    assert env["HF_HUB_DISABLE_XET"] == "1"
+    assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "0"
+
+
+def test_mitigation_applied_when_empty_string():
+    # The @app.function secrets dict forwards these as "" when they are absent
+    # from the local env; an empty value must still fall through to the default.
+    env = {"HF_HUB_DISABLE_XET": "", "HF_HUB_ENABLE_HF_TRANSFER": ""}
+    apply_hf_xet_mitigation(env)
+    assert env["HF_HUB_DISABLE_XET"] == "1"
+    assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "0"
+
+
+def test_explicit_local_value_overrides_default():
+    env = {"HF_HUB_DISABLE_XET": "0"}
+    apply_hf_xet_mitigation(env)
+    assert env["HF_HUB_DISABLE_XET"] == "0"  # explicit local override wins
+    assert env["HF_HUB_ENABLE_HF_TRANSFER"] == "0"  # unset -> default
+
+
+def test_mitigation_keys_are_the_two_expected():
+    assert set(HF_XET_MITIGATION) == {"HF_HUB_DISABLE_XET", "HF_HUB_ENABLE_HF_TRANSFER"}


### PR DESCRIPTION
## Cloud artifact contract: unify Modal + RunPod on HF Hub as the system of record

Converges both cloud lanes on one artifact contract with commit-level provenance and failure telemetry. Three coupled changes plus a doc that writes the convention down once.

### 1. Modal provenance fix (the reported gap)

`train_modal.run_training` received `repo_branch`/`repo_commit` as args and checked the repo out at that commit inside the container, but never exposed them to the training subprocess env. The `ModalBackend` set `CLOUD_REPO_BRANCH`/`CLOUD_REPO_COMMIT` only in the **local** `modal run` process env, and Modal forwards only explicitly-declared secrets into the remote container, so the remote `os.environ` never saw them. Result: `manifest.json` recorded `repo_commit=null` and the run dir was stamped `-local`.

`run_training` now bridges its authoritative checkout args (`repo_branch`/`repo_commit`) into that env before spawning the trainer.

### 2. Provider-generic hardening

New `shared.cloud_artifacts.resolve_repo_provenance()`: prefer the env contract, else derive branch/commit from the actual git checkout (`git rev-parse`). `train_sft`, `train_kto`, and `train_dpo` route through it, so any provider whose wrapper omits the env forwarding still records the exact commit that ran. (The hf_jobs command builder also does not export these env vars; this closes the same latent gap for it.) Detached-HEAD (the usual post-`git checkout <sha>` state) leaves branch unset rather than recording the useless label `HEAD`. Unit-tested: env-wins, git-fallback, detached-HEAD, non-git.

### 3. RunPod launcher into the fine-tuning skill

Replaces the SDK/GraphQL `runpod_run_job.py` with the REST-based launcher proven this session (r5/edrt9x crash-loop debugging, 4 dead pods). Root cause of the crash-loop: the unsloth image runs as a **non-root** user with no write access to `/root`, so the old `cd /root` aborted under `set -e` in <1s and RunPod restart-looped the container with uptime pinned at 1-2s — indistinguishable from a boot failure over an API with no logs endpoint. Four fixes now in the canonical script:

- image-agnostic writable workdir (`{ cd ${WORKDIR:-/workspace} 2>/dev/null || cd "$HOME"; }`);
- idempotent `rm -rf repo` before clone (RunPod restarts against the same writable layer);
- a 300s fail-hold on nonzero exit so a failed job is distinguishable from a boot crash-loop;
- `--max-hosts N` bad-host recycling, `--probe-only`, and `dockerEntrypoint` override via REST (the SDK's unescaped GraphQL `dockerArgs` corrupts on quotes and is swallowed by the image ENTRYPOINT).

### 4. The contract, written down

`reference/runpod-jobs.md` rewritten to cover all four gotchas plus the cross-provider artifact contract: every cloud job uploads results + manifest + logs to an HF staging repo under a provider-tagged path (`runs/runpod/<tag>`, `runs/modal/<tag>`) with the producing repo commit recorded; provider-native storage (Modal Volumes, pod disk) is scratch/checkpoint space, not provenance; HF push is the durable record. Documents that real Modal runs should pass `--publish-final-model` (code default stays off — a bare `modal run` should not silently publish). Skill trees synced (`.skills` -> `.agents/skills`, `.claude/skills`); `sync_skill_trees.py --check` clean.

### Verification

- **Modal provenance fix, end to end:** cheapest T4 run (`--gpu T4 --max-steps 1 --timeout-hours 1`, `UNSLOTH_COMPILE_DISABLE=1`, default public 1.2B model + dataset), cloning this branch at its HEAD commit. `manifest.json` now records `repo_branch`/`repo_commit` and the run dir is stamped with the commit sha8, not `-local`. (Evidence in the PR thread.)
- **Launcher:** no paid verification (the in-flight r6 RunPod run is the live end-to-end validation). `python -m py_compile` clean; `--dry-run` renders the correct REST pod spec (entrypoint override, fail-hold, idempotent clone, env keys redacted).
- **Cloud test suite:** 130 passed (1 pre-existing failure unrelated to this change: a broken `huggingface_hub` install in the test env — `HfApi` import — fails identically on `main`).

### Amendment (5483125): hf_xet download hang

Root-caused a cross-provider download stall that killed RunPod r6/r7/r8 and two Modal A0 attempts. A `py-spy` dump of a live hung worker sat in `xet_get` (`huggingface_hub/file_download.py:626`): the hf_xet CAS backend hangs without timeout on multi-GB pulls of the model repo, on BOTH providers. It supersedes hf_transfer (`HF_HUB_ENABLE_HF_TRANSFER=0` was already set in the hung process env and changed nothing). Mitigation validated in flight: `HF_HUB_DISABLE_XET=1` forces the classic resolve-endpoint HTTP path, speed-tested healthy.

- `runpod_run_job.py` now sets `HF_HUB_DISABLE_XET=1` and `HF_HUB_ENABLE_HF_TRANSFER=0` as default pod env, overridable by an explicit `--env` (verified: `--env HF_HUB_DISABLE_XET=0` wins; documented in `--env` help).
- `reference/runpod-jobs.md` gains gotcha #5 (symptom: frozen at unsloth's "Fast downloading is enabled" banner, uptime climbing, zero network RX; diagnosis: `py-spy dump`; fix: the two env vars), noting it applies to ANY provider running `huggingface_hub` with hf_xet — including Modal — with a cross-reference in the artifact-contract section for the Modal lane.
- Skill mirrors synced (`--check` clean).

### Amendment (e3743fa): bake the mitigation into the Modal lane too

Doc-level guidance was not enough — the hang bit the Modal lane twice. `train_modal.run_training` now applies the mitigation in the remote container via a small pure helper `apply_hf_xet_mitigation()` (`HF_HUB_DISABLE_XET=1`, `HF_HUB_ENABLE_HF_TRANSFER=0`), and the `@app.function` secrets dict forwards both so a local override reaches the container. Empty is treated as unset: the secrets dict forwards `""` when the var is absent locally, which would otherwise neither disable xet nor trip a plain `setdefault`, so an explicit local value (e.g. `0`) wins while the empty-string forward falls through to the default — the fix applies even on a bare `modal run`. 4 unit tests (`tests/cloud/test_train_modal_env.py`: unset / empty / explicit-override / key-set), all pass; no paid verification.

**Merge can proceed once the in-flight r6 RunPod run confirms the launcher end to end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD


