### PR TITLE
docs(fine-tuning): harden cloud-lane references (Modal + RunPod gotchas)

### DIFF
--- a/.agents/skills/fine-tuning/SKILL.md
+++ b/.agents/skills/fine-tuning/SKILL.md
@@ -28,6 +28,7 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Evolutionary SFT smoke test | `python tuner.py run-experiment --experiment-spec Trainers/cloud/experiments/<evolutionary-spec>.yaml --yes` |
 | Staggered experiment batch | `python3 scripts/launch_experiment_batch.py Trainers/cloud/experiments/<spec1>.yaml Trainers/cloud/experiments/<spec2>.yaml --yes` |
 | One-shot RunPod wrapper job | `python3 scripts/runpod_run_job.py --run-tag <tag> --repo-url <git-url> --commit <full-sha> --wrapper <repo-relative.sh> --dry-run` |
+| Detached Modal job (survives client exit) | `modal run --detach <app_module>::<function>` |
 | Blind hardware plan | `python tuner.py plan-hardware --experiment-spec Trainers/cloud/experiments/<spec>.yaml` |
 | Analyze finished experiment | `python tuner.py analyze-experiment --experiment-id latest` |
 | Analyze/prune dataset from loss | `python3 scripts/prune_dataset_from_loss.py --dataset-path ... --experiment-id ... --analyze-only` |
@@ -167,6 +168,7 @@ Load the specific reference you need:
 | **Cloud Training** | Provider-native persistence, exact-commit rules, cloud smoke tests | `reference/cloud-training.md` |
 | **Cloud Experiments** | Canonical train→eval launches with `--train-*` overrides | `reference/cloud-experiment-launching.md` |
 | **RunPod Jobs** | One-shot wrapper jobs on RunPod pods (non-training lane) | `reference/runpod-jobs.md` |
+| **Modal Jobs** | Serverless GPU jobs on Modal; detached runs, crash-proof resume pattern | `reference/modal-jobs.md` |
 | **Checkpoint Evaluation** | Best-checkpoint selection via eval | `reference/checkpoint-evaluation.md` |
 | **Experiment Loop** | Autonomous hyperparameter search (LLM + LightGBM) | `reference/experiment-loop.md` |
 | **LoRA Techniques** | LoRA variants, init methods, config recipes | `reference/lora-techniques.md` |

--- a/.agents/skills/fine-tuning/reference/modal-jobs.md
+++ b/.agents/skills/fine-tuning/reference/modal-jobs.md
@@ -1,0 +1,104 @@
+# Modal Jobs Reference
+
+Modal is a serverless-container cloud lane for GPU jobs: define an `@app.function`
+that runs your work inside a pinned image on a Modal-provisioned GPU. Use it when
+a job needs a GPU class or an on-demand elasticity that the RunPod wrapper lane
+(`reference/runpod-jobs.md`) does not give you, or as a second independent
+provider when HF Jobs and RunPod are both flaky.
+
+Like the RunPod lane, this is for arbitrary wrapper work. Cloud TRAINING through
+the tuner still goes via `tuner.py cloud-run` / `cloud-pipeline`; see
+`reference/cloud-training.md`.
+
+---
+
+## Launch: always `--detach` for real jobs
+
+A plain `modal run <app>` ties the app's lifetime to the launching client. When
+that client goes away -- session end, dropped connection, killed babysitter --
+Modal sends the app a cancellation signal and the run dies; the app is created as
+an "ephemeral" app for exactly this reason.
+
+For any job longer than a quick smoke, launch detached so the run outlives the
+client:
+
+```bash
+modal run --detach <app_module>::<function>
+```
+
+Monitor a detached run by its app id:
+
+```bash
+modal app logs <app-id>
+modal app list          # find the app id
+```
+
+---
+
+## Image setup gotchas
+
+- **Clear a hijacking ENTRYPOINT.** Images that ship a process supervisor (the
+  Unsloth images run `supervisord`) will hijack the container and never run your
+  function. Reset the entrypoint when building the image:
+  `image = base_image.entrypoint([])`.
+- **Bake the hf_xet mitigation into the image env.** The `hf_xet` CAS backend
+  hangs without a timeout on multi-GB model pulls (see gotcha #5 in
+  `reference/runpod-jobs.md`); it is a `huggingface_hub` issue, not provider
+  specific, so Modal hits it too. Set both in the image env (or the function's
+  secrets):
+
+  ```python
+  image = image.env({
+      "HF_HUB_DISABLE_XET": "1",
+      "HF_HUB_ENABLE_HF_TRANSFER": "0",
+  })
+  ```
+
+---
+
+## Crash-proof long-run pattern
+
+Modal containers can die mid-run (preemption, OOM, node loss). A long job must be
+able to survive a container death and resume rather than restart from zero. The
+pattern that holds up:
+
+1. **Write outputs to container-local disk first.** Fast, simple; the local disk
+   is scratch and disappears with the container.
+2. **Mirror to a `modal.Volume` on a background daemon thread.** A ~120s loop
+   copies new/changed output files into the mounted Volume and calls
+   `vol.commit()`. Catch and log every exception inside the loop -- a failed
+   mirror tick must NEVER kill the run.
+3. **Restore from the Volume before starting work.** At function entry, copy any
+   prior outputs back from the Volume onto local disk so the native script's own
+   resume logic engages (finds its last checkpoint / done markers and continues).
+4. **Let container death respawn and resume.** Decorate the function with retries
+   so a killed container comes back and re-enters step 3:
+
+   ```python
+   @app.function(retries=modal.Retries(max_retries=3, backoff_coefficient=1.0))
+   ```
+
+5. **Write a DONE marker at the very end.** A sentinel file (mirrored to the
+   Volume) lets a respawn distinguish "finished, nothing to do" from "died
+   partway, resume".
+
+The Volume is checkpoint/scratch space, not the system of record: the final
+result still has to land on the durable store (an HF staging repo) per the
+artifact contract in `reference/runpod-jobs.md`. A long run that produces a real
+model must opt into publishing it to the Hub -- the code default is off so a bare
+`modal run` cannot silently publish.
+
+---
+
+## When to prefer Modal vs RunPod
+
+- **RunPod wrapper lane** (`reference/runpod-jobs.md`): byte-pinned image + git
+  commit on a specific single-GPU class; the launcher owns pod teardown. Good for
+  reproducing a job that must match a known GPU exactly.
+- **Modal**: serverless elasticity, native retries/Volumes for crash recovery,
+  detached runs that survive the client. Good for long or bursty work, or a
+  different GPU class.
+
+Both lanes obey the same staging prerequisite and artifact contract (see
+`reference/runpod-jobs.md`): referenced repos exist on the Hub at pinned
+revisions before launch, and results land on the Hub as the durable record.

--- a/.agents/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.agents/skills/fine-tuning/reference/runpod-jobs.md
@@ -161,6 +161,55 @@ applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
 INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 (set them in the `@app.function` secrets or the container env).
 
+### 6. Pod restarts and re-runs the whole job when the command exits
+
+When the job command exits -- success OR failure -- RunPod RESTARTS the
+container and re-runs the whole job from the top. The launcher's
+`DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
+loop: it removes the pod the moment the poller sees EXITED. So if the launcher
+PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
+babysitter), the pod keeps re-running the job indefinitely and billing the whole
+time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
+until the pod reads null. Hardening option worth considering for long
+unattended jobs: have the wrapper self-terminate at job end by calling the REST
+delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
+so pod teardown does not depend on the launcher surviving.
+
+### 7. A quiet HF log pusher is not a stall
+
+`huggingface_hub` silently SKIPS an upload whose content is byte-identical to
+what is already there, and a periodic log pusher's cadence can look irregular
+for that reason. A log file that stops growing on the Hub is therefore NOT by
+itself a stall signal. Corroborate before intervening: check real container
+runtime via GraphQL `pod.runtime.uptimeInSeconds` (uptime still climbing means
+the container is alive) and compare progress counters over time. Only kill a job
+once uptime arithmetic plus counter movement actually confirm it is wedged.
+
+---
+
+## Adapter and dataset staging prerequisite
+
+Every base model, adapter, and dataset repo a cloud job references must ALREADY
+exist on the Hub at PREP time, pinned to an explicit revision (a commit sha),
+never `main`. Check existence at prep time, not launch time:
+
+```python
+from huggingface_hub import repo_info
+repo_info("<org>/<repo>", repo_type="model", revision="<full-sha>")
+```
+
+A missing repo or a moving `main` pin is a launch-time failure that wastes a
+paid boot; the prep-time check turns it into a free, early error.
+
+When uploading a local LoRA `final_model/` directory as an adapter repo, exclude
+two files:
+
+- the auto-generated `README.md` -- its YAML front matter carries a
+  `base_model:` pointing at a LOCAL path, which fails Hub model-card validation.
+- `training_args.bin`.
+
+Consumers pass the base model explicitly, so neither file is needed downstream.
+
 ---
 
 ## Outputs and the Artifact Contract

--- a/.claude/skills/fine-tuning/SKILL.md
+++ b/.claude/skills/fine-tuning/SKILL.md
@@ -28,6 +28,7 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Evolutionary SFT smoke test | `python tuner.py run-experiment --experiment-spec Trainers/cloud/experiments/<evolutionary-spec>.yaml --yes` |
 | Staggered experiment batch | `python3 scripts/launch_experiment_batch.py Trainers/cloud/experiments/<spec1>.yaml Trainers/cloud/experiments/<spec2>.yaml --yes` |
 | One-shot RunPod wrapper job | `python3 scripts/runpod_run_job.py --run-tag <tag> --repo-url <git-url> --commit <full-sha> --wrapper <repo-relative.sh> --dry-run` |
+| Detached Modal job (survives client exit) | `modal run --detach <app_module>::<function>` |
 | Blind hardware plan | `python tuner.py plan-hardware --experiment-spec Trainers/cloud/experiments/<spec>.yaml` |
 | Analyze finished experiment | `python tuner.py analyze-experiment --experiment-id latest` |
 | Analyze/prune dataset from loss | `python3 scripts/prune_dataset_from_loss.py --dataset-path ... --experiment-id ... --analyze-only` |
@@ -167,6 +168,7 @@ Load the specific reference you need:
 | **Cloud Training** | Provider-native persistence, exact-commit rules, cloud smoke tests | `reference/cloud-training.md` |
 | **Cloud Experiments** | Canonical train→eval launches with `--train-*` overrides | `reference/cloud-experiment-launching.md` |
 | **RunPod Jobs** | One-shot wrapper jobs on RunPod pods (non-training lane) | `reference/runpod-jobs.md` |
+| **Modal Jobs** | Serverless GPU jobs on Modal; detached runs, crash-proof resume pattern | `reference/modal-jobs.md` |
 | **Checkpoint Evaluation** | Best-checkpoint selection via eval | `reference/checkpoint-evaluation.md` |
 | **Experiment Loop** | Autonomous hyperparameter search (LLM + LightGBM) | `reference/experiment-loop.md` |
 | **LoRA Techniques** | LoRA variants, init methods, config recipes | `reference/lora-techniques.md` |

--- a/.claude/skills/fine-tuning/reference/modal-jobs.md
+++ b/.claude/skills/fine-tuning/reference/modal-jobs.md
@@ -1,0 +1,104 @@
+# Modal Jobs Reference
+
+Modal is a serverless-container cloud lane for GPU jobs: define an `@app.function`
+that runs your work inside a pinned image on a Modal-provisioned GPU. Use it when
+a job needs a GPU class or an on-demand elasticity that the RunPod wrapper lane
+(`reference/runpod-jobs.md`) does not give you, or as a second independent
+provider when HF Jobs and RunPod are both flaky.
+
+Like the RunPod lane, this is for arbitrary wrapper work. Cloud TRAINING through
+the tuner still goes via `tuner.py cloud-run` / `cloud-pipeline`; see
+`reference/cloud-training.md`.
+
+---
+
+## Launch: always `--detach` for real jobs
+
+A plain `modal run <app>` ties the app's lifetime to the launching client. When
+that client goes away -- session end, dropped connection, killed babysitter --
+Modal sends the app a cancellation signal and the run dies; the app is created as
+an "ephemeral" app for exactly this reason.
+
+For any job longer than a quick smoke, launch detached so the run outlives the
+client:
+
+```bash
+modal run --detach <app_module>::<function>
+```
+
+Monitor a detached run by its app id:
+
+```bash
+modal app logs <app-id>
+modal app list          # find the app id
+```
+
+---
+
+## Image setup gotchas
+
+- **Clear a hijacking ENTRYPOINT.** Images that ship a process supervisor (the
+  Unsloth images run `supervisord`) will hijack the container and never run your
+  function. Reset the entrypoint when building the image:
+  `image = base_image.entrypoint([])`.
+- **Bake the hf_xet mitigation into the image env.** The `hf_xet` CAS backend
+  hangs without a timeout on multi-GB model pulls (see gotcha #5 in
+  `reference/runpod-jobs.md`); it is a `huggingface_hub` issue, not provider
+  specific, so Modal hits it too. Set both in the image env (or the function's
+  secrets):
+
+  ```python
+  image = image.env({
+      "HF_HUB_DISABLE_XET": "1",
+      "HF_HUB_ENABLE_HF_TRANSFER": "0",
+  })
+  ```
+
+---
+
+## Crash-proof long-run pattern
+
+Modal containers can die mid-run (preemption, OOM, node loss). A long job must be
+able to survive a container death and resume rather than restart from zero. The
+pattern that holds up:
+
+1. **Write outputs to container-local disk first.** Fast, simple; the local disk
+   is scratch and disappears with the container.
+2. **Mirror to a `modal.Volume` on a background daemon thread.** A ~120s loop
+   copies new/changed output files into the mounted Volume and calls
+   `vol.commit()`. Catch and log every exception inside the loop -- a failed
+   mirror tick must NEVER kill the run.
+3. **Restore from the Volume before starting work.** At function entry, copy any
+   prior outputs back from the Volume onto local disk so the native script's own
+   resume logic engages (finds its last checkpoint / done markers and continues).
+4. **Let container death respawn and resume.** Decorate the function with retries
+   so a killed container comes back and re-enters step 3:
+
+   ```python
+   @app.function(retries=modal.Retries(max_retries=3, backoff_coefficient=1.0))
+   ```
+
+5. **Write a DONE marker at the very end.** A sentinel file (mirrored to the
+   Volume) lets a respawn distinguish "finished, nothing to do" from "died
+   partway, resume".
+
+The Volume is checkpoint/scratch space, not the system of record: the final
+result still has to land on the durable store (an HF staging repo) per the
+artifact contract in `reference/runpod-jobs.md`. A long run that produces a real
+model must opt into publishing it to the Hub -- the code default is off so a bare
+`modal run` cannot silently publish.
+
+---
+
+## When to prefer Modal vs RunPod
+
+- **RunPod wrapper lane** (`reference/runpod-jobs.md`): byte-pinned image + git
+  commit on a specific single-GPU class; the launcher owns pod teardown. Good for
+  reproducing a job that must match a known GPU exactly.
+- **Modal**: serverless elasticity, native retries/Volumes for crash recovery,
+  detached runs that survive the client. Good for long or bursty work, or a
+  different GPU class.
+
+Both lanes obey the same staging prerequisite and artifact contract (see
+`reference/runpod-jobs.md`): referenced repos exist on the Hub at pinned
+revisions before launch, and results land on the Hub as the durable record.

--- a/.claude/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.claude/skills/fine-tuning/reference/runpod-jobs.md
@@ -161,6 +161,55 @@ applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
 INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 (set them in the `@app.function` secrets or the container env).
 
+### 6. Pod restarts and re-runs the whole job when the command exits
+
+When the job command exits -- success OR failure -- RunPod RESTARTS the
+container and re-runs the whole job from the top. The launcher's
+`DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
+loop: it removes the pod the moment the poller sees EXITED. So if the launcher
+PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
+babysitter), the pod keeps re-running the job indefinitely and billing the whole
+time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
+until the pod reads null. Hardening option worth considering for long
+unattended jobs: have the wrapper self-terminate at job end by calling the REST
+delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
+so pod teardown does not depend on the launcher surviving.
+
+### 7. A quiet HF log pusher is not a stall
+
+`huggingface_hub` silently SKIPS an upload whose content is byte-identical to
+what is already there, and a periodic log pusher's cadence can look irregular
+for that reason. A log file that stops growing on the Hub is therefore NOT by
+itself a stall signal. Corroborate before intervening: check real container
+runtime via GraphQL `pod.runtime.uptimeInSeconds` (uptime still climbing means
+the container is alive) and compare progress counters over time. Only kill a job
+once uptime arithmetic plus counter movement actually confirm it is wedged.
+
+---
+
+## Adapter and dataset staging prerequisite
+
+Every base model, adapter, and dataset repo a cloud job references must ALREADY
+exist on the Hub at PREP time, pinned to an explicit revision (a commit sha),
+never `main`. Check existence at prep time, not launch time:
+
+```python
+from huggingface_hub import repo_info
+repo_info("<org>/<repo>", repo_type="model", revision="<full-sha>")
+```
+
+A missing repo or a moving `main` pin is a launch-time failure that wastes a
+paid boot; the prep-time check turns it into a free, early error.
+
+When uploading a local LoRA `final_model/` directory as an adapter repo, exclude
+two files:
+
+- the auto-generated `README.md` -- its YAML front matter carries a
+  `base_model:` pointing at a LOCAL path, which fails Hub model-card validation.
+- `training_args.bin`.
+
+Consumers pass the base model explicitly, so neither file is needed downstream.
+
 ---
 
 ## Outputs and the Artifact Contract

--- a/.skills/fine-tuning/SKILL.md
+++ b/.skills/fine-tuning/SKILL.md
@@ -28,6 +28,7 @@ Train language models with SFT, KTO, and GRPO locally or on supported cloud prov
 | Evolutionary SFT smoke test | `python tuner.py run-experiment --experiment-spec Trainers/cloud/experiments/<evolutionary-spec>.yaml --yes` |
 | Staggered experiment batch | `python3 scripts/launch_experiment_batch.py Trainers/cloud/experiments/<spec1>.yaml Trainers/cloud/experiments/<spec2>.yaml --yes` |
 | One-shot RunPod wrapper job | `python3 scripts/runpod_run_job.py --run-tag <tag> --repo-url <git-url> --commit <full-sha> --wrapper <repo-relative.sh> --dry-run` |
+| Detached Modal job (survives client exit) | `modal run --detach <app_module>::<function>` |
 | Blind hardware plan | `python tuner.py plan-hardware --experiment-spec Trainers/cloud/experiments/<spec>.yaml` |
 | Analyze finished experiment | `python tuner.py analyze-experiment --experiment-id latest` |
 | Analyze/prune dataset from loss | `python3 scripts/prune_dataset_from_loss.py --dataset-path ... --experiment-id ... --analyze-only` |
@@ -167,6 +168,7 @@ Load the specific reference you need:
 | **Cloud Training** | Provider-native persistence, exact-commit rules, cloud smoke tests | `reference/cloud-training.md` |
 | **Cloud Experiments** | Canonical train→eval launches with `--train-*` overrides | `reference/cloud-experiment-launching.md` |
 | **RunPod Jobs** | One-shot wrapper jobs on RunPod pods (non-training lane) | `reference/runpod-jobs.md` |
+| **Modal Jobs** | Serverless GPU jobs on Modal; detached runs, crash-proof resume pattern | `reference/modal-jobs.md` |
 | **Checkpoint Evaluation** | Best-checkpoint selection via eval | `reference/checkpoint-evaluation.md` |
 | **Experiment Loop** | Autonomous hyperparameter search (LLM + LightGBM) | `reference/experiment-loop.md` |
 | **LoRA Techniques** | LoRA variants, init methods, config recipes | `reference/lora-techniques.md` |

--- a/.skills/fine-tuning/reference/modal-jobs.md
+++ b/.skills/fine-tuning/reference/modal-jobs.md
@@ -1,0 +1,104 @@
+# Modal Jobs Reference
+
+Modal is a serverless-container cloud lane for GPU jobs: define an `@app.function`
+that runs your work inside a pinned image on a Modal-provisioned GPU. Use it when
+a job needs a GPU class or an on-demand elasticity that the RunPod wrapper lane
+(`reference/runpod-jobs.md`) does not give you, or as a second independent
+provider when HF Jobs and RunPod are both flaky.
+
+Like the RunPod lane, this is for arbitrary wrapper work. Cloud TRAINING through
+the tuner still goes via `tuner.py cloud-run` / `cloud-pipeline`; see
+`reference/cloud-training.md`.
+
+---
+
+## Launch: always `--detach` for real jobs
+
+A plain `modal run <app>` ties the app's lifetime to the launching client. When
+that client goes away -- session end, dropped connection, killed babysitter --
+Modal sends the app a cancellation signal and the run dies; the app is created as
+an "ephemeral" app for exactly this reason.
+
+For any job longer than a quick smoke, launch detached so the run outlives the
+client:
+
+```bash
+modal run --detach <app_module>::<function>
+```
+
+Monitor a detached run by its app id:
+
+```bash
+modal app logs <app-id>
+modal app list          # find the app id
+```
+
+---
+
+## Image setup gotchas
+
+- **Clear a hijacking ENTRYPOINT.** Images that ship a process supervisor (the
+  Unsloth images run `supervisord`) will hijack the container and never run your
+  function. Reset the entrypoint when building the image:
+  `image = base_image.entrypoint([])`.
+- **Bake the hf_xet mitigation into the image env.** The `hf_xet` CAS backend
+  hangs without a timeout on multi-GB model pulls (see gotcha #5 in
+  `reference/runpod-jobs.md`); it is a `huggingface_hub` issue, not provider
+  specific, so Modal hits it too. Set both in the image env (or the function's
+  secrets):
+
+  ```python
+  image = image.env({
+      "HF_HUB_DISABLE_XET": "1",
+      "HF_HUB_ENABLE_HF_TRANSFER": "0",
+  })
+  ```
+
+---
+
+## Crash-proof long-run pattern
+
+Modal containers can die mid-run (preemption, OOM, node loss). A long job must be
+able to survive a container death and resume rather than restart from zero. The
+pattern that holds up:
+
+1. **Write outputs to container-local disk first.** Fast, simple; the local disk
+   is scratch and disappears with the container.
+2. **Mirror to a `modal.Volume` on a background daemon thread.** A ~120s loop
+   copies new/changed output files into the mounted Volume and calls
+   `vol.commit()`. Catch and log every exception inside the loop -- a failed
+   mirror tick must NEVER kill the run.
+3. **Restore from the Volume before starting work.** At function entry, copy any
+   prior outputs back from the Volume onto local disk so the native script's own
+   resume logic engages (finds its last checkpoint / done markers and continues).
+4. **Let container death respawn and resume.** Decorate the function with retries
+   so a killed container comes back and re-enters step 3:
+
+   ```python
+   @app.function(retries=modal.Retries(max_retries=3, backoff_coefficient=1.0))
+   ```
+
+5. **Write a DONE marker at the very end.** A sentinel file (mirrored to the
+   Volume) lets a respawn distinguish "finished, nothing to do" from "died
+   partway, resume".
+
+The Volume is checkpoint/scratch space, not the system of record: the final
+result still has to land on the durable store (an HF staging repo) per the
+artifact contract in `reference/runpod-jobs.md`. A long run that produces a real
+model must opt into publishing it to the Hub -- the code default is off so a bare
+`modal run` cannot silently publish.
+
+---
+
+## When to prefer Modal vs RunPod
+
+- **RunPod wrapper lane** (`reference/runpod-jobs.md`): byte-pinned image + git
+  commit on a specific single-GPU class; the launcher owns pod teardown. Good for
+  reproducing a job that must match a known GPU exactly.
+- **Modal**: serverless elasticity, native retries/Volumes for crash recovery,
+  detached runs that survive the client. Good for long or bursty work, or a
+  different GPU class.
+
+Both lanes obey the same staging prerequisite and artifact contract (see
+`reference/runpod-jobs.md`): referenced repos exist on the Hub at pinned
+revisions before launch, and results land on the Hub as the durable record.

--- a/.skills/fine-tuning/reference/runpod-jobs.md
+++ b/.skills/fine-tuning/reference/runpod-jobs.md
@@ -161,6 +161,55 @@ applies to ANY provider running `huggingface_hub` with `hf_xet` installed,
 INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 (set them in the `@app.function` secrets or the container env).
 
+### 6. Pod restarts and re-runs the whole job when the command exits
+
+When the job command exits -- success OR failure -- RunPod RESTARTS the
+container and re-runs the whole job from the top. The launcher's
+`DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
+loop: it removes the pod the moment the poller sees EXITED. So if the launcher
+PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
+babysitter), the pod keeps re-running the job indefinitely and billing the whole
+time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
+until the pod reads null. Hardening option worth considering for long
+unattended jobs: have the wrapper self-terminate at job end by calling the REST
+delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
+so pod teardown does not depend on the launcher surviving.
+
+### 7. A quiet HF log pusher is not a stall
+
+`huggingface_hub` silently SKIPS an upload whose content is byte-identical to
+what is already there, and a periodic log pusher's cadence can look irregular
+for that reason. A log file that stops growing on the Hub is therefore NOT by
+itself a stall signal. Corroborate before intervening: check real container
+runtime via GraphQL `pod.runtime.uptimeInSeconds` (uptime still climbing means
+the container is alive) and compare progress counters over time. Only kill a job
+once uptime arithmetic plus counter movement actually confirm it is wedged.
+
+---
+
+## Adapter and dataset staging prerequisite
+
+Every base model, adapter, and dataset repo a cloud job references must ALREADY
+exist on the Hub at PREP time, pinned to an explicit revision (a commit sha),
+never `main`. Check existence at prep time, not launch time:
+
+```python
+from huggingface_hub import repo_info
+repo_info("<org>/<repo>", repo_type="model", revision="<full-sha>")
+```
+
+A missing repo or a moving `main` pin is a launch-time failure that wastes a
+paid boot; the prep-time check turns it into a free, early error.
+
+When uploading a local LoRA `final_model/` directory as an adapter repo, exclude
+two files:
+
+- the auto-generated `README.md` -- its YAML front matter carries a
+  `base_model:` pointing at a LOCAL path, which fails Hub model-card validation.
+- `training_args.bin`.
+
+Consumers pass the base model explicitly, so neither file is needed downstream.
+
 ---
 
 ## Outputs and the Artifact Contract


### PR DESCRIPTION
## What

Codifies generic cloud-lane operating lessons into the `fine-tuning` skill's reference files. Documentation only; no source or config changes.

### New: `reference/modal-jobs.md`
- **Detached launch:** plain `modal run` dies with its launching client (ephemeral-app cancellation); always `modal run --detach` for real jobs, monitor via `modal app logs <app-id>`.
- **Image setup:** clear a hijacking supervisord ENTRYPOINT (`image.entrypoint([])`); bake the hf_xet mitigation (`HF_HUB_DISABLE_XET=1` + `HF_HUB_ENABLE_HF_TRANSFER=0`) into the image env.
- **Crash-proof long-run pattern:** container-local write, ~120s `modal.Volume` mirror daemon with `vol.commit()` (exceptions swallowed), restore-from-Volume before start so native resume engages, `@app.function(retries=...)` so container death respawns, DONE marker at end.
- **Provider comparison** and shared staging/artifact-contract cross-links.

### Extended: `reference/runpod-jobs.md`
- **Gotcha 6 - pod restart loop:** the pod re-runs the whole job when the command exits (success or failure); the launcher terminate-in-`finally` is the only break, so a dead launcher orphans a billing pod. Manual `DELETE /v1/pods/<id>` sweep; optional wrapper self-terminate via `RUNPOD_POD_ID`.
- **Gotcha 7 - quiet log pusher is not a stall:** `huggingface_hub` skips content-identical uploads; corroborate with GraphQL `uptimeInSeconds` before intervening.
- **Adapter/dataset staging prerequisite:** referenced repos must exist on the Hub at a pinned revision, checked at prep time; when uploading a local LoRA `final_model/`, exclude the auto-generated `README.md` (local `base_model:` path fails Hub validation) and `training_args.bin`.

### Router
Both references wired into `SKILL.md` (reference index + Quick Reference); mirrors synced via `.skills/scripts/sync_skill_trees.py`.

## Scope
9 files, +465 lines, all under `.skills/fine-tuning/` and its generated mirrors. Nothing project-specific to any downstream consumer; no repo names, run tags, or amendment identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD