### PR TITLE
docs(fine-tuning): spawn() vs remote() and uptime-reset completion detection

### DIFF
--- a/.agents/skills/fine-tuning/reference/modal-jobs.md
+++ b/.agents/skills/fine-tuning/reference/modal-jobs.md
@@ -33,6 +33,32 @@ modal app logs <app-id>
 modal app list          # find the app id
 ```
 
+### `--detach` alone does not survive a graceful client death
+
+`--detach` protects the APP from client disconnect, but not the in-flight call.
+If the client process receives a graceful signal (SIGINT/SIGTERM) while blocked
+on `.remote()`, the unwinding call sends an explicit input-cancel RPC -- the log
+shows "Received a cancellation signal while processing input" -- and the running
+function dies even though the app was detached. Only SIGKILL or a network drop
+leaves the input running.
+
+The robust fix is to remove the blocking client entirely: have the local
+entrypoint use `.spawn()` instead of `.remote()`.
+
+```python
+@app.local_entrypoint()
+def main():
+    call = my_fn.spawn(...)   # returns immediately after scheduling
+    print(f"spawned {call.object_id}")
+```
+
+With `modal run --detach` + `.spawn()`, the client exits on its own within
+seconds and there is never an in-flight input for a dying client to cancel.
+Completion is then observed out-of-band: `modal app logs` plus a DONE marker on
+the checkpoint Volume (see the crash-proof pattern below). Note Modal's caveat
+that detach keeps only the LAST triggered function alive -- one spawn per
+`modal run` invocation.
+
 ---
 
 ## Image setup gotchas

--- a/.agents/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.agents/skills/fine-tuning/reference/runpod-jobs.md
@@ -166,14 +166,25 @@ INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 When the job command exits -- success OR failure -- RunPod RESTARTS the
 container and re-runs the whole job from the top. The launcher's
 `DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
-loop: it removes the pod the moment the poller sees EXITED. So if the launcher
-PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
-babysitter), the pod keeps re-running the job indefinitely and billing the whole
-time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
-until the pod reads null. Hardening option worth considering for long
-unattended jobs: have the wrapper self-terminate at job end by calling the REST
-delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
-so pod teardown does not depend on the launcher surviving.
+loop. So if the launcher PROCESS dies before that `finally` runs (session end,
+`TaskStop`, killed babysitter), the pod keeps re-running the job indefinitely
+and billing the whole time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm
+HTTP 204, then re-query until the pod reads null. Hardening option worth
+considering for long unattended jobs: have the wrapper self-terminate at job
+end by calling the REST delete with its own `RUNPOD_POD_ID` (injected into
+every pod) and the API key, so pod teardown does not depend on the launcher
+surviving.
+
+**Corollary: the pod never reports EXITED, so completion = uptime reset.** A
+poller waiting for status EXITED waits forever; because of the restart loop the
+pod stays RUNNING and `runtime.uptimeInSeconds` snaps back to ~0 each cycle
+(observed 2026-07-05: five completed jobs re-ran every 3-8 minutes until swept,
+with every artifact already uploaded). The reliable completion signal is an
+uptime RESET after boot: the job command ran to the end at least once, and the
+wrapper uploads outputs (or FAILED.txt) before exiting. Distinguish completion
+from a crash-loop by the length of the first run -- a reset after a substantial
+run (>= ~3 min) is completion, a reset after seconds is a crash-loop. On either
+verdict, terminate the pod immediately.
 
 ### 7. A quiet HF log pusher is not a stall
 

--- a/.claude/skills/fine-tuning/reference/modal-jobs.md
+++ b/.claude/skills/fine-tuning/reference/modal-jobs.md
@@ -33,6 +33,32 @@ modal app logs <app-id>
 modal app list          # find the app id
 ```
 
+### `--detach` alone does not survive a graceful client death
+
+`--detach` protects the APP from client disconnect, but not the in-flight call.
+If the client process receives a graceful signal (SIGINT/SIGTERM) while blocked
+on `.remote()`, the unwinding call sends an explicit input-cancel RPC -- the log
+shows "Received a cancellation signal while processing input" -- and the running
+function dies even though the app was detached. Only SIGKILL or a network drop
+leaves the input running.
+
+The robust fix is to remove the blocking client entirely: have the local
+entrypoint use `.spawn()` instead of `.remote()`.
+
+```python
+@app.local_entrypoint()
+def main():
+    call = my_fn.spawn(...)   # returns immediately after scheduling
+    print(f"spawned {call.object_id}")
+```
+
+With `modal run --detach` + `.spawn()`, the client exits on its own within
+seconds and there is never an in-flight input for a dying client to cancel.
+Completion is then observed out-of-band: `modal app logs` plus a DONE marker on
+the checkpoint Volume (see the crash-proof pattern below). Note Modal's caveat
+that detach keeps only the LAST triggered function alive -- one spawn per
+`modal run` invocation.
+
 ---
 
 ## Image setup gotchas

--- a/.claude/skills/fine-tuning/reference/runpod-jobs.md
+++ b/.claude/skills/fine-tuning/reference/runpod-jobs.md
@@ -166,14 +166,25 @@ INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 When the job command exits -- success OR failure -- RunPod RESTARTS the
 container and re-runs the whole job from the top. The launcher's
 `DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
-loop: it removes the pod the moment the poller sees EXITED. So if the launcher
-PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
-babysitter), the pod keeps re-running the job indefinitely and billing the whole
-time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
-until the pod reads null. Hardening option worth considering for long
-unattended jobs: have the wrapper self-terminate at job end by calling the REST
-delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
-so pod teardown does not depend on the launcher surviving.
+loop. So if the launcher PROCESS dies before that `finally` runs (session end,
+`TaskStop`, killed babysitter), the pod keeps re-running the job indefinitely
+and billing the whole time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm
+HTTP 204, then re-query until the pod reads null. Hardening option worth
+considering for long unattended jobs: have the wrapper self-terminate at job
+end by calling the REST delete with its own `RUNPOD_POD_ID` (injected into
+every pod) and the API key, so pod teardown does not depend on the launcher
+surviving.
+
+**Corollary: the pod never reports EXITED, so completion = uptime reset.** A
+poller waiting for status EXITED waits forever; because of the restart loop the
+pod stays RUNNING and `runtime.uptimeInSeconds` snaps back to ~0 each cycle
+(observed 2026-07-05: five completed jobs re-ran every 3-8 minutes until swept,
+with every artifact already uploaded). The reliable completion signal is an
+uptime RESET after boot: the job command ran to the end at least once, and the
+wrapper uploads outputs (or FAILED.txt) before exiting. Distinguish completion
+from a crash-loop by the length of the first run -- a reset after a substantial
+run (>= ~3 min) is completion, a reset after seconds is a crash-loop. On either
+verdict, terminate the pod immediately.
 
 ### 7. A quiet HF log pusher is not a stall
 

--- a/.skills/fine-tuning/reference/modal-jobs.md
+++ b/.skills/fine-tuning/reference/modal-jobs.md
@@ -33,6 +33,32 @@ modal app logs <app-id>
 modal app list          # find the app id
 ```
 
+### `--detach` alone does not survive a graceful client death
+
+`--detach` protects the APP from client disconnect, but not the in-flight call.
+If the client process receives a graceful signal (SIGINT/SIGTERM) while blocked
+on `.remote()`, the unwinding call sends an explicit input-cancel RPC -- the log
+shows "Received a cancellation signal while processing input" -- and the running
+function dies even though the app was detached. Only SIGKILL or a network drop
+leaves the input running.
+
+The robust fix is to remove the blocking client entirely: have the local
+entrypoint use `.spawn()` instead of `.remote()`.
+
+```python
+@app.local_entrypoint()
+def main():
+    call = my_fn.spawn(...)   # returns immediately after scheduling
+    print(f"spawned {call.object_id}")
+```
+
+With `modal run --detach` + `.spawn()`, the client exits on its own within
+seconds and there is never an in-flight input for a dying client to cancel.
+Completion is then observed out-of-band: `modal app logs` plus a DONE marker on
+the checkpoint Volume (see the crash-proof pattern below). Note Modal's caveat
+that detach keeps only the LAST triggered function alive -- one spawn per
+`modal run` invocation.
+
 ---
 
 ## Image setup gotchas

--- a/.skills/fine-tuning/reference/runpod-jobs.md
+++ b/.skills/fine-tuning/reference/runpod-jobs.md
@@ -166,14 +166,25 @@ INCLUDING Modal -- a Modal run pulling the same repo needs the same two env vars
 When the job command exits -- success OR failure -- RunPod RESTARTS the
 container and re-runs the whole job from the top. The launcher's
 `DELETE /pods/{id}` in the `finally` block is the only thing that breaks this
-loop: it removes the pod the moment the poller sees EXITED. So if the launcher
-PROCESS dies before that `finally` runs (session end, `TaskStop`, killed
-babysitter), the pod keeps re-running the job indefinitely and billing the whole
-time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm HTTP 204, then re-query
-until the pod reads null. Hardening option worth considering for long
-unattended jobs: have the wrapper self-terminate at job end by calling the REST
-delete with its own `RUNPOD_POD_ID` (injected into every pod) and the API key,
-so pod teardown does not depend on the launcher surviving.
+loop. So if the launcher PROCESS dies before that `finally` runs (session end,
+`TaskStop`, killed babysitter), the pod keeps re-running the job indefinitely
+and billing the whole time. Sweep it manually: `DELETE /v1/pods/<id>`, confirm
+HTTP 204, then re-query until the pod reads null. Hardening option worth
+considering for long unattended jobs: have the wrapper self-terminate at job
+end by calling the REST delete with its own `RUNPOD_POD_ID` (injected into
+every pod) and the API key, so pod teardown does not depend on the launcher
+surviving.
+
+**Corollary: the pod never reports EXITED, so completion = uptime reset.** A
+poller waiting for status EXITED waits forever; because of the restart loop the
+pod stays RUNNING and `runtime.uptimeInSeconds` snaps back to ~0 each cycle
+(observed 2026-07-05: five completed jobs re-ran every 3-8 minutes until swept,
+with every artifact already uploaded). The reliable completion signal is an
+uptime RESET after boot: the job command ran to the end at least once, and the
+wrapper uploads outputs (or FAILED.txt) before exiting. Distinguish completion
+from a crash-loop by the length of the first run -- a reset after a substantial
+run (>= ~3 min) is completion, a reset after seconds is a crash-loop. On either
+verdict, terminate the pod immediately.
 
 ### 7. A quiet HF log pusher is not a stall
 


### PR DESCRIPTION
Two cloud-lane refinements root-caused on 2026-07-05, both generic to any project using these lanes.

**Modal (modal-jobs.md):** `--detach` protects the app but not the in-flight call. A graceful signal to a client blocked on `.remote()` sends an input-cancel RPC and kills the running function ("Received a cancellation signal while processing input"). New guidance: use `.spawn()` in the local entrypoint so the client exits immediately after scheduling; monitor via app logs + a Volume DONE marker.

**RunPod (runpod-jobs.md):** community pods never reach status EXITED; restart-on-exit keeps them RUNNING with uptime snapping back to ~0 each cycle. A launcher polling for EXITED waits until its own timeout while the pod re-runs the finished job and bills. New guidance: treat an uptime reset after a substantial first run as the completion signal (a reset after seconds is a crash-loop) and terminate on either verdict.

Canonical `.skills/` edited, `.claude/` and `.agents/` mirrors synced byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD