### PR TITLE
Mech-interp cells: generic intervention/extraction/probe/gates modules + recipe-driven CLI verbs

### DIFF
--- a/MechInterp/__init__.py
+++ b/MechInterp/__init__.py
@@ -1,0 +1,28 @@
+"""
+MechInterp: generic mechanistic-interpretation cells for the Synaptic Tuner.
+
+This package gives any researcher a project-agnostic toolkit for reading and
+writing model internals during generation:
+
+  - intervention: forward-hook edits to the residual stream (additive push and
+    erase-and-write setpoint laws), with per-row selection, per-batch-element
+    strength, position policies, and readback instrumentation.
+  - extraction: generation with hidden-state capture at configurable token
+    positions and layer ranges, written to safetensors with a manifest.
+  - probe: linear readout fitting (configurable dim-reduction + classifier),
+    out-of-fold scoring, and direction freezing to JSON.
+  - stats: gate primitives (flip counts, kill-difference bootstrap CI,
+    permutation p-value, AUROC floor) and a declarative gates.yaml evaluator.
+  - grading: a thin interface for pluggable, project-supplied graders.
+
+The public surface is the recipe-driven cell model (see cell.py) plus the
+individual libraries, all reachable from the tuner CLI verbs.
+
+Vocabulary here is deliberately neutral: direction, readout, selection score,
+intervention, cell. Nothing in this package is tied to a particular research
+question.
+"""
+
+__all__ = [
+    "config",
+]

--- a/MechInterp/cell.py
+++ b/MechInterp/cell.py
@@ -1,0 +1,233 @@
+"""
+Steer cell orchestrator: the six-block declarative intervention run.
+
+This module holds the lane-agnostic logic that does not need a GPU or a model:
+row loading, arm resolution (including the seeded permuted control and the
+dose ladder), resume-from-output skipping, config-sha computation, and the smoke
+state file that gates the full arms. The model-facing execution (loading the
+model, registering the hook, generating) is left to the CLI layer so this module
+stays importable and testable on CPU.
+
+Arm resolution turns each ArmConfig into a per-row strength map: row_key -> value.
+A row absent from the map is an untouched no-op. The baseline arm maps every row
+to zero. A permuted control draws a count-matched set of rows uniformly at random
+from a seeded generator, matching the count of the arm it controls, so it probes
+the same dose on a different, randomly selected population.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+from MechInterp.config import ArmConfig, SteerCellConfig
+
+
+def load_jsonl(path: str | Path) -> list[dict]:
+    rows = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def row_key_of(row: dict) -> str:
+    for k in ("row_key", "id", "key"):
+        if k in row:
+            return str(row[k])
+    raise KeyError("row has no row_key / id / key field")
+
+
+def compute_config_sha(config: SteerCellConfig) -> str:
+    """Deterministic sha256 over the canonicalized config (readouts by path)."""
+    payload = config.model_dump(mode="json")
+    canon = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canon.encode("utf-8")).hexdigest()
+
+
+def _active_keys_for_arm(arm: ArmConfig, rows: list[dict]) -> list[str]:
+    """Return the row keys an arm activates, in row order."""
+    keys = [row_key_of(r) for r in rows]
+    if arm.flag_field is not None:
+        return [row_key_of(r) for r in rows if bool(r.get(arm.flag_field))]
+    if arm.score_field is not None:
+        out = []
+        for r in rows:
+            val = r.get(arm.score_field)
+            if val is not None and float(val) >= float(arm.threshold):
+                out.append(row_key_of(r))
+        return out
+    # fixed-strength arm (baseline or uniform dose): every row is active
+    return keys
+
+
+def resolve_arm_strengths(
+    arm: ArmConfig,
+    rows: list[dict],
+    arm_by_name: dict[str, ArmConfig],
+) -> dict[str, float]:
+    """Return a row_key -> strength map for one arm.
+
+    Fixed-strength arms map every row to arm.strength (baseline uses 0).
+    Selection arms map only their active rows to arm.strength.
+    A permuted control draws a seeded, count-matched random subset of all rows,
+    matching the count of the arm it controls, all at arm.strength.
+    """
+    keys_in_order = [row_key_of(r) for r in rows]
+
+    if arm.permuted_control_of is not None:
+        controlled = arm_by_name[arm.permuted_control_of]
+        controlled_keys = _active_keys_for_arm(controlled, rows)
+        n = len(controlled_keys)
+        rng = np.random.default_rng(arm.control_seed)
+        if n > len(keys_in_order):
+            raise ValueError(
+                f"arm {arm.name}: controlled count {n} exceeds row count"
+            )
+        chosen_idx = rng.choice(len(keys_in_order), size=n, replace=False)
+        chosen = sorted(keys_in_order[i] for i in chosen_idx)
+        strength = arm.strength if arm.strength != 0.0 else controlled.strength
+        return {k: float(strength) for k in chosen}
+
+    active = _active_keys_for_arm(arm, rows)
+    return {k: float(arm.strength) for k in active}
+
+
+def resolve_all_arms(config: SteerCellConfig, rows: list[dict]) -> dict[str, dict[str, float]]:
+    """Return {arm_name: {row_key: strength}} for every arm in the config."""
+    arm_by_name = {a.name: a for a in config.arms}
+    return {
+        a.name: resolve_arm_strengths(a, rows, arm_by_name) for a in config.arms
+    }
+
+
+def completed_keys(output_path: str | Path, arm: str) -> set[str]:
+    """Return the set of (arm, row_key) already present in the output JSONL."""
+    path = Path(output_path)
+    if not path.exists():
+        return set()
+    done = set()
+    for rec in load_jsonl(path):
+        if rec.get("arm") == arm:
+            done.add(str(rec.get("row_key")))
+    return done
+
+
+def pending_rows(
+    rows: list[dict],
+    strengths: dict[str, float],
+    arm: str,
+    output_path: str | Path,
+    resume: bool,
+) -> list[dict]:
+    """Rows to run for an arm: those with a strength assignment, minus completed.
+
+    A row with no strength assignment is a no-op and still runs (recorded with
+    strength 0) so the baseline population is complete; selection arms only
+    include their active rows plus all rows at strength 0 for the record. We keep
+    every row in the pass so downstream gate arrays are aligned, tagging each with
+    its resolved strength.
+    """
+    done = completed_keys(output_path, arm) if resume else set()
+    pending = []
+    for r in rows:
+        k = row_key_of(r)
+        if k in done:
+            continue
+        rr = dict(r)
+        rr["_strength"] = float(strengths.get(k, 0.0))
+        rr["_active"] = k in strengths
+        pending.append(rr)
+    return pending
+
+
+# --------------------------------------------------------------------------
+# Smoke state file
+# --------------------------------------------------------------------------
+
+
+def smoke_state_path(output_path: str | Path) -> Path:
+    p = Path(output_path)
+    return p.with_suffix(p.suffix + ".smoke_ok.json")
+
+
+def smoke_passed(output_path: str | Path, config_sha: str) -> bool:
+    """True if a smoke pass for this exact config sha has been recorded."""
+    sp = smoke_state_path(output_path)
+    if not sp.exists():
+        return False
+    try:
+        with open(sp) as f:
+            state = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return False
+    return bool(state.get("passed")) and state.get("config_sha") == config_sha
+
+
+def record_smoke(output_path: str | Path, config_sha: str, readback: dict) -> None:
+    sp = smoke_state_path(output_path)
+    sp.parent.mkdir(parents=True, exist_ok=True)
+    with open(sp, "w") as f:
+        json.dump(
+            {"passed": bool(readback.get("passed")), "config_sha": config_sha, "readback": readback},
+            f,
+            indent=2,
+        )
+
+
+def evaluate_smoke_readback(readback: dict, smoke_cfg) -> dict:
+    """Judge a readback dict against smoke tolerances.
+
+    readback carries commanded, measured, and offtarget_abs_max as produced by
+    the intervention hook. For erase_write, the write check compares measured to
+    commanded; for additive there is no commanded projection, so only the
+    off-target parity check applies.
+    """
+    commanded = [c for c in readback.get("commanded", []) if c is not None]
+    measured = readback.get("measured", [])
+    offtarget = float(readback.get("offtarget_abs_max", 0.0))
+
+    write_ok = True
+    max_err = 0.0
+    if commanded:
+        errs = [abs(m - c) for m, c in zip(measured, commanded)]
+        max_err = max(errs) if errs else 0.0
+        mean_cmd = sum(abs(c) for c in commanded) / len(commanded)
+        tol = smoke_cfg.write_rel_tol * mean_cmd if mean_cmd else smoke_cfg.write_abs_floor
+        write_ok = max_err <= max(tol, smoke_cfg.write_abs_floor)
+
+    parity_ok = offtarget <= smoke_cfg.offtarget_tol
+    return {
+        "passed": bool(write_ok and parity_ok),
+        "write_ok": bool(write_ok),
+        "parity_ok": bool(parity_ok),
+        "max_write_error": max_err,
+        "offtarget_abs_max": offtarget,
+    }
+
+
+def write_manifest(
+    output_path: str | Path,
+    config: SteerCellConfig,
+    config_sha: str,
+    arm_summaries: dict,
+) -> Path:
+    """Write a run manifest next to the output JSONL."""
+    p = Path(output_path)
+    manifest_path = p.with_suffix(p.suffix + ".manifest.json")
+    manifest = {
+        "config_sha": config_sha,
+        "law": config.law.model_dump(mode="json"),
+        "readouts": [r.model_dump(mode="json") for r in config.readouts],
+        "arms": arm_summaries,
+        "surface": config.surface.model_dump(mode="json"),
+    }
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    return manifest_path

--- a/MechInterp/cli.py
+++ b/MechInterp/cli.py
@@ -1,0 +1,402 @@
+"""
+CLI layer for the MechInterp verbs.
+
+This is the model-facing glue that turns a validated recipe into a run: it loads
+the model, resolves arms and readouts, registers the intervention hook, generates
+per row, grades, and writes per-row provenance plus a manifest. The lane-agnostic
+logic (arm resolution, resume, smoke gating, config sha) lives in cell.py and is
+imported here so this layer stays thin.
+
+Verbs:
+  extract     generate + capture hidden states to safetensors + manifest.
+  probe_fit   fit a linear readout from extracted activations and freeze it.
+  steer       run the six-block steer cell (smoke-gated).
+  score_gates evaluate a gates.yaml against a per-row output JSONL.
+
+The steer and extract verbs touch a GPU; they refuse to run without an explicit
+acknowledgement flag so a recipe never surprises a shared machine.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Optional
+
+import numpy as np
+
+from MechInterp import cell as cell_mod
+from MechInterp.config import (
+    SteerCellConfig,
+    ExtractConfig,
+    ProbeFitConfig,
+    load_steer_config,
+    load_extract_config,
+    load_probe_fit_config,
+)
+
+
+# --------------------------------------------------------------------------
+# Model loading (self-contained; handles the transformers 5.x dtype rename)
+# --------------------------------------------------------------------------
+
+
+def _load_model_and_tokenizer(model_name: str, adapter: Optional[str] = None):
+    import torch
+    import transformers
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    major = int(transformers.__version__.split(".")[0])
+    dtype_kwarg = {"dtype": torch.bfloat16} if major >= 5 else {"torch_dtype": torch.bfloat16}
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, device_map="auto", **dtype_kwarg
+    )
+    if adapter:
+        from peft import PeftModel
+
+        model = PeftModel.from_pretrained(model, adapter)
+    model.eval()
+    return model, tokenizer
+
+
+def _require_gpu_ack(ack: bool) -> Optional[int]:
+    if not ack:
+        print(
+            "Refusing to run a GPU verb without --i-know-this-runs-on-gpu. "
+            "This verb loads a model and runs generation."
+        )
+        return 2
+    return None
+
+
+def _load_callable(spec: str) -> Callable:
+    import importlib
+
+    module_path, _, attr = spec.partition(":")
+    return getattr(importlib.import_module(module_path), attr)
+
+
+# --------------------------------------------------------------------------
+# extract
+# --------------------------------------------------------------------------
+
+
+def run_extract(config: ExtractConfig, model_name: str, adapter: Optional[str], gpu_ack: bool) -> int:
+    guard = _require_gpu_ack(gpu_ack)
+    if guard is not None:
+        return guard
+    from MechInterp.extraction import PositionSpec, extract_rows
+
+    rows = cell_mod.load_jsonl(config.rows_path)
+    render_fn = _load_callable(config.render_fn)
+    content_end_fn = _load_callable(config.content_end_fn)
+    model, tokenizer = _load_model_and_tokenizer(model_name, adapter)
+    spec = PositionSpec(
+        families=config.families, every_k=config.every_k, layers=config.layers
+    )
+    manifest = extract_rows(
+        model,
+        tokenizer,
+        rows,
+        render_fn=render_fn,
+        content_end_fn=content_end_fn,
+        spec=spec,
+        out_dir=config.output_dir,
+        max_new_tokens=config.max_new_tokens,
+    )
+    print(
+        f"Extracted {manifest['n_answered']}/{manifest['n_rows']} answered rows "
+        f"to {config.output_dir}"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# probe_fit
+# --------------------------------------------------------------------------
+
+
+def _load_activation_matrix(activations_dir: str, family: str, labels: list[dict]):
+    """Assemble (X, y, layer_keys) from extracted safetensors for one layer sweep.
+
+    Returns a dict {layer_index: X} plus aligned y, using each label row's
+    row_key to find its safetensors file. Only rows with a captured file for the
+    family are included.
+    """
+    from safetensors.torch import load_file
+
+    act_dir = Path(activations_dir)
+    per_layer: dict[int, list] = {}
+    y = []
+    for rec in labels:
+        rk = str(rec.get("row_key", rec.get("id")))
+        safe_key = rk.replace("::", "__").replace("|", "_").replace("/", "_")
+        f = act_dir / f"{safe_key}__{family}.safetensors"
+        if not f.exists():
+            continue
+        tensors = load_file(str(f))
+        for key, t in tensors.items():
+            li = int(key[1:])  # "L23" -> 23
+            per_layer.setdefault(li, []).append(t[0].numpy())  # first captured pos
+        y.append(int(rec["label"]))
+    matrices = {li: np.stack(vals, axis=0) for li, vals in per_layer.items()}
+    return matrices, np.asarray(y, dtype=int)
+
+
+def run_probe_fit(config: ProbeFitConfig) -> int:
+    from MechInterp.probe import sweep_layers, freeze_direction
+
+    labels = cell_mod.load_jsonl(config.labels_path)
+    matrices, y = _load_activation_matrix(
+        config.activations_path, config.position_family, labels
+    )
+    if not matrices:
+        print("No activation matrices found for the requested family.")
+        return 1
+    clf_kwargs = {"solver": config.solver, "tol": config.tol, "C": config.C}
+    sweep = sweep_layers(
+        matrices,
+        y,
+        n_components=config.n_components,
+        n_splits=config.n_splits,
+        seed=config.seed,
+        **clf_kwargs,
+    )
+    best_layer = sweep["best_layer"]
+    record = freeze_direction(
+        matrices[best_layer],
+        y,
+        layer=best_layer,
+        out_path=config.output_direction,
+        n_components=config.n_components,
+        seed=config.seed,
+        normalize=config.normalize,
+        provenance={
+            "activations_path": config.activations_path,
+            "position_family": config.position_family,
+            "auroc_by_layer": sweep["auroc_by_layer"],
+        },
+        **clf_kwargs,
+    )
+    print(
+        f"Froze direction at layer {best_layer} "
+        f"(AUROC {sweep['auroc_by_layer'][best_layer]:.4f}) -> {config.output_direction}"
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------
+# steer (six-block cell)
+# --------------------------------------------------------------------------
+
+
+def _direction_tensor(readout_record: dict):
+    import torch
+
+    return torch.tensor(readout_record["vector_np"], dtype=torch.float32)
+
+
+def _run_one_pass(
+    model,
+    tokenizer,
+    controller,
+    row: dict,
+    generation,
+    generation_mode: str,
+    render_fn: Callable,
+) -> dict:
+    import torch
+
+    prompt = render_fn(row)
+    enc = tokenizer(prompt, return_tensors="pt").to(next(model.parameters()).device)
+    strength = float(row.get("_strength", 0.0))
+    controller.begin_pass(
+        generation_mode if strength != 0.0 else "off",
+        strength,
+        attention_mask=enc["attention_mask"],
+    )
+    gen = model.generate(
+        **enc,
+        max_new_tokens=generation.max_new_tokens,
+        do_sample=generation.do_sample,
+        num_beams=1,
+        return_dict_in_generate=True,
+    )
+    controller.reset()
+    full = gen.sequences[0]
+    prompt_len = enc["input_ids"].shape[1]
+    text = tokenizer.decode(full[prompt_len:], skip_special_tokens=True)
+    return {
+        "row_key": cell_mod.row_key_of(row),
+        "strength": strength,
+        "active": bool(row.get("_active", False)),
+        "answer_text": text,
+        "prompt_len": int(prompt_len),
+    }
+
+
+def run_steer(
+    config: SteerCellConfig,
+    model_name: str,
+    adapter: Optional[str],
+    render_fn_spec: str,
+    gpu_ack: bool,
+    force: bool = False,
+) -> int:
+    guard = _require_gpu_ack(gpu_ack)
+    if guard is not None:
+        return guard
+    import torch
+
+    from MechInterp.intervention import InterventionHook, GenerationInterventionController, get_decoder_layer
+    from MechInterp.probe import load_frozen_direction
+    from MechInterp.grading import load_grader
+
+    config_sha = cell_mod.compute_config_sha(config)
+    if config.surface.expected_config_sha and config.surface.expected_config_sha != config_sha:
+        print(
+            f"Config sha mismatch: expected {config.surface.expected_config_sha}, "
+            f"got {config_sha}. Aborting."
+        )
+        return 3
+
+    rows = cell_mod.load_jsonl(config.surface.rows_path)
+    render_fn = _load_callable(render_fn_spec)
+    readout_by_name = {
+        r.name: load_frozen_direction(r.path) for r in config.readouts
+    }
+    active_readout = readout_by_name[config.law.readout]
+    layer = config.law.layer if config.law.layer is not None else active_readout["layer"]
+
+    model, tokenizer = _load_model_and_tokenizer(model_name, adapter)
+    direction = _direction_tensor(active_readout)
+    sigma = float(active_readout.get("sigma", 1.0))
+    hook = InterventionHook(
+        law=config.law.kind,
+        direction=direction,
+        sigma=sigma,
+        position=config.law.position,
+    )
+    controller = GenerationInterventionController(hook)
+    layer_module = get_decoder_layer(model, layer)
+    handle = layer_module.register_forward_hook(controller)
+
+    grader = load_grader(config.execution.grader) if config.execution.grader else None
+
+    # Smoke gate: run n_rows through the intervention with readback and record.
+    if not force and not cell_mod.smoke_passed(config.execution.output_path, config_sha):
+        readback = _run_smoke(
+            model, tokenizer, config, rows, render_fn, direction, sigma, layer
+        )
+        verdict = cell_mod.evaluate_smoke_readback(readback, config.smoke)
+        readback["passed"] = verdict["passed"]
+        cell_mod.record_smoke(config.execution.output_path, config_sha, {**readback, **verdict})
+        if not verdict["passed"]:
+            handle.remove()
+            print(f"Smoke failed: {verdict}. Full arms not run. Fix or pass --force.")
+            return 4
+        print(f"Smoke passed: {verdict}")
+
+    strengths_by_arm = cell_mod.resolve_all_arms(config, rows)
+    arm_summaries = {}
+    out_path = Path(config.execution.output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_path, "a") as out:
+        for arm in config.arms:
+            strengths = strengths_by_arm[arm.name]
+            pending = cell_mod.pending_rows(
+                rows, strengths, arm.name, out_path, config.execution.resume
+            )
+            arm_summaries[arm.name] = {"n_active": len(strengths), "n_pending": len(pending)}
+            for row in pending:
+                rec = _run_one_pass(
+                    model, tokenizer, controller, row, config.surface.generation,
+                    config.law.generation_mode, render_fn,
+                )
+                rec["arm"] = arm.name
+                if grader is not None:
+                    rec.update(grader(rec))
+                out.write(json.dumps(rec) + "\n")
+
+    handle.remove()
+    cell_mod.write_manifest(out_path, config, config_sha, arm_summaries)
+    print(f"Steer cell complete. Output {out_path}, config_sha {config_sha}")
+    return 0
+
+
+def _run_smoke(model, tokenizer, config, rows, render_fn, direction, sigma, layer):
+    """Run a small forward-only readback over the first smoke rows.
+
+    For each smoke row, a fresh forward hook (in final-position mode with
+    readback on) applies the dose arm's strength at the anchor token, and the
+    realized projection is compared to the commanded value. Inactive rows probe
+    off-target movement. A dedicated hook is registered and removed here so it
+    does not interfere with the generation controller registered by the caller.
+    """
+    import torch
+
+    from MechInterp.intervention import InterventionHook, get_decoder_layer
+
+    smoke_rows = rows[: config.smoke.n_rows]
+    dose_arm = next((a for a in config.arms if a.strength != 0.0), config.arms[0])
+    strengths = cell_mod.resolve_arm_strengths(
+        dose_arm, rows, {a.name: a for a in config.arms}
+    )
+
+    smoke_hook = InterventionHook(
+        law=config.law.kind,
+        direction=direction,
+        sigma=sigma,
+        position="final",
+        measure_readback=True,
+    )
+    layer_module = get_decoder_layer(model, layer)
+    handle = layer_module.register_forward_hook(smoke_hook)
+
+    commanded, measured, offtarget = [], [], []
+    dev = next(model.parameters()).device
+    try:
+        for row in smoke_rows:
+            prompt = render_fn(row)
+            enc = tokenizer(prompt, return_tensors="pt").to(dev)
+            rk = cell_mod.row_key_of(row)
+            g = float(strengths.get(rk, 0.0))
+            smoke_hook.strength = g
+            smoke_hook.attention_mask = enc["attention_mask"]
+            smoke_hook.active = True
+            with torch.no_grad():
+                model(**enc, output_hidden_states=False, use_cache=False)
+            rb = smoke_hook.last_readback or {}
+            if g != 0.0:
+                commanded.extend(rb.get("commanded", []))
+                measured.extend(rb.get("measured", []))
+            offtarget.append(float(rb.get("offtarget_abs_max", 0.0)))
+    finally:
+        handle.remove()
+        smoke_hook.active = False
+
+    return {
+        "commanded": commanded,
+        "measured": measured,
+        "offtarget_abs_max": max(offtarget) if offtarget else 0.0,
+    }
+
+
+# --------------------------------------------------------------------------
+# score_gates
+# --------------------------------------------------------------------------
+
+
+def run_score_gates(gates_config_path: str, rows_path: str, arm_field: str = "arm") -> int:
+    from MechInterp.stats import evaluate_gates
+    from MechInterp.stats.evaluator import load_gates_config
+
+    gates_config = load_gates_config(gates_config_path)
+    rows = cell_mod.load_jsonl(rows_path)
+    report = evaluate_gates(gates_config, rows, arm_field=arm_field)
+    print(json.dumps(report, indent=2, default=str))
+    return 0 if report["overall_pass"] else 5

--- a/MechInterp/config.py
+++ b/MechInterp/config.py
@@ -1,0 +1,220 @@
+"""
+Pydantic v2 configuration models for MechInterp cells.
+
+Loaded from YAML and validated at parse time. The steer cell config is the
+six-block declarative model:
+
+  surface   where the rows come from, the generation contract, the seed, and an
+            optional expected-config sha for reproducibility pinning.
+  readouts  the frozen direction files the cell reads and writes along.
+  law       the intervention law and its shared parameters.
+  arms      named strength overrides, including the baseline no-op, a seeded
+            permuted control, and dose-ladder arms.
+  execution lane-agnostic run controls: output path, resume behavior, grader.
+  smoke     a small pre-run with readback tolerances; the full arms refuse to run
+            until the smoke has recorded a pass, unless explicitly overridden.
+
+The extraction and probe-fit configs are lighter; each drives one verb.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+# --------------------------------------------------------------------------
+# Shared building blocks
+# --------------------------------------------------------------------------
+
+
+class GenerationContract(BaseModel):
+    """How completions are produced. Greedy by default for reproducibility."""
+
+    max_new_tokens: int = 96
+    do_sample: bool = False
+    temperature: float = 1.0
+    top_p: float = 1.0
+    seed: int = 0
+
+
+class ReadoutRef(BaseModel):
+    """A frozen direction file the cell reads or writes along."""
+
+    name: str = Field(..., min_length=1)
+    path: str = Field(..., min_length=1, description="Path to a frozen direction JSON")
+
+
+# --------------------------------------------------------------------------
+# Steer cell
+# --------------------------------------------------------------------------
+
+
+class SurfaceConfig(BaseModel):
+    """Where rows come from and the reproducibility contract."""
+
+    rows_path: str = Field(..., min_length=1, description="JSONL of input rows")
+    generation: GenerationContract = Field(default_factory=GenerationContract)
+    seed: int = 0
+    expected_config_sha: Optional[str] = Field(
+        default=None,
+        description="If set, the run aborts unless the computed config sha matches.",
+    )
+
+
+class LawConfig(BaseModel):
+    """The intervention law and its shared parameters."""
+
+    kind: Literal["additive", "erase_write"] = "additive"
+    readout: str = Field(..., description="Name of the readout to intervene along")
+    layer: Optional[int] = Field(
+        default=None,
+        description="Override the layer; defaults to the readout's frozen layer.",
+    )
+    position: Literal["anchor", "anchor_onward", "final", "answer_window"] = "anchor"
+    generation_mode: Literal["anchor", "gen_stream"] = "anchor"
+
+
+class ArmConfig(BaseModel):
+    """A named arm: which rows are active and at what strength.
+
+    selection choices (exactly one of):
+      strength      apply a fixed strength to every row (baseline uses 0).
+      score_field + threshold + strength   activate rows whose selection score
+                    passes the threshold.
+      flag_field    activate rows whose named boolean field is true.
+      permuted_control  seeded count-matched control of another arm.
+    """
+
+    name: str = Field(..., min_length=1)
+    strength: float = 0.0
+    score_field: Optional[str] = None
+    threshold: Optional[float] = None
+    flag_field: Optional[str] = None
+    permuted_control_of: Optional[str] = None
+    control_seed: Optional[int] = None
+
+    @model_validator(mode="after")
+    def _one_selection(self) -> "ArmConfig":
+        if self.score_field is not None and self.threshold is None:
+            raise ValueError(f"arm {self.name}: score_field requires threshold")
+        if self.permuted_control_of is not None and self.control_seed is None:
+            raise ValueError(
+                f"arm {self.name}: permuted_control_of requires control_seed"
+            )
+        return self
+
+
+class SmokeConfig(BaseModel):
+    """Small pre-run with readback tolerances that gates the full arms."""
+
+    n_rows: int = Field(default=8, ge=1)
+    write_rel_tol: float = Field(
+        default=0.05,
+        description="Allowed relative error on the commanded projection.",
+    )
+    write_abs_floor: float = Field(
+        default=0.5, description="Absolute error floor for the write check."
+    )
+    offtarget_tol: float = Field(
+        default=1e-3, description="Max allowed movement of inactive rows."
+    )
+
+
+class ExecutionConfig(BaseModel):
+    """Lane-agnostic run controls."""
+
+    output_path: str = Field(..., min_length=1, description="Per-row output JSONL")
+    resume: bool = True
+    grader: Optional[str] = Field(
+        default=None, description="Grader spec 'module.path:callable'"
+    )
+
+
+class SteerCellConfig(BaseModel):
+    """The full six-block steer cell."""
+
+    surface: SurfaceConfig
+    readouts: list[ReadoutRef] = Field(..., min_length=1)
+    law: LawConfig
+    arms: list[ArmConfig] = Field(..., min_length=1)
+    execution: ExecutionConfig
+    smoke: SmokeConfig = Field(default_factory=SmokeConfig)
+
+    @model_validator(mode="after")
+    def _readout_exists(self) -> "SteerCellConfig":
+        names = {r.name for r in self.readouts}
+        if self.law.readout not in names:
+            raise ValueError(
+                f"law.readout {self.law.readout!r} is not a declared readout"
+            )
+        for arm in self.arms:
+            if arm.permuted_control_of and arm.permuted_control_of not in {
+                a.name for a in self.arms
+            }:
+                raise ValueError(
+                    f"arm {arm.name}: permuted_control_of references unknown arm "
+                    f"{arm.permuted_control_of!r}"
+                )
+        return self
+
+
+# --------------------------------------------------------------------------
+# Extraction and probe-fit
+# --------------------------------------------------------------------------
+
+
+class ExtractConfig(BaseModel):
+    rows_path: str = Field(..., min_length=1)
+    output_dir: str = Field(..., min_length=1)
+    families: list[str] = Field(default_factory=lambda: ["anchor", "answer_end"])
+    every_k: int = 4
+    layers: Optional[list[int]] = None
+    max_new_tokens: int = 48
+    render_fn: str = Field(
+        ..., description="Callable spec 'module.path:callable' returning a prompt"
+    )
+    content_end_fn: str = Field(
+        ..., description="Callable spec resolving the last content-token index"
+    )
+
+
+class ProbeFitConfig(BaseModel):
+    activations_path: str = Field(
+        ..., min_length=1, description="Directory of extracted safetensors + manifest"
+    )
+    labels_path: str = Field(..., min_length=1, description="JSONL with row_key + label")
+    position_family: str = "anchor"
+    n_components: int = 128
+    n_splits: int = 5
+    seed: int = 0
+    solver: str = "saga"
+    tol: float = 1e-3
+    C: float = 1.0
+    output_direction: str = Field(..., min_length=1, description="Frozen direction JSON")
+    normalize: bool = True
+
+
+# --------------------------------------------------------------------------
+# Loaders
+# --------------------------------------------------------------------------
+
+
+def _load_yaml(path: str | Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def load_steer_config(path: str | Path) -> SteerCellConfig:
+    return SteerCellConfig(**_load_yaml(path))
+
+
+def load_extract_config(path: str | Path) -> ExtractConfig:
+    return ExtractConfig(**_load_yaml(path))
+
+
+def load_probe_fit_config(path: str | Path) -> ProbeFitConfig:
+    return ProbeFitConfig(**_load_yaml(path))

--- a/MechInterp/configs/templates/example_direction.json
+++ b/MechInterp/configs/templates/example_direction.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "mechinterp-direction/v1",
+  "layer": 20,
+  "hidden_dim": 8,
+  "normalized": true,
+  "vector": [0.612372, 0.408248, 0.306186, 0.306186, 0.306186, 0.306186, 0.204124, 0.204124],
+  "raw_norm": 1.0,
+  "intercept": 0.0,
+  "mu": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+  "sigma": 2.0,
+  "calibration": {
+    "positive_mean": 3.0,
+    "positive_std": 1.0,
+    "negative_mean": -1.0,
+    "negative_std": 1.0,
+    "sigma": 2.0,
+    "separation": 4.0,
+    "n_positive": 2,
+    "n_negative": 2
+  },
+  "recipe": {
+    "n_components": 8,
+    "seed": 20240101,
+    "solver": "saga",
+    "tol": 0.001,
+    "C": 1.0
+  },
+  "provenance": {
+    "note": "Illustrative example direction for the steer_cell template. NOT fitted on real data; hand-written so the template runs end to end. Replace with a probe-fit output."
+  }
+}

--- a/MechInterp/configs/templates/example_labels.jsonl
+++ b/MechInterp/configs/templates/example_labels.jsonl
@@ -1,0 +1,4 @@
+{"row_key": "r001", "label": 1}
+{"row_key": "r002", "label": 0}
+{"row_key": "r003", "label": 1}
+{"row_key": "r004", "label": 0}

--- a/MechInterp/configs/templates/example_rows.jsonl
+++ b/MechInterp/configs/templates/example_rows.jsonl
@@ -1,0 +1,4 @@
+{"row_key": "r001", "prompt": "What is the capital of France?", "selection_score": 1.4, "flagged": true}
+{"row_key": "r002", "prompt": "Who wrote the play Hamlet?", "selection_score": 0.3, "flagged": false}
+{"row_key": "r003", "prompt": "What is the boiling point of water at sea level?", "selection_score": 1.1, "flagged": true}
+{"row_key": "r004", "prompt": "Name a prime number between 10 and 20.", "selection_score": 0.8, "flagged": false}

--- a/MechInterp/configs/templates/extract.yaml
+++ b/MechInterp/configs/templates/extract.yaml
@@ -1,0 +1,18 @@
+# MechInterp extraction cell: generate + capture hidden states.
+# Usage:
+#   python tuner.py mechinterp extract \
+#     --mi-config MechInterp/configs/templates/extract.yaml \
+#     --model <base-model> --i-know-this-runs-on-gpu
+#
+# render_fn and content_end_fn are project-supplied callables:
+#   render_fn(row) -> prompt string
+#   content_end_fn(full_ids, prompt_len, tokenizer) -> index of last content token
+
+rows_path: MechInterp/configs/templates/example_rows.jsonl
+output_dir: MechInterp/runs/example/activations
+families: [anchor, answer_end]   # anchor | first_visible | answer_end | every_k
+every_k: 4
+layers: null                     # null = all hidden_states indices, or a list like [20, 22, 24]
+max_new_tokens: 48
+render_fn: my_project.prompts:render
+content_end_fn: my_project.prompts:content_end

--- a/MechInterp/configs/templates/gates.yaml
+++ b/MechInterp/configs/templates/gates.yaml
@@ -1,0 +1,42 @@
+# MechInterp gates: declarative pass/fail policy over a per-row output JSONL.
+# Usage:
+#   python tuner.py mechinterp score-gates \
+#     --gates-config MechInterp/configs/templates/gates.yaml \
+#     --rows-path MechInterp/runs/example/rows.jsonl
+#
+# Rows are grouped by their "arm" field. Each gate names a primitive and the
+# per-row fields it reads. overall_pass is True only if every gate passes.
+
+seed: 20240101
+n_boot: 1000
+n_perm: 1000
+
+gates:
+  # Reach: how many primary rows moved from positive to negative on a predicate.
+  - name: reach
+    primitive: count_flips
+    arm: primary
+    before: baseline_positive
+    after: positive
+    from_state: true
+    to_state: false
+    pass_if: ">= 5"
+
+  # Specificity: primary vs seeded control kill difference, CI must exclude zero.
+  - name: specificity
+    primitive: kill_diff_vs_control
+    primary_arm: primary
+    control_arm: control
+    primary_indicator: killed
+    control_indicator: killed
+    pass_if_diff: ">= 5"
+    pass_if_ci_excludes_zero: true
+
+  # Readout floor: does a score separate the two classes above a lower bound?
+  - name: readout_floor
+    primitive: auroc_floor
+    arm: primary
+    label: label
+    score: readout_score
+    pass_if_auroc: ">= 0.75"
+    pass_if_floor: ">= 0.6"

--- a/MechInterp/configs/templates/probe_fit.yaml
+++ b/MechInterp/configs/templates/probe_fit.yaml
@@ -1,0 +1,20 @@
+# MechInterp probe-fit cell: fit a linear readout and freeze a direction.
+# Usage:
+#   python tuner.py mechinterp probe-fit \
+#     --mi-config MechInterp/configs/templates/probe_fit.yaml
+#
+# activations_path is the output_dir of an extract run; labels_path is a JSONL
+# with row_key + label (0/1). The verb sweeps layers by out-of-fold AUROC and
+# freezes the best layer's direction.
+
+activations_path: MechInterp/runs/example/activations
+labels_path: MechInterp/configs/templates/example_labels.jsonl
+position_family: anchor
+n_components: 128
+n_splits: 5
+seed: 20240101
+solver: saga
+tol: 0.001
+C: 1.0
+normalize: true
+output_direction: MechInterp/runs/example/direction.json

--- a/MechInterp/configs/templates/steer_cell.yaml
+++ b/MechInterp/configs/templates/steer_cell.yaml
@@ -1,0 +1,62 @@
+# MechInterp steer cell: the six-block declarative intervention run.
+# Usage:
+#   python tuner.py mechinterp steer \
+#     --mi-config MechInterp/configs/templates/steer_cell.yaml \
+#     --model <base-model> --render-fn my_project.prompts:render \
+#     --i-know-this-runs-on-gpu
+#
+# The verb runs a smoke pass first and refuses the full arms until the smoke
+# records a pass for this exact config; pass --force-full-run to override.
+
+# 1. surface: where rows come from and the reproducibility contract.
+surface:
+  rows_path: MechInterp/configs/templates/example_rows.jsonl
+  seed: 20240101
+  generation:
+    max_new_tokens: 96
+    do_sample: false
+  # expected_config_sha: <fill after a first run to pin reproducibility>
+
+# 2. readouts: frozen direction files the cell may read/write along.
+readouts:
+  - name: primary_axis
+    path: MechInterp/configs/templates/example_direction.json
+
+# 3. law: the intervention law and its shared parameters.
+law:
+  kind: erase_write          # additive | erase_write
+  readout: primary_axis
+  position: anchor           # anchor | anchor_onward | final | answer_window
+  generation_mode: anchor    # anchor | gen_stream
+
+# 4. arms: named strength overrides.
+arms:
+  - name: baseline           # a no-op population for comparison
+    strength: 0.0
+  - name: primary            # activate rows whose selection score passes threshold
+    strength: 2.0
+    score_field: selection_score
+    threshold: 1.0
+  - name: control            # seeded count-matched permuted control of primary
+    strength: 2.0
+    permuted_control_of: primary
+    control_seed: 20240101
+  - name: dose_low           # dose-ladder arm on flagged rows
+    strength: 1.0
+    flag_field: flagged
+  - name: dose_high
+    strength: 3.0
+    flag_field: flagged
+
+# 5. execution: lane-agnostic run controls.
+execution:
+  output_path: MechInterp/runs/example/rows.jsonl
+  resume: true
+  grader: MechInterp.grading.interface:example_grader
+
+# 6. smoke: readback tolerances that gate the full arms.
+smoke:
+  n_rows: 8
+  write_rel_tol: 0.05
+  write_abs_floor: 0.5
+  offtarget_tol: 0.001

--- a/MechInterp/extraction/__init__.py
+++ b/MechInterp/extraction/__init__.py
@@ -1,0 +1,13 @@
+"""Hidden-state extraction during generation."""
+
+from MechInterp.extraction.capture import (
+    PositionSpec,
+    resolve_capture_positions,
+    extract_rows,
+)
+
+__all__ = [
+    "PositionSpec",
+    "resolve_capture_positions",
+    "extract_rows",
+]

--- a/MechInterp/extraction/capture.py
+++ b/MechInterp/extraction/capture.py
@@ -1,0 +1,208 @@
+"""
+Hidden-state extraction during generation.
+
+For each input row the extractor generates a completion, then runs a single
+clean forward pass over the prompt plus completion (with the KV cache disabled)
+and slices hidden states at configurable token positions across a configurable
+layer range. Captured tensors are written to safetensors, one file per row and
+position family, with a manifest describing the run.
+
+Position families:
+  anchor        the last prompt token (pre-generation read).
+  first_visible the first generated token.
+  answer_end    the last content token of the completion (post-generation read).
+  every_k       every k-th generated token, stacked.
+
+Capturing at anchor and answer_end together gives the dual pre/post read used by
+many readout studies. Positions are resolved against the concatenated
+prompt+completion sequence so the same forward pass serves every family.
+
+The tensors are stored float32 and contiguous so downstream probe fitting reads
+them without surprises. Nothing here assumes a particular tokenizer, chat
+template, or research question; the caller supplies a render function and a
+content-end resolver.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+import torch
+
+
+@dataclass
+class PositionSpec:
+    """Which token positions to capture and over which layers.
+
+    families: subset of {"anchor", "first_visible", "answer_end", "every_k"}.
+    every_k:  stride for the every_k family (ignored otherwise).
+    layers:   explicit list of hidden_states indices, or None for all layers.
+    """
+
+    families: Sequence[str] = field(default_factory=lambda: ["anchor", "answer_end"])
+    every_k: int = 4
+    layers: Optional[Sequence[int]] = None
+
+
+_VALID_FAMILIES = {"anchor", "first_visible", "answer_end", "every_k"}
+
+
+def resolve_capture_positions(
+    spec: PositionSpec,
+    prompt_len: int,
+    content_end: int,
+    seq_total: int,
+) -> dict[str, list[int]]:
+    """Map each requested family to a list of token indices in the full sequence.
+
+    prompt_len is the number of prompt tokens; content_end is the index of the
+    last content token in the concatenated sequence; seq_total is its length.
+    Indices out of range are dropped so a short completion never raises.
+    """
+    for fam in spec.families:
+        if fam not in _VALID_FAMILIES:
+            raise ValueError(f"unknown position family {fam!r}")
+    positions: dict[str, list[int]] = {}
+    if "anchor" in spec.families:
+        positions["anchor"] = [max(0, prompt_len - 1)]
+    if "first_visible" in spec.families:
+        idx = prompt_len
+        positions["first_visible"] = [idx] if idx <= content_end else []
+    if "answer_end" in spec.families:
+        positions["answer_end"] = [content_end] if content_end >= 0 else []
+    if "every_k" in spec.families:
+        k = max(1, spec.every_k)
+        idxs = list(range(prompt_len, content_end + 1, k))
+        positions["every_k"] = [i for i in idxs if 0 <= i < seq_total]
+    return positions
+
+
+def _layer_indices(spec: PositionSpec, n_hidden_states: int) -> list[int]:
+    if spec.layers is None:
+        return list(range(n_hidden_states))
+    return [li for li in spec.layers if 0 <= li < n_hidden_states]
+
+
+def extract_rows(
+    model,
+    tokenizer,
+    rows: list[dict],
+    render_fn: Callable[[dict], str],
+    content_end_fn: Callable[[torch.Tensor, int, "object"], int],
+    spec: PositionSpec,
+    out_dir: str | Path,
+    max_new_tokens: int = 48,
+    row_key_fn: Callable[[dict], str] = lambda r: str(r.get("row_key", r.get("id"))),
+    save_tensors: bool = True,
+    device: Optional[str] = None,
+) -> dict:
+    """Generate + capture hidden states for each row; write safetensors + manifest.
+
+    Args:
+      render_fn(row) -> prompt string (caller applies any chat template).
+      content_end_fn(full_ids, prompt_len, tokenizer) -> index of last content
+        token in the concatenated sequence, or a value < prompt_len if the row
+        produced no usable content.
+      spec: which positions/layers to capture.
+      out_dir: destination directory for <row>__<family>.safetensors + manifest.
+
+    Returns the manifest dict.
+    """
+    from safetensors.torch import save_file
+
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    dev = device or (next(model.parameters()).device if save_tensors else "cpu")
+
+    row_records = []
+    hidden_dim = None
+    n_hidden_states = None
+
+    for row in rows:
+        prompt = render_fn(row)
+        enc = tokenizer(prompt, return_tensors="pt")
+        input_ids = enc["input_ids"].to(dev)
+        prompt_len = input_ids.shape[1]
+
+        gen = model.generate(
+            input_ids=input_ids,
+            attention_mask=torch.ones_like(input_ids),
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            num_beams=1,
+            return_dict_in_generate=True,
+        )
+        full = gen.sequences[0]
+        seq_total = full.shape[0]
+        content_end = int(content_end_fn(full, prompt_len, tokenizer))
+        answered = content_end >= prompt_len
+
+        rec = {
+            "row_key": row_key_fn(row),
+            "prompt_len": int(prompt_len),
+            "seq_total": int(seq_total),
+            "content_end": int(content_end),
+            "answered": bool(answered),
+            "answer_text": tokenizer.decode(
+                full[prompt_len:], skip_special_tokens=True
+            ),
+        }
+
+        if answered and save_tensors:
+            fwd_ids = full[: content_end + 1].unsqueeze(0)
+            attn = torch.ones_like(fwd_ids)
+            with torch.no_grad():
+                out = model(
+                    input_ids=fwd_ids,
+                    attention_mask=attn,
+                    output_hidden_states=True,
+                    use_cache=False,
+                )
+            hs = out.hidden_states
+            n_hidden_states = len(hs)
+            hidden_dim = hs[0].shape[-1]
+            layers = _layer_indices(spec, n_hidden_states)
+            positions = resolve_capture_positions(
+                spec, prompt_len, content_end, content_end + 1
+            )
+            safe_key = rec["row_key"].replace("::", "__").replace("|", "_").replace("/", "_")
+            for family, idxs in positions.items():
+                if not idxs:
+                    continue
+                tensors = {}
+                for li in layers:
+                    cols = [
+                        hs[li][0, p, :].float().cpu().contiguous()
+                        for p in idxs
+                        if p < hs[li].shape[1]
+                    ]
+                    if cols:
+                        tensors[f"L{li}"] = torch.stack(cols, dim=0)
+                if tensors:
+                    save_file(
+                        tensors, str(out_dir / f"{safe_key}__{family}.safetensors")
+                    )
+            rec["captured_families"] = list(positions.keys())
+
+        row_records.append(rec)
+
+    manifest = {
+        "n_rows": len(rows),
+        "n_answered": sum(1 for r in row_records if r["answered"]),
+        "hidden_dim": hidden_dim,
+        "n_hidden_states": n_hidden_states,
+        "position_families": list(spec.families),
+        "every_k": spec.every_k,
+        "layers": spec.layers if spec.layers is not None else "all",
+        "max_new_tokens": max_new_tokens,
+        "persist_dtype": "float32",
+        "decode": "greedy",
+        "rows": row_records,
+    }
+    import json
+
+    with open(out_dir / "manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+    return manifest

--- a/MechInterp/grading/__init__.py
+++ b/MechInterp/grading/__init__.py
@@ -1,0 +1,5 @@
+"""Pluggable grading interface for intervention cells."""
+
+from MechInterp.grading.interface import load_grader, Grader
+
+__all__ = ["load_grader", "Grader"]

--- a/MechInterp/grading/interface.py
+++ b/MechInterp/grading/interface.py
@@ -1,0 +1,55 @@
+"""
+Pluggable grading interface.
+
+The tuner defines only the contract: a grader is a callable that takes one row
+dict (a per-row cell output record) and returns a grade dict, which the cell
+merges back into that row. All grading semantics live in the project-supplied
+callable, so the tuner ships no notion of what a "correct" or "refused" output
+means.
+
+A recipe names a grader as "module.path:callable". load_grader imports and
+returns it. The example grader below is deliberately trivial: it marks a row as
+positive when its generated text is non-empty. Real projects replace it with a
+callable that inspects text, labels, or scores however they choose.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Callable, Protocol
+
+
+class Grader(Protocol):
+    """A grader maps a per-row output dict to a grade dict."""
+
+    def __call__(self, row: dict) -> dict:  # pragma: no cover - protocol
+        ...
+
+
+def load_grader(spec: str) -> Callable[[dict], dict]:
+    """Import a grader from a "module.path:callable" string.
+
+    Raises ValueError if the spec is malformed and the usual import errors if the
+    module or attribute is missing.
+    """
+    if ":" not in spec:
+        raise ValueError(
+            f"grader spec {spec!r} must be 'module.path:callable'"
+        )
+    module_path, _, attr = spec.partition(":")
+    module = importlib.import_module(module_path)
+    grader = getattr(module, attr)
+    if not callable(grader):
+        raise ValueError(f"grader {spec!r} is not callable")
+    return grader
+
+
+def example_grader(row: dict) -> dict:
+    """Trivial example grader: positive when generated text is non-empty.
+
+    Projects replace this with their own callable. The return dict is merged into
+    the row, so keys here become row fields the gate evaluator can reference.
+    """
+    text = str(row.get("answer_text", "")).strip()
+    positive = len(text) > 0
+    return {"positive": positive, "grade": "nonempty" if positive else "empty"}

--- a/MechInterp/intervention/__init__.py
+++ b/MechInterp/intervention/__init__.py
@@ -1,0 +1,27 @@
+"""Intervention engine: forward-hook edits to a decoder layer's output."""
+
+from MechInterp.intervention.hooks import (
+    InterventionHook,
+    GenerationInterventionController,
+    additive_push,
+    erase_and_write,
+    resolve_final_positions,
+    get_decoder_layer,
+)
+from MechInterp.intervention.equivalence import (
+    max_abs_divergence,
+    relative_tolerance,
+    equivalence_ok,
+)
+
+__all__ = [
+    "InterventionHook",
+    "GenerationInterventionController",
+    "additive_push",
+    "erase_and_write",
+    "resolve_final_positions",
+    "get_decoder_layer",
+    "max_abs_divergence",
+    "relative_tolerance",
+    "equivalence_ok",
+]

--- a/MechInterp/intervention/equivalence.py
+++ b/MechInterp/intervention/equivalence.py
@@ -1,0 +1,67 @@
+"""
+Batched-vs-unbatched equivalence self-check for the intervention engine.
+
+When an intervention is applied inside a padded batch, the edited hidden state
+for each row should match the edit computed for that row on its own (unpadded).
+Any divergence should sit at the model's own batched-vs-unbatched numeric floor
+(a few parts in the low thousandths in bf16), which is orders of magnitude below
+any useful intervention magnitude. This check computes that divergence so a
+caller can confirm the batched path did not introduce a position or masking bug.
+
+The comparison is a relative one: the maximum absolute divergence is reported
+alongside a tolerance derived from the compared magnitudes, so the same check
+works whether the hidden states are large or small. Pass/fail is left to the
+caller, which typically requires the divergence to be far below the intervention
+strength.
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def max_abs_divergence(batched_final: torch.Tensor, unbatched_final: torch.Tensor) -> dict:
+    """Compare per-row final-token hidden states from batched vs unbatched runs.
+
+    Both inputs are (n_rows, hidden_dim). Returns the per-row max-absolute
+    divergence and the overall maximum, computed in float32.
+    """
+    if batched_final.shape != unbatched_final.shape:
+        raise ValueError("batched and unbatched tensors must have the same shape")
+    a = batched_final.detach().float()
+    b = unbatched_final.detach().float()
+    diff = (a - b).abs()
+    per_row = diff.amax(dim=1)
+    return {
+        "max_abs": float(diff.max()),
+        "per_row_max_abs": per_row.tolist(),
+        "mean_abs": float(diff.mean()),
+    }
+
+
+def relative_tolerance(
+    reference: torch.Tensor, rel: float = 1e-2, floor: float = 1e-3
+) -> float:
+    """Return a tolerance scaled to the reference magnitude, with a floor.
+
+    The tolerance is rel times the reference's max absolute value, but never
+    below floor, so a near-zero reference still admits the numeric floor.
+    """
+    scale = float(reference.detach().float().abs().max())
+    return max(rel * scale, floor)
+
+
+def equivalence_ok(
+    batched_final: torch.Tensor,
+    unbatched_final: torch.Tensor,
+    rel: float = 1e-2,
+    floor: float = 1e-3,
+) -> dict:
+    """Judge batched-vs-unbatched equivalence against a relative tolerance."""
+    div = max_abs_divergence(batched_final, unbatched_final)
+    tol = relative_tolerance(unbatched_final, rel=rel, floor=floor)
+    return {
+        **div,
+        "tolerance": tol,
+        "passed": div["max_abs"] <= tol,
+    }

--- a/MechInterp/intervention/hooks.py
+++ b/MechInterp/intervention/hooks.py
@@ -1,0 +1,439 @@
+"""
+Forward-hook intervention engine.
+
+Two intervention laws act on a single decoder layer's output hidden state h:
+
+  additive push:      h' = h + alpha * d
+  erase-and-write:    h' = h - (h . c) c + (gain * sigma) c
+
+The additive push shifts the residual stream along a unit direction d by a
+per-row strength alpha. The erase-and-write law removes whatever the current
+row projects onto a unit direction c and writes a commanded coordinate
+gain*sigma in its place, so the post-write projection equals gain*sigma exactly
+regardless of the pre-write value, while the orthogonal complement is untouched.
+
+Both laws support:
+  - per-row selection: only rows the caller marks active are edited; inactive
+    rows pass through unchanged (a strength of zero, or no gain, is a no-op).
+  - per-batch-element strength: alpha / gain may be a scalar or a length-batch
+    vector.
+  - position policies: which token columns are edited (anchor / anchor_onward /
+    final / answer_window).
+  - readback: the caller can measure the realized projection to confirm the
+    commanded edit landed and that off-target rows did not move.
+
+The final-position policy resolves each row's true last non-pad token from the
+attention mask and handles left AND right padding identically. Directions are
+stored float32 and cast to the hidden dtype at edit time; the hidden tensor is
+cloned before any in-place write so no autograd view alias is mutated.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence, Union
+
+import torch
+
+
+# Decoder-layer container attribute paths, tried in order. Covers the common
+# causal-LM and multimodal-wrapper layouts.
+_LAYER_PATHS = (
+    "model.layers",
+    "language_model.model.layers",
+    "model.decoder.layers",
+    "transformer.h",
+    "model.model.layers",
+)
+
+
+def get_decoder_layer(model, layer_idx: int):
+    """Return the decoder block at layer_idx for common architectures.
+
+    Raises AttributeError if no known layer container is found.
+    """
+    for path in _LAYER_PATHS:
+        obj = model
+        ok = True
+        for part in path.split("."):
+            if not hasattr(obj, part):
+                ok = False
+                break
+            obj = getattr(obj, part)
+        if ok:
+            return obj[layer_idx]
+    raise AttributeError(
+        "Could not locate decoder layers on this model; tried: "
+        + ", ".join(_LAYER_PATHS)
+    )
+
+
+def resolve_final_positions(
+    batch: int,
+    seq_len: int,
+    attention_mask: Optional[torch.Tensor] = None,
+    explicit: Optional[torch.Tensor] = None,
+    device: Optional[torch.device] = None,
+) -> torch.Tensor:
+    """Return a length-batch LongTensor of each row's target column.
+
+    Priority: explicit positions (wrapped modulo seq_len) > derived from the
+    attention mask > fallback to seq_len - 1 for every row.
+
+    The mask derivation flips the mask and takes the argmax so it finds the last
+    real token under both left and right padding. A fully padded row clamps to
+    seq_len - 1.
+    """
+    dev = device if device is not None else (
+        attention_mask.device if attention_mask is not None else torch.device("cpu")
+    )
+    if explicit is not None:
+        pos = explicit.to(dev).long() % seq_len
+        return pos
+    if attention_mask is not None:
+        mask = attention_mask.to(dev)
+        flipped = torch.flip(mask, dims=[1])
+        last_from_right = torch.argmax(flipped.long(), dim=1)
+        pos = (seq_len - 1) - last_from_right
+        pos = pos.clamp(min=0, max=seq_len - 1).long()
+        return pos
+    return torch.full((batch,), seq_len - 1, dtype=torch.long, device=dev)
+
+
+def _strength_per_row(
+    strength: Union[float, Sequence[float], torch.Tensor],
+    batch: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Broadcast a scalar / length-1 / length-batch strength to length batch."""
+    if isinstance(strength, torch.Tensor):
+        t = strength.to(device=device, dtype=dtype)
+        if t.ndim == 0:
+            return t.expand(batch).clone()
+        if t.numel() == 1:
+            return t.reshape(1).expand(batch).clone()
+        if t.numel() != batch:
+            raise ValueError(
+                f"strength length {t.numel()} does not match batch {batch}"
+            )
+        return t
+    if isinstance(strength, (list, tuple)):
+        if len(strength) == 1:
+            return torch.full((batch,), float(strength[0]), device=device, dtype=dtype)
+        if len(strength) != batch:
+            raise ValueError(
+                f"strength length {len(strength)} does not match batch {batch}"
+            )
+        return torch.tensor(list(strength), device=device, dtype=dtype)
+    return torch.full((batch,), float(strength), device=device, dtype=dtype)
+
+
+def _column_mask_for_policy(
+    policy: str,
+    seq_len: int,
+    anchor_index: Optional[int],
+    window_start: Optional[int],
+    device: torch.device,
+) -> torch.Tensor:
+    """Return a length-seq_len bool column mask for shared-position policies.
+
+    Used by anchor and anchor_onward; final is per-row and handled separately.
+    """
+    mask = torch.zeros(seq_len, dtype=torch.bool, device=device)
+    if policy == "anchor":
+        idx = anchor_index if anchor_index is not None else seq_len - 1
+        idx = idx % seq_len
+        mask[idx] = True
+    elif policy == "anchor_onward":
+        start = (window_start or 0) % seq_len if window_start else 0
+        mask[start:] = True
+    elif policy == "answer_window":
+        start = (window_start or 0)
+        start = max(0, min(start, seq_len))
+        mask[start:] = True
+    else:
+        raise ValueError(f"policy {policy!r} is not a shared-column policy")
+    return mask
+
+
+def additive_push(
+    hidden: torch.Tensor,
+    direction: torch.Tensor,
+    alpha_row: torch.Tensor,
+    columns: torch.Tensor,
+    per_row: bool,
+    final_positions: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Apply h += alpha * d in place on a cloned hidden tensor.
+
+    direction is unit-norm, cast to hidden dtype/device by the caller.
+    columns is a bool column mask (shared policies) unless per_row is True, in
+    which case final_positions gives each row's single target column.
+    Rows with alpha == 0 are skipped.
+    """
+    batch, seq_len, hidden_dim = hidden.shape
+    d = direction
+    if per_row:
+        active = alpha_row != 0.0
+        if active.any():
+            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+            cols = final_positions[rows]
+            delta = alpha_row[rows].unsqueeze(1) * d.unsqueeze(0)
+            hidden[rows, cols, :] = hidden[rows, cols, :] + delta
+        return hidden
+    # add is (batch, 1, hidden_dim): per-row strength times the direction. It
+    # broadcasts over the masked columns, so the number of selected columns need
+    # not be baked into its shape.
+    add = alpha_row.view(batch, 1, 1) * d.view(1, 1, hidden_dim)
+    hidden[:, columns, :] = hidden[:, columns, :] + add
+    return hidden
+
+
+def erase_and_write(
+    hidden: torch.Tensor,
+    direction: torch.Tensor,
+    setpoint_row: torch.Tensor,
+    gain_row: torch.Tensor,
+    columns: torch.Tensor,
+    per_row: bool,
+    final_positions: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Apply h' = h - (h.c)c + setpoint*c in place on a cloned hidden tensor.
+
+    direction (c) is unit-norm, cast to hidden dtype/device by the caller.
+    setpoint_row[b] is the commanded projection for row b (typically gain*sigma).
+    gain_row selects which rows are active (gain == 0 or NaN is a no-op row).
+    """
+    batch, seq_len, hidden_dim = hidden.shape
+    c = direction
+    active = (gain_row != 0.0) & (~torch.isnan(gain_row))
+    if per_row:
+        if active.any():
+            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+            cols = final_positions[rows]
+            sub = hidden[rows, cols, :]
+            proj = (sub @ c).unsqueeze(-1)
+            sp = setpoint_row[rows].unsqueeze(-1)
+            hidden[rows, cols, :] = sub - proj * c + sp * c
+        return hidden
+    # shared columns: apply the law per active row across the masked columns
+    if not active.any():
+        return hidden
+    rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+    col_idx = torch.nonzero(columns, as_tuple=False).squeeze(1)
+    for b in rows.tolist():
+        sub = hidden[b, col_idx, :]
+        proj = (sub @ c).unsqueeze(-1)
+        hidden[b, col_idx, :] = sub - proj * c + setpoint_row[b] * c
+    return hidden
+
+
+class InterventionHook:
+    """A forward hook that edits a decoder layer's output hidden state.
+
+    law:      "additive" or "erase_write".
+    direction: unit-norm 1-D tensor (float32); cast to hidden dtype at call time.
+    strength:  alpha (additive) or gain (erase_write); scalar or length-batch.
+    sigma:     scale for erase_write (setpoint = gain * sigma); ignored otherwise.
+    position:  "anchor" | "anchor_onward" | "final" | "answer_window".
+    attention_mask / final_positions / anchor_index / window_start: position inputs.
+
+    When measure_readback is True the realized projection of each edited row onto
+    the direction is stored in last_readback after each call.
+    """
+
+    def __init__(
+        self,
+        law: str,
+        direction: torch.Tensor,
+        strength: Union[float, Sequence[float], torch.Tensor] = 1.0,
+        sigma: float = 1.0,
+        position: str = "final",
+        attention_mask: Optional[torch.Tensor] = None,
+        final_positions: Optional[torch.Tensor] = None,
+        anchor_index: Optional[int] = None,
+        window_start: Optional[int] = None,
+        measure_readback: bool = False,
+    ):
+        if law not in ("additive", "erase_write"):
+            raise ValueError(f"unknown law {law!r}")
+        if position not in ("anchor", "anchor_onward", "final", "answer_window"):
+            raise ValueError(f"unknown position policy {position!r}")
+        self.law = law
+        self.direction = direction.detach().to(torch.float32)
+        self.strength = strength
+        self.sigma = float(sigma)
+        self.position = position
+        self.attention_mask = attention_mask
+        self.final_positions = final_positions
+        self.anchor_index = anchor_index
+        self.window_start = window_start
+        self.measure_readback = measure_readback
+        self.active = True
+        self.last_readback: Optional[dict] = None
+
+    def __call__(self, module, inputs, output):
+        if not self.active:
+            return output
+
+        is_tuple = isinstance(output, tuple)
+        hidden = output[0] if is_tuple else output
+        rest = output[1:] if is_tuple else ()
+
+        hidden = hidden.clone()
+        batch, seq_len, hidden_dim = hidden.shape
+        device, dtype = hidden.device, hidden.dtype
+        c = self.direction.to(device=device, dtype=dtype)
+
+        per_row = self.position == "final"
+        if per_row:
+            final_pos = resolve_final_positions(
+                batch,
+                seq_len,
+                attention_mask=self.attention_mask,
+                explicit=self.final_positions,
+                device=device,
+            )
+            columns = torch.zeros(seq_len, dtype=torch.bool, device=device)
+        else:
+            final_pos = None
+            columns = _column_mask_for_policy(
+                self.position, seq_len, self.anchor_index, self.window_start, device
+            )
+
+        if self.law == "additive":
+            alpha = _strength_per_row(self.strength, batch, device, dtype)
+            hidden = additive_push(hidden, c, alpha, columns, per_row, final_pos)
+            gain_for_readback = alpha
+        else:
+            gain = _strength_per_row(self.strength, batch, device, dtype)
+            setpoint = gain * self.sigma
+            hidden = erase_and_write(
+                hidden, c, setpoint, gain, columns, per_row, final_pos
+            )
+            gain_for_readback = gain
+
+        if self.measure_readback:
+            self.last_readback = self._readback(
+                hidden, c, per_row, final_pos, columns, gain_for_readback
+            )
+
+        if is_tuple:
+            return (hidden,) + rest
+        return hidden
+
+    def _readback(self, hidden, c, per_row, final_pos, columns, gain_row) -> dict:
+        """Measure realized projection onto the direction (float64) after the edit.
+
+        Returns per-row commanded vs measured projection for active rows and the
+        mean absolute projection of inactive rows (off-target parity check).
+        """
+        c64 = c.detach().to(torch.float64)
+        batch = hidden.shape[0]
+        if per_row:
+            active = gain_row != 0.0
+            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+            inactive = torch.nonzero(~active, as_tuple=False).squeeze(1)
+            measured = []
+            for b in rows.tolist():
+                col = int(final_pos[b].item())
+                measured.append(
+                    float(hidden[b, col, :].to(torch.float64) @ c64)
+                )
+            off = []
+            for b in inactive.tolist():
+                col = int(final_pos[b].item())
+                off.append(abs(float(hidden[b, col, :].to(torch.float64) @ c64)))
+        else:
+            col_idx = torch.nonzero(columns, as_tuple=False).squeeze(1)
+            first_col = int(col_idx[0].item()) if col_idx.numel() else hidden.shape[1] - 1
+            active = gain_row != 0.0
+            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+            inactive = torch.nonzero(~active, as_tuple=False).squeeze(1)
+            measured = [
+                float(hidden[b, first_col, :].to(torch.float64) @ c64)
+                for b in rows.tolist()
+            ]
+            off = [
+                abs(float(hidden[b, first_col, :].to(torch.float64) @ c64))
+                for b in inactive.tolist()
+            ]
+        if self.law == "erase_write":
+            commanded = [float(gain_row[b].item()) * self.sigma for b in rows.tolist()]
+        else:
+            commanded = [None for _ in rows.tolist()]
+        return {
+            "law": self.law,
+            "active_rows": rows.tolist(),
+            "commanded": commanded,
+            "measured": measured,
+            "offtarget_abs_mean": (sum(off) / len(off)) if off else 0.0,
+            "offtarget_abs_max": max(off) if off else 0.0,
+        }
+
+
+class GenerationInterventionController:
+    """Wraps an InterventionHook to gate prefill vs decode during generate().
+
+    Register the controller (not the raw hook) once. Call begin_pass(...) before
+    each generate() to set the active law/strength for that pass, and reset()
+    after. The controller counts forward calls to distinguish the prefill step
+    (seq_len == prompt_len, call 1) from single-token decode steps (seq_len == 1).
+
+    modes:
+      "anchor"     edit only the prefill step at the last prompt token; the edit
+                   propagates through the KV cache to all later tokens.
+      "gen_stream" skip prefill, then edit every decode step at its single token.
+      "off"        pass through.
+    """
+
+    def __init__(self, hook: InterventionHook):
+        self.hook = hook
+        self.mode = "off"
+        self._nth_call = 0
+
+    def begin_pass(
+        self,
+        mode: str,
+        strength: Union[float, Sequence[float], torch.Tensor],
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> None:
+        if mode not in ("anchor", "gen_stream", "off"):
+            raise ValueError(f"unknown mode {mode!r}")
+        self.mode = mode
+        self.hook.strength = strength
+        self.hook.attention_mask = attention_mask
+        self._nth_call = 0
+
+    def reset(self) -> None:
+        self.mode = "off"
+        self._nth_call = 0
+        self.hook.active = False
+
+    def __call__(self, module, inputs, output):
+        self._nth_call += 1
+        if self.mode == "off":
+            self.hook.active = False
+            return output
+
+        is_tuple = isinstance(output, tuple)
+        hidden = output[0] if is_tuple else output
+        seq_len = hidden.shape[1]
+        is_prefill = self._nth_call == 1 and seq_len > 1
+
+        if self.mode == "anchor":
+            if is_prefill:
+                self.hook.active = True
+                self.hook.position = "anchor"
+                self.hook.anchor_index = None
+            else:
+                self.hook.active = False
+        elif self.mode == "gen_stream":
+            if is_prefill:
+                self.hook.active = False
+            else:
+                self.hook.active = True
+                self.hook.position = "anchor_onward"
+                self.hook.window_start = 0
+
+        return self.hook(module, inputs, output)

--- a/MechInterp/probe/__init__.py
+++ b/MechInterp/probe/__init__.py
@@ -1,0 +1,19 @@
+"""Linear readout fitting and direction freezing."""
+
+from MechInterp.probe.fit import (
+    fit_pca,
+    cv_auroc,
+    fit_full_probe,
+    sweep_layers,
+    freeze_direction,
+    load_frozen_direction,
+)
+
+__all__ = [
+    "fit_pca",
+    "cv_auroc",
+    "fit_full_probe",
+    "sweep_layers",
+    "freeze_direction",
+    "load_frozen_direction",
+]

--- a/MechInterp/probe/fit.py
+++ b/MechInterp/probe/fit.py
@@ -1,0 +1,230 @@
+"""
+Linear readout fitting with dimensionality reduction and out-of-fold scoring.
+
+The default recipe reduces each activation matrix with a randomized PCA (fit
+label-agnostically) and fits a saga logistic classifier on the reduced features.
+Out-of-fold scoring fits PCA and classifier on each training fold only, so the
+reported AUROC never sees test-fold information. The full-data direction folds
+the classifier weight back through the PCA basis into the original activation
+space, giving a single vector that scores raw (mean-centered) activations by a
+dot product.
+
+The frozen direction is a self-describing JSON: the layer it was read at, the
+vector, the mean offset, the class-projection statistics, and provenance fields.
+This is the object the intervention engine and downstream readers consume.
+
+The recipe is configurable: n_components, classifier solver / tol / C, and the
+number of CV folds are all parameters, with PCA-k randomized + saga as defaults
+because they fit high-dimensional activations quickly without a per-feature
+scaler.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+from sklearn.decomposition import PCA
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import StratifiedKFold
+
+
+def fit_pca(X: np.ndarray, n_components: int = 128, seed: int = 0):
+    """Fit a randomized PCA on mean-centered X (label-agnostic).
+
+    Returns (mu, components) where mu is the feature mean and components has
+    shape (k, d). k is clipped to min(n_components, n_samples - 1, n_features).
+    """
+    mu = X.mean(axis=0)
+    k = min(n_components, X.shape[0] - 1, X.shape[1])
+    pca = PCA(n_components=k, svd_solver="randomized", random_state=seed)
+    pca.fit(X - mu)
+    return mu, pca.components_
+
+
+def _make_classifier(solver: str, tol: float, C: float, max_iter: int):
+    return LogisticRegression(solver=solver, tol=tol, C=C, max_iter=max_iter)
+
+
+def cv_auroc(
+    X: np.ndarray,
+    y: np.ndarray,
+    n_components: int = 128,
+    n_splits: int = 5,
+    seed: int = 0,
+    solver: str = "saga",
+    tol: float = 1e-3,
+    C: float = 1.0,
+    max_iter: int = 2000,
+):
+    """Out-of-fold AUROC. PCA and classifier are fit on train folds only.
+
+    Returns (mean_auc, std_auc, oof_scores) where oof_scores are the held-out
+    decision-function values for every row.
+    """
+    X = np.asarray(X, dtype=np.float64)
+    y = np.asarray(y, dtype=int)
+    skf = StratifiedKFold(n_splits=n_splits, shuffle=True, random_state=seed)
+    oof = np.full(len(y), np.nan, dtype=np.float64)
+    aucs = []
+    for tr, te in skf.split(X, y):
+        mu = X[tr].mean(axis=0)
+        k = min(n_components, len(tr) - 1, X.shape[1])
+        pca = PCA(n_components=k, svd_solver="randomized", random_state=seed)
+        ztr = pca.fit_transform(X[tr] - mu)
+        zte = pca.transform(X[te] - mu)
+        clf = _make_classifier(solver, tol, C, max_iter)
+        clf.fit(ztr, y[tr])
+        s = clf.decision_function(zte)
+        oof[te] = s
+        aucs.append(roc_auc_score(y[te], s))
+    assert not np.isnan(oof).any(), "every row must receive an out-of-fold score"
+    return float(np.mean(aucs)), float(np.std(aucs)), oof
+
+
+def fit_full_probe(
+    X: np.ndarray,
+    y: np.ndarray,
+    n_components: int = 128,
+    seed: int = 0,
+    solver: str = "saga",
+    tol: float = 1e-3,
+    C: float = 1.0,
+    max_iter: int = 2000,
+) -> dict:
+    """Fit on all data and fold the classifier weight into activation space.
+
+    Returns a dict with:
+      coef      (d,) direction in raw activation space
+      intercept scalar such that score(x) = x @ coef + intercept
+      mu        feature mean used for centering
+    The score is equivalent to the reduced-space logistic decision function.
+    """
+    X = np.asarray(X, dtype=np.float64)
+    y = np.asarray(y, dtype=int)
+    mu, comps = fit_pca(X, n_components=n_components, seed=seed)
+    Z = (X - mu) @ comps.T
+    clf = _make_classifier(solver, tol, C, max_iter)
+    clf.fit(Z, y)
+    coef_full = comps.T @ clf.coef_.ravel()
+    intercept = float(clf.intercept_[0]) - float(mu @ coef_full)
+    return {"coef": coef_full, "intercept": intercept, "mu": mu}
+
+
+def score_full_probe(fp: dict, X: np.ndarray) -> np.ndarray:
+    """Score rows with a full-data probe: X @ coef + intercept."""
+    X = np.asarray(X, dtype=np.float64)
+    return X @ fp["coef"] + fp["intercept"]
+
+
+def sweep_layers(
+    layer_activations: dict[int, np.ndarray],
+    y: np.ndarray,
+    n_components: int = 128,
+    n_splits: int = 5,
+    seed: int = 0,
+    **clf_kwargs,
+) -> dict:
+    """Run cv_auroc per layer and return {layer: mean_auc} plus the best layer.
+
+    layer_activations maps a layer index to its (n_rows, d) activation matrix.
+    """
+    surface = {}
+    for layer, X in layer_activations.items():
+        mean_auc, _, _ = cv_auroc(
+            X, y, n_components=n_components, n_splits=n_splits, seed=seed, **clf_kwargs
+        )
+        surface[layer] = mean_auc
+    best_layer = max(surface, key=surface.get)
+    return {"auroc_by_layer": surface, "best_layer": best_layer}
+
+
+def _projection_stats(scores: np.ndarray, y: np.ndarray) -> dict:
+    """Class-conditioned statistics of the readout score."""
+    pos = scores[y == 1]
+    neg = scores[y == 0]
+    return {
+        "positive_mean": float(pos.mean()) if len(pos) else float("nan"),
+        "positive_std": float(pos.std()) if len(pos) else float("nan"),
+        "negative_mean": float(neg.mean()) if len(neg) else float("nan"),
+        "negative_std": float(neg.std()) if len(neg) else float("nan"),
+        "sigma": float(scores.std()),
+        "separation": (
+            float(pos.mean() - neg.mean()) if len(pos) and len(neg) else float("nan")
+        ),
+        "n_positive": int((y == 1).sum()),
+        "n_negative": int((y == 0).sum()),
+    }
+
+
+def freeze_direction(
+    X: np.ndarray,
+    y: np.ndarray,
+    layer: int,
+    out_path: str | Path,
+    n_components: int = 128,
+    seed: int = 0,
+    normalize: bool = True,
+    provenance: Optional[dict] = None,
+    **clf_kwargs,
+) -> dict:
+    """Fit a full-data direction at one layer and write it to a JSON file.
+
+    The written JSON carries the unit (or raw) direction vector, the mean offset,
+    the setpoint scale sigma (the score standard deviation), the class-projection
+    statistics, the layer, and any provenance the caller supplies. This is the
+    object the intervention engine loads to steer or to erase-and-write.
+    """
+    fp = fit_full_probe(X, y, n_components=n_components, seed=seed, **clf_kwargs)
+    scores = score_full_probe(fp, X)
+    stats = _projection_stats(scores, np.asarray(y, dtype=int))
+
+    coef = np.asarray(fp["coef"], dtype=np.float64)
+    norm = float(np.linalg.norm(coef))
+    if normalize:
+        if norm < 1e-12:
+            raise ValueError("direction has near-zero norm; cannot normalize")
+        vector = (coef / norm).astype(np.float64)
+    else:
+        vector = coef
+
+    record = {
+        "schema_version": "mechinterp-direction/v1",
+        "layer": int(layer),
+        "hidden_dim": int(coef.shape[0]),
+        "normalized": bool(normalize),
+        "vector": vector.tolist(),
+        "raw_norm": norm,
+        "intercept": float(fp["intercept"]),
+        "mu": np.asarray(fp["mu"], dtype=np.float64).tolist(),
+        "sigma": stats["sigma"],
+        "calibration": stats,
+        "recipe": {
+            "n_components": int(n_components),
+            "seed": int(seed),
+            **{k: v for k, v in clf_kwargs.items()},
+        },
+        "provenance": provenance or {},
+    }
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w") as f:
+        json.dump(record, f, indent=2)
+    return record
+
+
+def load_frozen_direction(path: str | Path) -> dict:
+    """Load a frozen direction JSON, returning the record with numpy arrays.
+
+    The returned dict adds a "vector_np" (float32) and "mu_np" (float64) for
+    direct use by the intervention engine.
+    """
+    with open(path) as f:
+        record = json.load(f)
+    record["vector_np"] = np.asarray(record["vector"], dtype=np.float32)
+    if "mu" in record and record["mu"] is not None:
+        record["mu_np"] = np.asarray(record["mu"], dtype=np.float64)
+    return record

--- a/MechInterp/stats/__init__.py
+++ b/MechInterp/stats/__init__.py
@@ -1,0 +1,19 @@
+"""Statistics and gate primitives for intervention cells."""
+
+from MechInterp.stats.gates import (
+    count_flips,
+    kill_diff_vs_control,
+    permutation_p,
+    auroc_floor,
+    hanley_mcneil_se,
+)
+from MechInterp.stats.evaluator import evaluate_gates
+
+__all__ = [
+    "count_flips",
+    "kill_diff_vs_control",
+    "permutation_p",
+    "auroc_floor",
+    "hanley_mcneil_se",
+    "evaluate_gates",
+]

--- a/MechInterp/stats/evaluator.py
+++ b/MechInterp/stats/evaluator.py
@@ -1,0 +1,195 @@
+"""
+Declarative gate evaluator over per-row cell provenance.
+
+A gates.yaml declares a list of named gates. Each gate names a primitive and its
+inputs, expressed as filters over the per-row output the cell produced. The
+evaluator loads the rows, computes each gate's inputs, calls the primitive, and
+reports pass/fail against the declared threshold. This keeps the pass/fail policy
+in configuration rather than code.
+
+gates.yaml shape:
+
+    seed: 20240101            # default seed for primitives that take one
+    n_boot: 1000
+    gates:
+      - name: reach
+        primitive: count_flips
+        arm: primary          # which arm's rows to read
+        before: baseline_positive   # per-row boolean field before intervention
+        after: positive             # per-row boolean field after intervention
+        from_state: true
+        to_state: false
+        pass_if: ">= 5"       # comparison against the primitive's scalar result
+
+      - name: specificity
+        primitive: kill_diff_vs_control
+        primary_indicator: killed     # 0/1 per-row field in the primary arm
+        control_indicator: killed     # 0/1 per-row field in the control arm
+        pass_if_diff: ">= 5"
+        pass_if_ci_excludes_zero: true
+
+Rows are grouped by an "arm" field so a single per-row JSONL holds every arm.
+"""
+
+from __future__ import annotations
+
+import operator
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+import yaml
+
+from MechInterp.stats.gates import (
+    count_flips,
+    kill_diff_vs_control,
+    permutation_p,
+    auroc_floor,
+)
+
+_OPS: dict[str, Callable[[Any, Any], bool]] = {
+    ">=": operator.ge,
+    "<=": operator.le,
+    ">": operator.gt,
+    "<": operator.lt,
+    "==": operator.eq,
+    "!=": operator.ne,
+}
+
+
+def _parse_comparison(expr: str):
+    """Parse a "OP value" comparison string into (op_fn, threshold)."""
+    parts = expr.strip().split()
+    if len(parts) != 2 or parts[0] not in _OPS:
+        raise ValueError(f"bad comparison expression {expr!r} (want 'OP value')")
+    return _OPS[parts[0]], float(parts[1])
+
+
+def _rows_for_arm(rows: list[dict], arm: Optional[str], arm_field: str) -> list[dict]:
+    if arm is None:
+        return rows
+    return [r for r in rows if r.get(arm_field) == arm]
+
+
+def _field(row: dict, name: str):
+    if name not in row:
+        raise KeyError(f"row is missing field {name!r}")
+    return row[name]
+
+
+def _eval_count_flips(gate: dict, rows: list[dict], arm_field: str) -> dict:
+    arm_rows = _rows_for_arm(rows, gate.get("arm"), arm_field)
+    before = [bool(_field(r, gate["before"])) for r in arm_rows]
+    after = [bool(_field(r, gate["after"])) for r in arm_rows]
+    result = count_flips(
+        before,
+        after,
+        from_state=bool(gate.get("from_state", True)),
+        to_state=bool(gate.get("to_state", False)),
+    )
+    op_fn, thr = _parse_comparison(gate["pass_if"])
+    return {"value": result, "passed": bool(op_fn(result, thr)), "threshold": thr}
+
+
+def _eval_kill_diff(
+    gate: dict, rows: list[dict], arm_field: str, seed: int, n_boot: int
+) -> dict:
+    primary_rows = _rows_for_arm(rows, gate.get("primary_arm", "primary"), arm_field)
+    control_rows = _rows_for_arm(rows, gate.get("control_arm", "control"), arm_field)
+    p_ind = [int(_field(r, gate["primary_indicator"])) for r in primary_rows]
+    c_ind = [int(_field(r, gate["control_indicator"])) for r in control_rows]
+    # align lengths over a shared universe by padding the shorter with zeros
+    n = max(len(p_ind), len(c_ind))
+    p_ind += [0] * (n - len(p_ind))
+    c_ind += [0] * (n - len(c_ind))
+    stats = kill_diff_vs_control(
+        p_ind, c_ind, seed=gate.get("seed", seed), n_boot=gate.get("n_boot", n_boot)
+    )
+    passed = True
+    if "pass_if_diff" in gate:
+        op_fn, thr = _parse_comparison(gate["pass_if_diff"])
+        passed = passed and bool(op_fn(stats["diff"], thr))
+    if gate.get("pass_if_ci_excludes_zero", False):
+        passed = passed and (stats["ci_lo"] > 0)
+    return {"value": stats, "passed": passed}
+
+
+def _eval_permutation_p(
+    gate: dict, rows: list[dict], arm_field: str, seed: int, n_perm: int
+) -> dict:
+    pool_rows = _rows_for_arm(rows, gate.get("pool_arm"), arm_field)
+    primary_rows = _rows_for_arm(rows, gate.get("primary_arm", "primary"), arm_field)
+    pool_ind = [bool(_field(r, gate["indicator"])) for r in pool_rows]
+    primary_positive = sum(bool(_field(r, gate["indicator"])) for r in primary_rows)
+    stats = permutation_p(
+        primary_positive,
+        pool_ind,
+        n_primary=len(primary_rows),
+        seed=gate.get("seed", seed),
+        n_perm=gate.get("n_perm", n_perm),
+    )
+    op_fn, thr = _parse_comparison(gate.get("pass_if_p", "<= 0.05"))
+    return {"value": stats, "passed": bool(op_fn(stats["p_value"], thr))}
+
+
+def _eval_auroc_floor(
+    gate: dict, rows: list[dict], arm_field: str, seed: int, n_boot: int
+) -> dict:
+    arm_rows = _rows_for_arm(rows, gate.get("arm"), arm_field)
+    labels = [int(_field(r, gate["label"])) for r in arm_rows]
+    scores = [float(_field(r, gate["score"])) for r in arm_rows]
+    stats = auroc_floor(
+        labels, scores, seed=gate.get("seed", seed), n_boot=gate.get("n_boot", n_boot)
+    )
+    passed = True
+    if "pass_if_auroc" in gate:
+        op_fn, thr = _parse_comparison(gate["pass_if_auroc"])
+        passed = passed and bool(op_fn(stats["auroc"], thr))
+    if "pass_if_floor" in gate:
+        op_fn, thr = _parse_comparison(gate["pass_if_floor"])
+        passed = passed and bool(op_fn(stats["ci_lb"], thr))
+    return {"value": stats, "passed": passed}
+
+
+_DISPATCH = {
+    "count_flips": _eval_count_flips,
+    "kill_diff_vs_control": _eval_kill_diff,
+    "permutation_p": _eval_permutation_p,
+    "auroc_floor": _eval_auroc_floor,
+}
+
+
+def evaluate_gates(
+    gates_config: dict,
+    rows: list[dict],
+    arm_field: str = "arm",
+) -> dict:
+    """Evaluate every gate in gates_config against per-row output.
+
+    Returns a report dict with one entry per gate plus an overall_pass flag that
+    is True only if every gate passed.
+    """
+    seed = int(gates_config.get("seed", 0))
+    n_boot = int(gates_config.get("n_boot", 1000))
+    n_perm = int(gates_config.get("n_perm", 1000))
+    results = {}
+    all_pass = True
+    for gate in gates_config.get("gates", []):
+        name = gate["name"]
+        primitive = gate["primitive"]
+        if primitive not in _DISPATCH:
+            raise ValueError(f"unknown gate primitive {primitive!r}")
+        if primitive == "count_flips":
+            res = _DISPATCH[primitive](gate, rows, arm_field)
+        elif primitive == "permutation_p":
+            res = _DISPATCH[primitive](gate, rows, arm_field, seed, n_perm)
+        else:
+            res = _DISPATCH[primitive](gate, rows, arm_field, seed, n_boot)
+        res["primitive"] = primitive
+        results[name] = res
+        all_pass = all_pass and res["passed"]
+    return {"gates": results, "overall_pass": all_pass}
+
+
+def load_gates_config(path: str | Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)

--- a/MechInterp/stats/gates.py
+++ b/MechInterp/stats/gates.py
@@ -1,0 +1,224 @@
+"""
+Gate primitives for intervention-cell adjudication.
+
+All randomness is seeded explicitly so a gate verdict is reproducible from its
+recorded seed. The primitives operate on per-row outcome arrays so they are
+agnostic to the project's notion of what a "flip" or a "kill" means; the caller
+supplies boolean/integer indicators.
+
+  count_flips(before, after, target)
+      Count rows whose outcome moved from one state to another. Generic enough
+      to express "monitored predicate cleared" (True -> False on a target
+      predicate) or "collateral" (a desirable state that flipped).
+
+  kill_diff_vs_control(primary_ind, control_ind, seed, n_boot)
+      Difference in per-row positive-indicator counts between a primary arm and
+      a count-matched control, with a seeded row-bootstrap confidence interval.
+
+  permutation_p(primary_ind, pool_ind, n_primary, seed, n_perm)
+      One-sided permutation p-value: how often a random count-matched draw from
+      the pool matches or beats the primary arm's positive count.
+
+  auroc_floor(labels, scores, seed, n_boot)
+      Point AUROC plus a Hanley-McNeil analytic standard error and a seeded
+      bootstrap lower confidence bound.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+import numpy as np
+
+
+def _as_bool_array(x: Sequence) -> np.ndarray:
+    return np.asarray(x, dtype=bool)
+
+
+def count_flips(
+    before: Sequence,
+    after: Sequence,
+    from_state: bool = True,
+    to_state: bool = False,
+) -> int:
+    """Count rows that moved from from_state to to_state.
+
+    before / after are aligned per-row boolean indicators of some predicate.
+    The default (True -> False) counts rows where the predicate held before the
+    intervention and no longer holds after it.
+    """
+    b = _as_bool_array(before)
+    a = _as_bool_array(after)
+    if b.shape != a.shape:
+        raise ValueError("before and after must be the same length")
+    moved = (b == from_state) & (a == to_state)
+    return int(moved.sum())
+
+
+def kill_diff_vs_control(
+    primary_ind: Sequence,
+    control_ind: Sequence,
+    seed: int,
+    n_boot: int = 1000,
+    ci: float = 0.95,
+) -> dict:
+    """Positive-count difference between primary and control, with bootstrap CI.
+
+    primary_ind and control_ind are aligned per-row 0/1 indicators over the same
+    universe of rows (for example, 1 if the row was a positive event in that arm,
+    else 0). The point estimate is sum(primary) - sum(control). The CI resamples
+    row indices with replacement n_boot times and reports the diff-of-sums
+    percentile interval.
+
+    Passing convention is left to the caller (typically diff >= floor AND the CI
+    lower bound excludes zero).
+    """
+    p = np.asarray(primary_ind, dtype=float)
+    c = np.asarray(control_ind, dtype=float)
+    if p.shape != c.shape:
+        raise ValueError("primary_ind and control_ind must be the same length")
+    n = p.shape[0]
+    diff = float(p.sum() - c.sum())
+    per_row = p - c
+    rng = np.random.default_rng(seed)
+    boots = np.empty(n_boot, dtype=float)
+    for b in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        boots[b] = per_row[idx].sum()
+    lo_q = (1.0 - ci) / 2.0
+    hi_q = 1.0 - lo_q
+    ci_lo = float(np.quantile(boots, lo_q))
+    ci_hi = float(np.quantile(boots, hi_q))
+    return {
+        "diff": diff,
+        "ci_lo": ci_lo,
+        "ci_hi": ci_hi,
+        "ci_level": ci,
+        "n_boot": n_boot,
+        "seed": seed,
+        "n_rows": n,
+    }
+
+
+def permutation_p(
+    primary_positive: int,
+    pool_ind: Sequence,
+    n_primary: int,
+    seed: int,
+    n_perm: int = 1000,
+) -> dict:
+    """One-sided permutation p-value for a count-matched positive count.
+
+    Draw n_primary rows without replacement from the pool n_perm times and count
+    how often the drawn positive count is >= the observed primary positive count.
+    The p-value is (hits + 1) / (n_perm + 1) (add-one smoothing so it is never 0).
+    """
+    pool = _as_bool_array(pool_ind)
+    if n_primary > pool.shape[0]:
+        raise ValueError("n_primary exceeds pool size")
+    rng = np.random.default_rng(seed)
+    idx_all = np.arange(pool.shape[0])
+    hits = 0
+    null_counts = np.empty(n_perm, dtype=int)
+    for k in range(n_perm):
+        draw = rng.choice(idx_all, size=n_primary, replace=False)
+        cnt = int(pool[draw].sum())
+        null_counts[k] = cnt
+        if cnt >= primary_positive:
+            hits += 1
+    p_value = (hits + 1) / (n_perm + 1)
+    return {
+        "primary_positive": int(primary_positive),
+        "null_mean": float(null_counts.mean()),
+        "null_max": int(null_counts.max()),
+        "p_value": float(p_value),
+        "n_perm": n_perm,
+        "seed": seed,
+    }
+
+
+def _roc_auc(labels: np.ndarray, scores: np.ndarray) -> float:
+    """Rank-based AUROC with tie handling (Mann-Whitney U / (n_pos*n_neg))."""
+    pos = labels == 1
+    neg = labels == 0
+    n_pos = int(pos.sum())
+    n_neg = int(neg.sum())
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+    order = np.argsort(scores, kind="mergesort")
+    ranks = np.empty(len(scores), dtype=float)
+    s_sorted = scores[order]
+    # average ranks for ties
+    i = 0
+    r = 1
+    while i < len(s_sorted):
+        j = i
+        while j + 1 < len(s_sorted) and s_sorted[j + 1] == s_sorted[i]:
+            j += 1
+        avg_rank = (r + (r + (j - i))) / 2.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg_rank
+        r += (j - i) + 1
+        i = j + 1
+    sum_ranks_pos = ranks[pos].sum()
+    u = sum_ranks_pos - n_pos * (n_pos + 1) / 2.0
+    return float(u / (n_pos * n_neg))
+
+
+def hanley_mcneil_se(auc: float, n_pos: int, n_neg: int) -> float:
+    """Hanley-McNeil analytic standard error of an AUROC estimate."""
+    if n_pos == 0 or n_neg == 0:
+        return float("nan")
+    q1 = auc / (2.0 - auc)
+    q2 = 2.0 * auc * auc / (1.0 + auc)
+    num = (
+        auc * (1.0 - auc)
+        + (n_pos - 1) * (q1 - auc * auc)
+        + (n_neg - 1) * (q2 - auc * auc)
+    )
+    return float(np.sqrt(num / (n_pos * n_neg)))
+
+
+def auroc_floor(
+    labels: Sequence,
+    scores: Sequence,
+    seed: int,
+    n_boot: int = 1000,
+    ci: float = 0.95,
+) -> dict:
+    """AUROC point estimate with Hanley-McNeil SE and a seeded bootstrap CI-LB.
+
+    labels are 0/1; scores are real-valued (higher = more positive). Returns the
+    point AUROC, the analytic SE, and the bootstrap lower confidence bound (the
+    "floor"), which the caller compares against a threshold.
+    """
+    y = np.asarray(labels, dtype=int)
+    s = np.asarray(scores, dtype=float)
+    if y.shape != s.shape:
+        raise ValueError("labels and scores must be the same length")
+    auc = _roc_auc(y, s)
+    n_pos = int((y == 1).sum())
+    n_neg = int((y == 0).sum())
+    se = hanley_mcneil_se(auc, n_pos, n_neg)
+    rng = np.random.default_rng(seed)
+    n = y.shape[0]
+    boots = []
+    for b in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        yb, sb = y[idx], s[idx]
+        if (yb == 1).sum() == 0 or (yb == 0).sum() == 0:
+            continue
+        boots.append(_roc_auc(yb, sb))
+    lo_q = (1.0 - ci) / 2.0
+    ci_lb = float(np.quantile(boots, lo_q)) if boots else float("nan")
+    return {
+        "auroc": auc,
+        "hanley_mcneil_se": se,
+        "ci_lb": ci_lb,
+        "ci_level": ci,
+        "n_pos": n_pos,
+        "n_neg": n_neg,
+        "n_boot": n_boot,
+        "n_boot_used": len(boots),
+        "seed": seed,
+    }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -56,6 +56,10 @@ Then read based on your hardware:
 - `WORKSPACE_KEY_FILES_REFERENCE.md` - Important files reference
 - `WORKSPACE_DOCUMENTATION_INDEX.md` - All documentation
 
+### For Mechanistic-Interpretation Cells
+
+- `MECH_INTERP_CELLS.md` - Project-agnostic intervention/extraction/probe/gates toolkit driven by recipe YAML (`mechinterp` CLI verbs)
+
 ## ☁️ Cloud Training Documentation (Nebius AI) 🆕
 
 ### Why Use Nebius?

--- a/docs/MECH_INTERP_CELLS.md
+++ b/docs/MECH_INTERP_CELLS.md
@@ -1,0 +1,148 @@
+# Mechanistic-Interpretation Cells
+
+The `MechInterp` package gives any researcher a project-agnostic toolkit for
+reading and writing a model's internal activations during generation, driven by
+declarative recipe YAML through the tuner CLI. Nothing in it is tied to a
+particular research question, dataset, model, or grading rule: the vocabulary is
+neutral (direction, readout, selection score, intervention, cell) and every
+project-specific decision is a plug-in point named in a recipe.
+
+A **cell** is one intervention or readout experiment described entirely by a
+recipe. There are four verbs:
+
+| Verb | What it does |
+|------|--------------|
+| `mechinterp extract` | generate over rows and capture hidden states to safetensors + a manifest |
+| `mechinterp probe-fit` | fit a linear readout from extracted activations and freeze a direction JSON |
+| `mechinterp steer` | run the six-block declarative intervention cell (smoke-gated) |
+| `mechinterp score-gates` | evaluate a declarative `gates.yaml` against a per-row output JSONL |
+
+Example recipes ship under `MechInterp/configs/templates/`. List them with
+`python tuner.py mechinterp list-configs`.
+
+## The six-block cell model
+
+A `steer` cell recipe has six blocks. The first five are in the cell YAML; gates
+are scored separately so a run and its adjudication stay independent.
+
+1. **surface**: where rows come from (`rows_path`, a JSONL), the generation
+   contract (`max_new_tokens`, greedy vs sampled, `seed`), and an optional
+   `expected_config_sha` that pins reproducibility: if set, the run aborts unless
+   the recipe still hashes to it.
+2. **readouts**: the frozen direction files the cell reads or writes along. Each
+   is a self-describing JSON produced by `probe-fit` (layer, vector, mean offset,
+   `sigma` scale, class-projection calibration).
+3. **law**: the intervention law and its shared parameters:
+   - `additive` push: `h' = h + strength * d` shifts the residual stream along a
+     unit direction.
+   - `erase_write` setpoint: `h' = h - (h . d) d + (strength * sigma) d` removes
+     the current projection onto `d` and writes a commanded coordinate, so the
+     post-write projection equals `strength * sigma` exactly while the orthogonal
+     complement is untouched.
+   - `position` selects which token columns are edited: `anchor` (the last prompt
+     token), `anchor_onward`, `final` (each row's true last non-pad token), or
+     `answer_window`.
+   - `generation_mode` selects how the edit propagates during `generate()`:
+     `anchor` (edit only the prefill anchor; the KV cache carries it forward) or
+     `gen_stream` (edit every decode step).
+4. **arms**: named strength overrides that select which rows are active:
+   - fixed `strength` (a baseline uses `0.0`);
+   - `score_field` + `threshold` (activate rows whose selection score passes);
+   - `flag_field` (activate rows whose named boolean is true);
+   - `permuted_control_of` + `control_seed` (a seeded, count-matched random draw
+     that probes the same dose on a different population).
+5. **execution**: lane-agnostic run controls: `output_path` for the per-row
+   JSONL, `resume` (skip rows already present), and an optional `grader`.
+6. **smoke**: readback tolerances. Before the full arms run, a small smoke pass
+   applies the intervention to `n_rows` and reads back the realized projection.
+   `steer` refuses the full arms until a smoke passes for this exact config sha;
+   `--force-full-run` overrides.
+
+## Plug-in points (kept out of the toolkit)
+
+The tuner ships no notion of what a prompt looks like, what "correct" means, or
+which rows matter. Each is a callable or a file named in the recipe:
+
+- **render function** (`--render-fn module.path:callable`): maps a row dict to a
+  prompt string. You apply any chat template here.
+- **content-end resolver** (`content_end_fn` in an extract recipe): maps
+  `(full_ids, prompt_len, tokenizer)` to the index of the last content token.
+- **grader** (`grader: module.path:callable` in a steer recipe): maps a per-row
+  output dict to a grade dict, merged back into the row so gates can read it.
+  `MechInterp.grading.interface:example_grader` is a trivial default (positive
+  when the generated text is non-empty); replace it with your own.
+- **row pool** (`rows_path`): any JSONL your project produces, one object per row
+  with a `row_key` (or `id`/`key`).
+
+## Typical workflow
+
+```bash
+# 1. Extract hidden states over a labeled row pool.
+python tuner.py mechinterp extract \
+  --mi-config my_project/extract.yaml \
+  --model <base-model> \
+  --render-fn my_project.prompts:render \
+  --i-know-this-runs-on-gpu
+
+# 2. Fit a linear readout and freeze a direction (CPU; sweeps layers by OOF AUROC).
+python tuner.py mechinterp probe-fit --mi-config my_project/probe_fit.yaml
+
+# 3. Run the intervention cell (smoke first, then the full arms).
+python tuner.py mechinterp steer \
+  --mi-config my_project/steer_cell.yaml \
+  --model <base-model> \
+  --render-fn my_project.prompts:render \
+  --i-know-this-runs-on-gpu
+
+# 4. Adjudicate with declarative gates.
+python tuner.py mechinterp score-gates \
+  --gates-config my_project/gates.yaml \
+  --rows-path MechInterp/runs/example/rows.jsonl
+```
+
+`extract` and `steer` load a model and use a GPU, so they refuse to run without
+`--i-know-this-runs-on-gpu`. `probe-fit` and `score-gates` are CPU-only.
+
+## Gates
+
+A `gates.yaml` declares named gates over the per-row output, grouped by an `arm`
+field. Each gate names a primitive and the row fields it reads; `overall_pass` is
+true only if every gate passes. The primitives are all seeded, so a verdict is
+reproducible from its recorded seed:
+
+- `count_flips`: rows whose outcome moved from one boolean state to another
+  (for example, a monitored predicate that held before the intervention and no
+  longer holds after it).
+- `kill_diff_vs_control`: the positive-count difference between a primary arm
+  and a count-matched control, with a seeded row-bootstrap confidence interval.
+- `permutation_p`: a one-sided permutation p-value for a count-matched positive
+  count against a pool (add-one smoothed, never exactly zero).
+- `auroc_floor`: a tie-safe AUROC point estimate with a Hanley-McNeil analytic
+  standard error and a seeded bootstrap lower confidence bound.
+
+See `MechInterp/configs/templates/gates.yaml` for a worked example.
+
+## Direction JSON schema
+
+`probe-fit` writes a `mechinterp-direction/v1` record: `layer`, `hidden_dim`,
+`vector` (unit-norm when `normalized`), `mu` (mean offset), `sigma` (the setpoint
+scale, the readout score standard deviation), a `calibration` block with the
+class-conditioned projection statistics, the fit `recipe`, and free-form
+`provenance`. This is the object `steer` loads to intervene and that any external
+reader can consume.
+
+## Design notes
+
+- The intervention math is unit-tested on stub tensors, so the hook semantics are
+  verifiable without downloading a model. The `final` position policy resolves
+  each row's last non-pad token from the attention mask and handles left and
+  right padding identically. The hidden tensor is cloned before any in-place
+  write so no autograd view alias is mutated.
+- Extraction runs a clean forward pass over prompt + completion (KV cache off)
+  and slices hidden states at the requested position families across the
+  requested layer range, one safetensors file per row and family.
+- Probe fitting reduces each activation matrix with a randomized PCA fit
+  label-agnostically, then fits a saga logistic classifier; out-of-fold scoring
+  fits PCA and classifier on train folds only, so the reported AUROC never sees
+  test-fold information. The full-data direction folds the classifier weight back
+  through the PCA basis into raw activation space.

--- a/tests/mech_interp/test_cell.py
+++ b/tests/mech_interp/test_cell.py
@@ -1,0 +1,136 @@
+"""CPU tests for the lane-agnostic steer-cell logic: arm resolution, resume,
+config sha, and the smoke state file."""
+
+import json
+
+import pytest
+
+from MechInterp.config import SteerCellConfig, SmokeConfig
+from MechInterp import cell as cell_mod
+
+
+def _config():
+    return SteerCellConfig(
+        surface={"rows_path": "rows.jsonl", "seed": 3},
+        readouts=[{"name": "axis", "path": "d.json"}],
+        law={"kind": "erase_write", "readout": "axis", "position": "anchor"},
+        arms=[
+            {"name": "baseline", "strength": 0.0},
+            {"name": "primary", "strength": 2.0, "score_field": "s", "threshold": 1.0},
+            {
+                "name": "control",
+                "strength": 2.0,
+                "permuted_control_of": "primary",
+                "control_seed": 99,
+            },
+            {"name": "flagged_dose", "strength": 1.0, "flag_field": "flag"},
+        ],
+        execution={"output_path": "out/rows.jsonl"},
+    )
+
+
+def _rows():
+    return [
+        {"row_key": "a", "s": 1.5, "flag": True},
+        {"row_key": "b", "s": 0.2, "flag": False},
+        {"row_key": "c", "s": 1.1, "flag": True},
+        {"row_key": "d", "s": 0.9, "flag": False},
+    ]
+
+
+def test_baseline_arm_maps_every_row_to_zero():
+    cfg = _config()
+    strengths = cell_mod.resolve_all_arms(cfg, _rows())
+    assert strengths["baseline"] == {"a": 0.0, "b": 0.0, "c": 0.0, "d": 0.0}
+
+
+def test_score_threshold_selects_passing_rows():
+    cfg = _config()
+    strengths = cell_mod.resolve_all_arms(cfg, _rows())
+    assert set(strengths["primary"]) == {"a", "c"}  # s >= 1.0
+    assert all(v == 2.0 for v in strengths["primary"].values())
+
+
+def test_flag_field_selection():
+    cfg = _config()
+    strengths = cell_mod.resolve_all_arms(cfg, _rows())
+    assert set(strengths["flagged_dose"]) == {"a", "c"}
+    assert all(v == 1.0 for v in strengths["flagged_dose"].values())
+
+
+def test_permuted_control_is_count_matched_and_seeded():
+    cfg = _config()
+    rows = _rows()
+    s1 = cell_mod.resolve_all_arms(cfg, rows)["control"]
+    s2 = cell_mod.resolve_all_arms(cfg, rows)["control"]
+    # primary activates 2 rows -> control matches the count
+    assert len(s1) == 2
+    assert s1 == s2  # seeded determinism
+
+
+def test_config_sha_is_deterministic_and_content_sensitive():
+    cfg = _config()
+    sha1 = cell_mod.compute_config_sha(cfg)
+    sha2 = cell_mod.compute_config_sha(cfg)
+    assert sha1 == sha2
+    cfg2 = _config()
+    cfg2.law.position = "final"
+    assert cell_mod.compute_config_sha(cfg2) != sha1
+
+
+def test_pending_rows_skips_completed_on_resume(tmp_path):
+    out = tmp_path / "rows.jsonl"
+    out.write_text(json.dumps({"arm": "primary", "row_key": "a"}) + "\n")
+    cfg = _config()
+    strengths = cell_mod.resolve_all_arms(cfg, _rows())["primary"]
+    pending = cell_mod.pending_rows(_rows(), strengths, "primary", out, resume=True)
+    keys = {r["row_key"] for r in pending}
+    assert "a" not in keys  # already done
+    assert {"b", "c", "d"} <= keys
+
+
+def test_pending_rows_no_resume_runs_all(tmp_path):
+    out = tmp_path / "rows.jsonl"
+    out.write_text(json.dumps({"arm": "primary", "row_key": "a"}) + "\n")
+    cfg = _config()
+    strengths = cell_mod.resolve_all_arms(cfg, _rows())["primary"]
+    pending = cell_mod.pending_rows(_rows(), strengths, "primary", out, resume=False)
+    assert len(pending) == 4
+
+
+def test_smoke_state_roundtrip(tmp_path):
+    out = tmp_path / "rows.jsonl"
+    sha = "abc123"
+    assert cell_mod.smoke_passed(out, sha) is False
+    cell_mod.record_smoke(out, sha, {"passed": True})
+    assert cell_mod.smoke_passed(out, sha) is True
+    # a different config sha must NOT count as a passed smoke
+    assert cell_mod.smoke_passed(out, "different") is False
+
+
+def test_evaluate_smoke_readback_erase_write_pass():
+    rb = {"commanded": [6.0, 6.0], "measured": [6.0, 6.001], "offtarget_abs_max": 1e-5}
+    verdict = cell_mod.evaluate_smoke_readback(rb, SmokeConfig())
+    assert verdict["passed"] is True
+
+
+def test_evaluate_smoke_readback_offtarget_fail():
+    rb = {"commanded": [6.0], "measured": [6.0], "offtarget_abs_max": 1.0}
+    verdict = cell_mod.evaluate_smoke_readback(rb, SmokeConfig())
+    assert verdict["parity_ok"] is False
+    assert verdict["passed"] is False
+
+
+def test_evaluate_smoke_readback_write_error_fail():
+    rb = {"commanded": [6.0], "measured": [2.0], "offtarget_abs_max": 0.0}
+    verdict = cell_mod.evaluate_smoke_readback(rb, SmokeConfig())
+    assert verdict["write_ok"] is False
+    assert verdict["passed"] is False
+
+
+def test_row_key_fallbacks():
+    assert cell_mod.row_key_of({"row_key": "x"}) == "x"
+    assert cell_mod.row_key_of({"id": "y"}) == "y"
+    assert cell_mod.row_key_of({"key": "z"}) == "z"
+    with pytest.raises(KeyError):
+        cell_mod.row_key_of({"nope": 1})

--- a/tests/mech_interp/test_cell_and_config.py
+++ b/tests/mech_interp/test_cell_and_config.py
@@ -1,0 +1,174 @@
+"""CPU tests for config parsing, arm resolution, resume, and smoke gating."""
+
+import json
+
+import pytest
+
+from MechInterp import cell as cell_mod
+from MechInterp.config import (
+    SteerCellConfig,
+    SurfaceConfig,
+    LawConfig,
+    ArmConfig,
+    ExecutionConfig,
+    ReadoutRef,
+    SmokeConfig,
+)
+
+
+def _mk_config(tmp_path, arms):
+    return SteerCellConfig(
+        surface=SurfaceConfig(rows_path=str(tmp_path / "rows.jsonl"), seed=1),
+        readouts=[ReadoutRef(name="axis", path="d.json")],
+        law=LawConfig(kind="erase_write", readout="axis", position="anchor"),
+        arms=arms,
+        execution=ExecutionConfig(output_path=str(tmp_path / "out.jsonl")),
+        smoke=SmokeConfig(n_rows=2),
+    )
+
+
+def _rows():
+    return [
+        {"row_key": "a", "selection_score": 1.5, "flagged": True},
+        {"row_key": "b", "selection_score": 0.2, "flagged": False},
+        {"row_key": "c", "selection_score": 1.1, "flagged": True},
+        {"row_key": "d", "selection_score": 0.9, "flagged": False},
+    ]
+
+
+def test_law_readout_must_be_declared(tmp_path):
+    with pytest.raises(ValueError):
+        SteerCellConfig(
+            surface=SurfaceConfig(rows_path="r.jsonl"),
+            readouts=[ReadoutRef(name="axis", path="d.json")],
+            law=LawConfig(kind="additive", readout="missing"),
+            arms=[ArmConfig(name="baseline", strength=0.0)],
+            execution=ExecutionConfig(output_path="o.jsonl"),
+        )
+
+
+def test_permuted_control_requires_seed():
+    with pytest.raises(ValueError):
+        ArmConfig(name="ctrl", permuted_control_of="primary")
+
+
+def test_score_arm_requires_threshold():
+    with pytest.raises(ValueError):
+        ArmConfig(name="p", score_field="selection_score")
+
+
+def test_baseline_arm_maps_all_rows_to_zero(tmp_path):
+    cfg = _mk_config(tmp_path, [ArmConfig(name="baseline", strength=0.0)])
+    strengths = cell_mod.resolve_arm_strengths(
+        cfg.arms[0], _rows(), {a.name: a for a in cfg.arms}
+    )
+    assert set(strengths) == {"a", "b", "c", "d"}
+    assert all(v == 0.0 for v in strengths.values())
+
+
+def test_score_selection_arm_activates_above_threshold(tmp_path):
+    arm = ArmConfig(name="primary", strength=2.0, score_field="selection_score", threshold=1.0)
+    cfg = _mk_config(tmp_path, [arm])
+    strengths = cell_mod.resolve_arm_strengths(arm, _rows(), {arm.name: arm})
+    assert set(strengths) == {"a", "c"}
+    assert all(v == 2.0 for v in strengths.values())
+
+
+def test_flag_arm_activates_flagged_rows(tmp_path):
+    arm = ArmConfig(name="dose", strength=1.0, flag_field="flagged")
+    strengths = cell_mod.resolve_arm_strengths(arm, _rows(), {arm.name: arm})
+    assert set(strengths) == {"a", "c"}
+
+
+def test_permuted_control_is_count_matched_and_seeded(tmp_path):
+    primary = ArmConfig(name="primary", strength=2.0, score_field="selection_score", threshold=1.0)
+    control = ArmConfig(name="control", strength=2.0, permuted_control_of="primary", control_seed=7)
+    arm_by_name = {a.name: a for a in (primary, control)}
+    rows = _rows()
+    s1 = cell_mod.resolve_arm_strengths(control, rows, arm_by_name)
+    s2 = cell_mod.resolve_arm_strengths(control, rows, arm_by_name)
+    # count matches primary's active count (2)
+    assert len(s1) == 2
+    # same seed -> same draw
+    assert set(s1) == set(s2)
+
+
+def test_permuted_control_seed_changes_draw(tmp_path):
+    primary = ArmConfig(name="primary", strength=2.0, flag_field="flagged")
+    # broaden the pool so different seeds can pick different rows
+    rows = [{"row_key": k, "flagged": k in ("a", "b")} for k in "abcdefgh"]
+    c7 = ArmConfig(name="c", strength=2.0, permuted_control_of="primary", control_seed=7)
+    c9 = ArmConfig(name="c", strength=2.0, permuted_control_of="primary", control_seed=9)
+    arm_by_name = {"primary": primary}
+    s7 = cell_mod.resolve_arm_strengths(c7, rows, arm_by_name)
+    s9 = cell_mod.resolve_arm_strengths(c9, rows, arm_by_name)
+    assert len(s7) == len(s9) == 2
+    # very likely different draws across 8 rows choosing 2
+    assert set(s7) != set(s9)
+
+
+def test_config_sha_is_stable(tmp_path):
+    cfg = _mk_config(tmp_path, [ArmConfig(name="baseline", strength=0.0)])
+    assert cell_mod.compute_config_sha(cfg) == cell_mod.compute_config_sha(cfg)
+
+
+def test_config_sha_changes_with_content(tmp_path):
+    a = _mk_config(tmp_path, [ArmConfig(name="baseline", strength=0.0)])
+    b = _mk_config(tmp_path, [ArmConfig(name="baseline", strength=1.0)])
+    assert cell_mod.compute_config_sha(a) != cell_mod.compute_config_sha(b)
+
+
+def test_resume_skips_completed_rows(tmp_path):
+    out = tmp_path / "out.jsonl"
+    out.write_text(json.dumps({"arm": "primary", "row_key": "a"}) + "\n")
+    strengths = {"a": 2.0, "c": 2.0}
+    pending = cell_mod.pending_rows(_rows(), strengths, "primary", out, resume=True)
+    keys = {p["row_key"] for p in pending}
+    assert "a" not in keys
+    assert {"b", "c", "d"} <= keys
+
+
+def test_resume_disabled_runs_all(tmp_path):
+    out = tmp_path / "out.jsonl"
+    out.write_text(json.dumps({"arm": "primary", "row_key": "a"}) + "\n")
+    pending = cell_mod.pending_rows(_rows(), {"a": 2.0}, "primary", out, resume=False)
+    assert len(pending) == 4
+
+
+def test_pending_rows_tag_strength_and_active(tmp_path):
+    out = tmp_path / "out.jsonl"
+    pending = cell_mod.pending_rows(_rows(), {"a": 2.0}, "primary", out, resume=True)
+    by_key = {p["row_key"]: p for p in pending}
+    assert by_key["a"]["_strength"] == 2.0 and by_key["a"]["_active"] is True
+    assert by_key["b"]["_strength"] == 0.0 and by_key["b"]["_active"] is False
+
+
+def test_smoke_state_roundtrip(tmp_path):
+    out = tmp_path / "out.jsonl"
+    assert not cell_mod.smoke_passed(out, "sha1")
+    cell_mod.record_smoke(out, "sha1", {"passed": True})
+    assert cell_mod.smoke_passed(out, "sha1")
+    # different config sha does not count as passed
+    assert not cell_mod.smoke_passed(out, "sha2")
+
+
+def test_evaluate_smoke_readback_erase_write():
+    class Cfg:
+        write_rel_tol = 0.05
+        write_abs_floor = 0.5
+        offtarget_tol = 1e-3
+
+    rb = {"commanded": [6.0, 6.0], "measured": [6.0, 6.01], "offtarget_abs_max": 0.0}
+    verdict = cell_mod.evaluate_smoke_readback(rb, Cfg())
+    assert verdict["passed"]
+
+
+def test_evaluate_smoke_readback_fails_offtarget():
+    class Cfg:
+        write_rel_tol = 0.05
+        write_abs_floor = 0.5
+        offtarget_tol = 1e-3
+
+    rb = {"commanded": [6.0], "measured": [6.0], "offtarget_abs_max": 1.0}
+    verdict = cell_mod.evaluate_smoke_readback(rb, Cfg())
+    assert not verdict["passed"] and not verdict["parity_ok"]

--- a/tests/mech_interp/test_config.py
+++ b/tests/mech_interp/test_config.py
@@ -1,0 +1,81 @@
+"""CPU tests for MechInterp recipe parsing and validation."""
+
+import pytest
+import yaml
+
+from MechInterp.config import (
+    SteerCellConfig,
+    load_steer_config,
+    load_extract_config,
+    load_probe_fit_config,
+)
+
+
+def _minimal_steer_dict():
+    return {
+        "surface": {"rows_path": "rows.jsonl", "seed": 7},
+        "readouts": [{"name": "axis", "path": "d.json"}],
+        "law": {"kind": "erase_write", "readout": "axis", "position": "anchor"},
+        "arms": [
+            {"name": "baseline", "strength": 0.0},
+            {"name": "primary", "strength": 2.0, "score_field": "s", "threshold": 1.0},
+        ],
+        "execution": {"output_path": "out/rows.jsonl"},
+    }
+
+
+def test_steer_config_parses_and_defaults():
+    cfg = SteerCellConfig(**_minimal_steer_dict())
+    assert cfg.law.readout == "axis"
+    assert cfg.smoke.n_rows == 8  # default
+    assert cfg.surface.generation.do_sample is False  # greedy default
+
+
+def test_law_readout_must_be_declared():
+    d = _minimal_steer_dict()
+    d["law"]["readout"] = "missing"
+    with pytest.raises(ValueError):
+        SteerCellConfig(**d)
+
+
+def test_score_field_requires_threshold():
+    d = _minimal_steer_dict()
+    d["arms"][1] = {"name": "primary", "strength": 2.0, "score_field": "s"}
+    with pytest.raises(ValueError):
+        SteerCellConfig(**d)
+
+
+def test_permuted_control_requires_seed():
+    d = _minimal_steer_dict()
+    d["arms"].append({"name": "control", "permuted_control_of": "primary"})
+    with pytest.raises(ValueError):
+        SteerCellConfig(**d)
+
+
+def test_permuted_control_references_known_arm():
+    d = _minimal_steer_dict()
+    d["arms"].append(
+        {"name": "control", "permuted_control_of": "ghost", "control_seed": 1}
+    )
+    with pytest.raises(ValueError):
+        SteerCellConfig(**d)
+
+
+def test_bundled_templates_parse(tmp_path):
+    """The shipped example recipes must parse against the schema."""
+    from pathlib import Path
+
+    tdir = Path(__file__).resolve().parents[2] / "MechInterp" / "configs" / "templates"
+    steer = load_steer_config(tdir / "steer_cell.yaml")
+    assert any(a.permuted_control_of == "primary" for a in steer.arms)
+    extract = load_extract_config(tdir / "extract.yaml")
+    assert extract.families
+    probe = load_probe_fit_config(tdir / "probe_fit.yaml")
+    assert probe.n_components > 0
+
+
+def test_load_steer_config_roundtrip(tmp_path):
+    p = tmp_path / "cell.yaml"
+    p.write_text(yaml.safe_dump(_minimal_steer_dict()))
+    cfg = load_steer_config(p)
+    assert cfg.arms[1].threshold == 1.0

--- a/tests/mech_interp/test_equivalence.py
+++ b/tests/mech_interp/test_equivalence.py
@@ -1,0 +1,45 @@
+"""CPU tests for the batched-vs-unbatched equivalence self-check."""
+
+import pytest
+import torch
+
+from MechInterp.intervention.equivalence import (
+    max_abs_divergence,
+    relative_tolerance,
+    equivalence_ok,
+)
+
+
+def test_max_abs_divergence_zero_for_identical():
+    a = torch.randn(3, 8)
+    div = max_abs_divergence(a, a.clone())
+    assert div["max_abs"] == 0.0
+    assert div["per_row_max_abs"] == [0.0, 0.0, 0.0]
+
+
+def test_max_abs_divergence_shape_mismatch():
+    with pytest.raises(ValueError):
+        max_abs_divergence(torch.randn(2, 4), torch.randn(3, 4))
+
+
+def test_relative_tolerance_scales_and_floors():
+    big = torch.tensor([[100.0, -50.0]])
+    small = torch.tensor([[0.0, 0.0]])
+    assert relative_tolerance(big, rel=0.01) == pytest.approx(1.0)
+    assert relative_tolerance(small, rel=0.01, floor=1e-3) == pytest.approx(1e-3)
+
+
+def test_equivalence_ok_passes_at_numeric_floor():
+    ref = torch.randn(4, 16) * 10.0
+    perturbed = ref + torch.randn(4, 16) * 1e-4  # tiny numeric noise
+    res = equivalence_ok(ref + 0, perturbed, rel=1e-2, floor=1e-3)
+    assert res["passed"]
+
+
+def test_equivalence_ok_fails_on_real_divergence():
+    ref = torch.zeros(2, 4)
+    diverged = ref.clone()
+    diverged[0, 0] = 5.0  # a real edit, far above the floor
+    res = equivalence_ok(ref, diverged, rel=1e-2, floor=1e-3)
+    assert not res["passed"]
+    assert res["max_abs"] == pytest.approx(5.0)

--- a/tests/mech_interp/test_evaluator.py
+++ b/tests/mech_interp/test_evaluator.py
@@ -1,0 +1,116 @@
+"""CPU tests for the declarative gates.yaml evaluator."""
+
+import pytest
+
+from MechInterp.stats.evaluator import evaluate_gates, _parse_comparison
+
+
+def _rows():
+    # primary: 3 baseline-positive rows flip to negative (killed); control: 1.
+    rows = []
+    for k in range(3):
+        rows.append({"arm": "primary", "row_key": f"p{k}",
+                     "baseline_positive": True, "positive": False, "killed": 1})
+    for k in range(2):
+        rows.append({"arm": "primary", "row_key": f"pn{k}",
+                     "baseline_positive": True, "positive": True, "killed": 0})
+    for k in range(1):
+        rows.append({"arm": "control", "row_key": f"c{k}",
+                     "baseline_positive": True, "positive": False, "killed": 1})
+    for k in range(4):
+        rows.append({"arm": "control", "row_key": f"cn{k}",
+                     "baseline_positive": True, "positive": True, "killed": 0})
+    return rows
+
+
+def test_parse_comparison():
+    op, thr = _parse_comparison(">= 5")
+    assert op(5, 5) and not op(4, 5)
+    assert thr == 5.0
+    with pytest.raises(ValueError):
+        _parse_comparison("bad")
+
+
+def test_count_flips_gate_pass():
+    cfg = {
+        "gates": [
+            {"name": "reach", "primitive": "count_flips", "arm": "primary",
+             "before": "baseline_positive", "after": "positive",
+             "from_state": True, "to_state": False, "pass_if": ">= 3"}
+        ]
+    }
+    report = evaluate_gates(cfg, _rows())
+    assert report["gates"]["reach"]["value"] == 3
+    assert report["gates"]["reach"]["passed"] is True
+    assert report["overall_pass"] is True
+
+
+def test_count_flips_gate_fail():
+    cfg = {
+        "gates": [
+            {"name": "reach", "primitive": "count_flips", "arm": "primary",
+             "before": "baseline_positive", "after": "positive",
+             "pass_if": ">= 10"}
+        ]
+    }
+    report = evaluate_gates(cfg, _rows())
+    assert report["gates"]["reach"]["passed"] is False
+    assert report["overall_pass"] is False
+
+
+def test_kill_diff_gate_with_ci():
+    cfg = {
+        "seed": 1,
+        "n_boot": 300,
+        "gates": [
+            {"name": "specificity", "primitive": "kill_diff_vs_control",
+             "primary_arm": "primary", "control_arm": "control",
+             "primary_indicator": "killed", "control_indicator": "killed",
+             "pass_if_diff": ">= 1"}
+        ],
+    }
+    report = evaluate_gates(cfg, _rows())
+    # primary killed 3, control killed 1 -> diff 2 >= 1
+    assert report["gates"]["specificity"]["value"]["diff"] == pytest.approx(2.0)
+    assert report["gates"]["specificity"]["passed"] is True
+
+
+def test_auroc_floor_gate():
+    rows = []
+    for i, (lab, sc) in enumerate([(0, 0.1), (0, 0.2), (0, 0.3),
+                                   (1, 0.7), (1, 0.8), (1, 0.9)]):
+        rows.append({"arm": "primary", "row_key": f"r{i}",
+                     "label": lab, "readout_score": sc})
+    cfg = {
+        "seed": 0,
+        "n_boot": 200,
+        "gates": [
+            {"name": "readout", "primitive": "auroc_floor", "arm": "primary",
+             "label": "label", "score": "readout_score",
+             "pass_if_auroc": ">= 0.9"}
+        ],
+    }
+    report = evaluate_gates(cfg, rows)
+    assert report["gates"]["readout"]["value"]["auroc"] == pytest.approx(1.0)
+    assert report["gates"]["readout"]["passed"] is True
+
+
+def test_overall_pass_requires_all_gates():
+    cfg = {
+        "gates": [
+            {"name": "g1", "primitive": "count_flips", "arm": "primary",
+             "before": "baseline_positive", "after": "positive", "pass_if": ">= 3"},
+            {"name": "g2", "primitive": "count_flips", "arm": "primary",
+             "before": "baseline_positive", "after": "positive", "pass_if": ">= 99"},
+        ]
+    }
+    report = evaluate_gates(cfg, _rows())
+    assert report["gates"]["g1"]["passed"] is True
+    assert report["gates"]["g2"]["passed"] is False
+    assert report["overall_pass"] is False
+
+
+def test_unknown_primitive_raises():
+    cfg = {"gates": [{"name": "x", "primitive": "nope"}]}
+    with pytest.raises(ValueError):
+        evaluate_gates(cfg, _rows())

--- a/tests/mech_interp/test_gates.py
+++ b/tests/mech_interp/test_gates.py
@@ -1,0 +1,112 @@
+"""CPU tests for gate primitives against hand-computed fixtures."""
+
+import numpy as np
+import pytest
+
+from MechInterp.stats.gates import (
+    count_flips,
+    kill_diff_vs_control,
+    permutation_p,
+    auroc_floor,
+    hanley_mcneil_se,
+    _roc_auc,
+)
+
+
+def test_count_flips_true_to_false():
+    before = [True, True, True, False]
+    after = [False, True, False, False]
+    # rows 0 and 2 moved True->False
+    assert count_flips(before, after) == 2
+
+
+def test_count_flips_custom_states():
+    before = [False, False, True]
+    after = [True, False, True]
+    # count False->True: only row 0
+    assert count_flips(before, after, from_state=False, to_state=True) == 1
+
+
+def test_count_flips_length_mismatch():
+    with pytest.raises(ValueError):
+        count_flips([True], [True, False])
+
+
+def test_kill_diff_point_estimate():
+    primary = [1, 1, 1, 0, 0]  # 3 positives
+    control = [1, 0, 0, 0, 0]  # 1 positive
+    res = kill_diff_vs_control(primary, control, seed=0, n_boot=200)
+    assert res["diff"] == pytest.approx(2.0)
+    assert res["ci_lo"] <= res["diff"] <= res["ci_hi"]
+
+
+def test_kill_diff_ci_excludes_zero_when_strongly_separated():
+    primary = [1] * 20
+    control = [0] * 20
+    res = kill_diff_vs_control(primary, control, seed=1, n_boot=500)
+    assert res["diff"] == pytest.approx(20.0)
+    assert res["ci_lo"] > 0
+
+
+def test_kill_diff_reproducible_by_seed():
+    primary = [1, 0, 1, 0, 1, 0]
+    control = [0, 1, 0, 1, 0, 1]
+    a = kill_diff_vs_control(primary, control, seed=42, n_boot=300)
+    b = kill_diff_vs_control(primary, control, seed=42, n_boot=300)
+    assert a["ci_lo"] == b["ci_lo"] and a["ci_hi"] == b["ci_hi"]
+
+
+def test_roc_auc_perfect_separation():
+    labels = np.array([0, 0, 1, 1])
+    scores = np.array([0.1, 0.2, 0.8, 0.9])
+    assert _roc_auc(labels, scores) == pytest.approx(1.0)
+
+
+def test_roc_auc_reversed_is_zero():
+    labels = np.array([0, 0, 1, 1])
+    scores = np.array([0.9, 0.8, 0.2, 0.1])
+    assert _roc_auc(labels, scores) == pytest.approx(0.0)
+
+
+def test_roc_auc_ties_give_half():
+    # all identical scores -> AUROC 0.5 (Mann-Whitney with all ties)
+    labels = np.array([0, 1, 0, 1])
+    scores = np.array([0.5, 0.5, 0.5, 0.5])
+    assert _roc_auc(labels, scores) == pytest.approx(0.5)
+
+
+def test_hanley_mcneil_se_known_shape():
+    # SE must be positive and shrink as sample size grows
+    se_small = hanley_mcneil_se(0.8, 10, 10)
+    se_large = hanley_mcneil_se(0.8, 100, 100)
+    assert se_small > se_large > 0
+
+
+def test_auroc_floor_perfect():
+    labels = [0, 0, 0, 1, 1, 1]
+    scores = [0.1, 0.2, 0.3, 0.7, 0.8, 0.9]
+    res = auroc_floor(labels, scores, seed=0, n_boot=200)
+    assert res["auroc"] == pytest.approx(1.0)
+    assert res["ci_lb"] <= 1.0
+    assert res["n_pos"] == 3 and res["n_neg"] == 3
+
+
+def test_permutation_p_strong_effect_is_small():
+    # primary took the 5 positives; pool has only 5 positives among 20
+    pool = [1] * 5 + [0] * 15
+    res = permutation_p(primary_positive=5, pool_ind=pool, n_primary=5, seed=0, n_perm=500)
+    # matching 5/5 by chance is rare
+    assert res["p_value"] < 0.05
+
+
+def test_permutation_p_null_effect_is_large():
+    pool = [1] * 10 + [0] * 10
+    res = permutation_p(primary_positive=5, pool_ind=pool, n_primary=10, seed=0, n_perm=500)
+    # expected positives in a draw of 10 is ~5, so p should be well above 0.05
+    assert res["p_value"] > 0.2
+
+
+def test_permutation_p_never_zero():
+    pool = [1] * 5 + [0] * 5
+    res = permutation_p(primary_positive=5, pool_ind=pool, n_primary=5, seed=0, n_perm=100)
+    assert res["p_value"] > 0.0

--- a/tests/mech_interp/test_intervention_hooks.py
+++ b/tests/mech_interp/test_intervention_hooks.py
@@ -1,0 +1,177 @@
+"""CPU tests for the intervention hook math."""
+
+import numpy as np
+import pytest
+import torch
+
+from MechInterp.intervention.hooks import (
+    InterventionHook,
+    additive_push,
+    erase_and_write,
+    resolve_final_positions,
+)
+
+
+def _unit(v):
+    v = torch.tensor(v, dtype=torch.float32)
+    return v / v.norm()
+
+
+def test_resolve_final_positions_right_padding():
+    # rows padded on the RIGHT: real tokens first, then zeros.
+    mask = torch.tensor([[1, 1, 1, 0, 0], [1, 1, 1, 1, 1], [1, 0, 0, 0, 0]])
+    pos = resolve_final_positions(3, 5, attention_mask=mask)
+    assert pos.tolist() == [2, 4, 0]
+
+
+def test_resolve_final_positions_left_padding():
+    # rows padded on the LEFT: zeros first, then real tokens.
+    mask = torch.tensor([[0, 0, 1, 1, 1], [1, 1, 1, 1, 1], [0, 0, 0, 0, 1]])
+    pos = resolve_final_positions(3, 5, attention_mask=mask)
+    assert pos.tolist() == [4, 4, 4]
+
+
+def test_resolve_final_positions_explicit_wraps():
+    pos = resolve_final_positions(2, 5, explicit=torch.tensor([-1, 2]))
+    assert pos.tolist() == [4, 2]
+
+
+def test_resolve_final_positions_fallback_last_column():
+    pos = resolve_final_positions(3, 7)
+    assert pos.tolist() == [6, 6, 6]
+
+
+def test_additive_push_final_position_per_row():
+    d = _unit([1.0, 0.0, 0.0])
+    hidden = torch.zeros(2, 4, 3)
+    # row 0 last real token = col 1 (right padded), row 1 = col 3
+    mask = torch.tensor([[1, 1, 0, 0], [1, 1, 1, 1]])
+    final_pos = resolve_final_positions(2, 4, attention_mask=mask)
+    alpha = torch.tensor([2.0, -3.0])
+    out = additive_push(hidden.clone(), d, alpha, torch.zeros(4, dtype=torch.bool), True, final_pos)
+    assert out[0, 1, 0].item() == pytest.approx(2.0)
+    assert out[1, 3, 0].item() == pytest.approx(-3.0)
+    # untouched columns stay zero
+    assert out[0, 0, 0].item() == 0.0
+    assert out[1, 0, 0].item() == 0.0
+
+
+def test_additive_push_zero_alpha_is_noop():
+    d = _unit([0.0, 1.0, 0.0])
+    hidden = torch.randn(2, 3, 3)
+    final_pos = torch.tensor([2, 2])
+    alpha = torch.tensor([0.0, 0.0])
+    out = additive_push(hidden.clone(), d, alpha, torch.zeros(3, dtype=torch.bool), True, final_pos)
+    assert torch.allclose(out, hidden)
+
+
+def test_erase_and_write_lands_at_setpoint_exactly():
+    # direction along a non-axis unit vector; post-write projection == setpoint.
+    d = _unit([1.0, 2.0, -1.0, 0.5])
+    hidden = torch.randn(3, 5, 4).double().float()
+    final_pos = torch.tensor([4, 4, 4])
+    gain = torch.tensor([2.0, 2.0, 2.0])
+    sigma = 3.0
+    setpoint = gain * sigma
+    out = erase_and_write(
+        hidden.clone(), d, setpoint, gain, torch.zeros(5, dtype=torch.bool), True, final_pos
+    )
+    for b in range(3):
+        proj = float(out[b, 4, :].double() @ d.double())
+        assert proj == pytest.approx(6.0, abs=1e-4)
+
+
+def test_erase_and_write_preserves_orthogonal_complement():
+    d = _unit([1.0, 0.0, 0.0, 0.0])
+    hidden = torch.randn(2, 3, 4)
+    final_pos = torch.tensor([2, 2])
+    gain = torch.tensor([1.0, 1.0])
+    sigma = 5.0
+    before = hidden.clone()
+    out = erase_and_write(
+        hidden.clone(), d, gain * sigma, gain, torch.zeros(3, dtype=torch.bool), True, final_pos
+    )
+    # the orthogonal complement (dims 1..3) at the edited token is unchanged
+    for b in range(2):
+        assert torch.allclose(out[b, 2, 1:], before[b, 2, 1:], atol=1e-5)
+        # the on-direction coordinate (dim 0) equals the setpoint
+        assert out[b, 2, 0].item() == pytest.approx(5.0, abs=1e-4)
+
+
+def test_erase_and_write_inactive_rows_untouched():
+    d = _unit([1.0, 1.0, 0.0])
+    hidden = torch.randn(3, 2, 3)
+    final_pos = torch.tensor([1, 1, 1])
+    gain = torch.tensor([2.0, 0.0, 2.0])  # row 1 inactive
+    before = hidden.clone()
+    out = erase_and_write(
+        hidden.clone(), d, gain * 4.0, gain, torch.zeros(2, dtype=torch.bool), True, final_pos
+    )
+    assert torch.allclose(out[1], before[1])
+    assert not torch.allclose(out[0], before[0])
+
+
+def test_hook_tuple_output_reattaches_rest():
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=1.0, position="final")
+    hidden = torch.zeros(1, 2, 2)
+    extra = torch.tensor([7.0])
+    out = hook(None, None, (hidden, extra))
+    assert isinstance(out, tuple)
+    assert torch.equal(out[1], extra)
+
+
+def test_hook_readback_reports_setpoint_for_erase_write():
+    d = _unit([1.0, 0.0, 0.0])
+    hook = InterventionHook(
+        "erase_write", d, strength=2.0, sigma=3.0, position="final", measure_readback=True
+    )
+    hidden = torch.randn(2, 3, 3)
+    mask = torch.tensor([[1, 1, 1], [1, 1, 1]])
+    hook.attention_mask = mask
+    hook(None, None, hidden)
+    rb = hook.last_readback
+    assert rb["commanded"] == pytest.approx([6.0, 6.0])
+    assert rb["measured"] == pytest.approx([6.0, 6.0], abs=1e-3)
+
+
+def test_hook_anchor_position_edits_single_shared_column():
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=1.0, position="anchor")
+    hidden = torch.zeros(2, 4, 2)
+    out = hook(None, None, hidden.clone())
+    # anchor default = last column
+    assert out[0, 3, 0].item() == pytest.approx(1.0)
+    assert out[0, 0, 0].item() == 0.0
+
+
+def test_additive_push_multi_column_shared_mask_per_row():
+    # regression: a shared-column additive edit over MORE than one column (the
+    # anchor_onward / answer_window case) must broadcast the per-row strength
+    # across every masked column without a shape mismatch.
+    d = _unit([1.0, 0.0, 0.0])
+    hidden = torch.zeros(2, 4, 3)
+    cols = torch.zeros(4, dtype=torch.bool)
+    cols[1:] = True  # columns 1, 2, 3
+    alpha = torch.tensor([2.0, -1.0])
+    out = additive_push(hidden.clone(), d, alpha, cols, False, None)
+    assert out[0, 0, 0].item() == 0.0
+    assert all(out[0, c, 0].item() == pytest.approx(2.0) for c in (1, 2, 3))
+    assert all(out[1, c, 0].item() == pytest.approx(-1.0) for c in (1, 2, 3))
+
+
+def test_hook_anchor_onward_additive_over_full_sequence():
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=1.5, position="anchor_onward")
+    hidden = torch.zeros(1, 3, 2)
+    out = hook(None, None, hidden.clone())
+    assert all(out[0, c, 0].item() == pytest.approx(1.5) for c in range(3))
+
+
+def test_strength_length_mismatch_raises():
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=[1.0, 2.0, 3.0], position="final")
+    hidden = torch.zeros(2, 2, 2)
+    hook.attention_mask = torch.ones(2, 2, dtype=torch.long)
+    with pytest.raises(ValueError):
+        hook(None, None, hidden)

--- a/tests/mech_interp/test_probe_and_gates_eval.py
+++ b/tests/mech_interp/test_probe_and_gates_eval.py
@@ -1,0 +1,152 @@
+"""CPU tests for probe fitting, direction freezing, and the gate evaluator."""
+
+import numpy as np
+import pytest
+
+from MechInterp.probe.fit import (
+    fit_pca,
+    cv_auroc,
+    fit_full_probe,
+    score_full_probe,
+    sweep_layers,
+    freeze_direction,
+    load_frozen_direction,
+)
+from MechInterp.stats.evaluator import evaluate_gates
+from MechInterp.extraction.capture import PositionSpec, resolve_capture_positions
+
+
+def _separable(n=60, d=16, seed=0):
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, d))
+    w = rng.normal(size=d)
+    y = (X @ w > 0).astype(int)
+    # push classes apart along w so the probe has real signal
+    X += (y[:, None] * 2 - 1) * w[None, :] * 1.5
+    return X, y
+
+
+def test_fit_pca_shapes():
+    X, _ = _separable()
+    mu, comps = fit_pca(X, n_components=8, seed=0)
+    assert mu.shape == (16,)
+    assert comps.shape[0] == 8 and comps.shape[1] == 16
+
+
+def test_cv_auroc_recovers_signal():
+    X, y = _separable(seed=1)
+    mean_auc, std_auc, oof = cv_auroc(X, y, n_components=8, seed=1)
+    assert mean_auc > 0.8
+    assert not np.isnan(oof).any()
+
+
+def test_full_probe_score_matches_direction():
+    X, y = _separable(seed=2)
+    fp = fit_full_probe(X, y, n_components=8, seed=2)
+    s = score_full_probe(fp, X)
+    # scores should separate the classes
+    assert s[y == 1].mean() > s[y == 0].mean()
+
+
+def test_sweep_layers_picks_best():
+    X, y = _separable(seed=3)
+    noise = np.random.default_rng(0).normal(size=X.shape)
+    sweep = sweep_layers({0: X, 1: noise}, y, n_components=8, seed=3)
+    assert sweep["best_layer"] == 0
+    assert sweep["auroc_by_layer"][0] > sweep["auroc_by_layer"][1]
+
+
+def test_freeze_and_load_direction(tmp_path):
+    X, y = _separable(seed=4)
+    out = tmp_path / "dir.json"
+    rec = freeze_direction(X, y, layer=7, out_path=out, n_components=8, seed=4)
+    assert rec["layer"] == 7
+    assert rec["normalized"] is True
+    loaded = load_frozen_direction(out)
+    assert loaded["vector_np"].shape == (16,)
+    assert abs(np.linalg.norm(loaded["vector_np"]) - 1.0) < 1e-4
+    assert "sigma" in loaded and loaded["sigma"] > 0
+
+
+def test_evaluate_gates_count_flips_pass():
+    rows = [
+        {"arm": "primary", "baseline_positive": True, "positive": False},
+        {"arm": "primary", "baseline_positive": True, "positive": False},
+        {"arm": "primary", "baseline_positive": True, "positive": True},
+    ]
+    config = {
+        "gates": [
+            {
+                "name": "reach",
+                "primitive": "count_flips",
+                "arm": "primary",
+                "before": "baseline_positive",
+                "after": "positive",
+                "pass_if": ">= 2",
+            }
+        ]
+    }
+    report = evaluate_gates(config, rows)
+    assert report["gates"]["reach"]["value"] == 2
+    assert report["overall_pass"]
+
+
+def test_evaluate_gates_kill_diff_ci():
+    rows = [{"arm": "primary", "killed": 1} for _ in range(12)]
+    rows += [{"arm": "control", "killed": 0} for _ in range(12)]
+    config = {
+        "seed": 0,
+        "n_boot": 300,
+        "gates": [
+            {
+                "name": "spec",
+                "primitive": "kill_diff_vs_control",
+                "primary_arm": "primary",
+                "control_arm": "control",
+                "primary_indicator": "killed",
+                "control_indicator": "killed",
+                "pass_if_diff": ">= 5",
+                "pass_if_ci_excludes_zero": True,
+            }
+        ],
+    }
+    report = evaluate_gates(config, rows)
+    assert report["overall_pass"]
+    assert report["gates"]["spec"]["value"]["ci_lo"] > 0
+
+
+def test_evaluate_gates_overall_fail_when_one_fails():
+    rows = [
+        {"arm": "primary", "baseline_positive": True, "positive": True},
+    ]
+    config = {
+        "gates": [
+            {
+                "name": "reach",
+                "primitive": "count_flips",
+                "arm": "primary",
+                "before": "baseline_positive",
+                "after": "positive",
+                "pass_if": ">= 1",
+            }
+        ]
+    }
+    report = evaluate_gates(config, rows)
+    assert not report["overall_pass"]
+
+
+def test_resolve_capture_positions_families():
+    spec = PositionSpec(families=["anchor", "first_visible", "answer_end", "every_k"], every_k=2)
+    pos = resolve_capture_positions(spec, prompt_len=5, content_end=10, seq_total=11)
+    assert pos["anchor"] == [4]
+    assert pos["first_visible"] == [5]
+    assert pos["answer_end"] == [10]
+    assert pos["every_k"] == [5, 7, 9]
+
+
+def test_resolve_capture_positions_short_completion_drops_out_of_range():
+    spec = PositionSpec(families=["first_visible", "answer_end"])
+    # completion produced nothing: content_end before prompt_len
+    pos = resolve_capture_positions(spec, prompt_len=5, content_end=4, seq_total=5)
+    assert pos["first_visible"] == []
+    assert pos["answer_end"] == [4]

--- a/tests/mech_interp/test_probe_fit.py
+++ b/tests/mech_interp/test_probe_fit.py
@@ -1,0 +1,89 @@
+"""CPU tests for linear readout fitting and direction freezing (synthetic data)."""
+
+import json
+
+import numpy as np
+import pytest
+
+from MechInterp.probe.fit import (
+    fit_pca,
+    cv_auroc,
+    fit_full_probe,
+    score_full_probe,
+    sweep_layers,
+    freeze_direction,
+    load_frozen_direction,
+)
+
+
+def _separable(n=80, d=16, sep=3.0, seed=0):
+    """Two Gaussian blobs separated along axis 0; label 1 is the positive blob."""
+    rng = np.random.default_rng(seed)
+    X = rng.standard_normal((n, d))
+    y = (np.arange(n) % 2).astype(int)
+    X[y == 1, 0] += sep
+    return X, y
+
+
+def test_fit_pca_shapes():
+    X, _ = _separable()
+    mu, comps = fit_pca(X, n_components=8, seed=0)
+    assert mu.shape == (X.shape[1],)
+    assert comps.shape[0] == 8
+    assert comps.shape[1] == X.shape[1]
+
+
+def test_cv_auroc_separable_is_high_and_scores_every_row():
+    X, y = _separable(sep=4.0)
+    mean_auc, std_auc, oof = cv_auroc(X, y, n_components=8, n_splits=4, seed=0)
+    assert mean_auc > 0.9
+    assert not np.isnan(oof).any()  # every row got an out-of-fold score
+
+
+def test_full_probe_score_separates_classes():
+    X, y = _separable(sep=4.0)
+    fp = fit_full_probe(X, y, n_components=8, seed=0)
+    scores = score_full_probe(fp, X)
+    assert scores[y == 1].mean() > scores[y == 0].mean()
+
+
+def test_sweep_layers_picks_the_separable_layer():
+    X_good, y = _separable(sep=5.0, seed=1)
+    rng = np.random.default_rng(2)
+    X_noise = rng.standard_normal(X_good.shape)  # no signal
+    sweep = sweep_layers({10: X_noise, 20: X_good}, y, n_components=8, n_splits=4, seed=0)
+    assert sweep["best_layer"] == 20
+    assert sweep["auroc_by_layer"][20] > sweep["auroc_by_layer"][10]
+
+
+def test_freeze_direction_writes_self_describing_json(tmp_path):
+    X, y = _separable(sep=4.0)
+    out = tmp_path / "dir.json"
+    record = freeze_direction(X, y, layer=20, out_path=out, n_components=8, seed=0)
+    assert out.exists()
+    assert record["layer"] == 20
+    assert record["schema_version"] == "mechinterp-direction/v1"
+    assert record["normalized"] is True
+    # unit-norm when normalized
+    assert np.isclose(np.linalg.norm(record["vector"]), 1.0, atol=1e-6)
+    assert "sigma" in record and record["sigma"] > 0
+    assert record["calibration"]["separation"] > 0
+
+
+def test_load_frozen_direction_adds_numpy(tmp_path):
+    X, y = _separable(sep=4.0)
+    out = tmp_path / "dir.json"
+    freeze_direction(X, y, layer=5, out_path=out, n_components=8, seed=0)
+    loaded = load_frozen_direction(out)
+    assert loaded["vector_np"].dtype == np.float32
+    assert loaded["vector_np"].shape[0] == X.shape[1]
+
+
+def test_bundled_example_direction_loads():
+    from pathlib import Path
+
+    p = (Path(__file__).resolve().parents[2] / "MechInterp" / "configs"
+         / "templates" / "example_direction.json")
+    loaded = load_frozen_direction(p)
+    assert loaded["hidden_dim"] == loaded["vector_np"].shape[0]
+    assert np.isclose(np.linalg.norm(loaded["vector_np"]), 1.0, atol=1e-4)

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -145,7 +145,7 @@ Examples:
     parser.add_argument(
         "command",
         nargs="?",
-        choices=["train", "cloud", "cloud-run", "local-run", "cloud-jobs", "plan-hardware", "cloud-pipeline", "cloud-eval", "cloud-gym", "cloud-inspect", "cloud-extract", "bucket", "run-experiment", "analyze-experiment", "eval", "synthchat", "modelops", "ml", "flywheel", "experiment-loop", "prompt-optimize", "surgery", "status", "doctor", "list", "list-runs", "compute-losses", "compare-runs", "judge-sample", "create-experiment", "cloud-compare", "download-experiment"],
+        choices=["train", "cloud", "cloud-run", "local-run", "cloud-jobs", "plan-hardware", "cloud-pipeline", "cloud-eval", "cloud-gym", "cloud-inspect", "cloud-extract", "bucket", "run-experiment", "analyze-experiment", "eval", "synthchat", "modelops", "ml", "mechinterp", "flywheel", "experiment-loop", "prompt-optimize", "surgery", "status", "doctor", "list", "list-runs", "compute-losses", "compare-runs", "judge-sample", "create-experiment", "cloud-compare", "download-experiment"],
         help="Command to run (optional, defaults to interactive menu)"
     )
 
@@ -418,6 +418,51 @@ Examples:
     parser.add_argument("--files-only", action="store_true", help="For bucket list, show files only.")
     parser.add_argument("--dirs-only", action="store_true", help="For bucket list, show directories only.")
     parser.add_argument("--follow", action="store_true", help="Stream live logs for cloud-jobs logs.")
+
+    # MechInterp flags (extract / probe-fit / steer / score-gates sub-commands)
+    parser.add_argument(
+        "--mi-config",
+        dest="mechinterp_config",
+        help="Path to a MechInterp recipe YAML (mechinterp extract/probe-fit/steer)",
+    )
+    parser.add_argument(
+        "--render-fn",
+        dest="render_fn",
+        help="Prompt render callable 'module.path:callable' (mechinterp steer/extract)",
+    )
+    parser.add_argument(
+        "--adapter",
+        dest="adapter",
+        help="Optional PEFT adapter path/id to load on the base model (mechinterp).",
+    )
+    parser.add_argument(
+        "--gates-config",
+        dest="gates_config",
+        help="Path to a gates.yaml (mechinterp score-gates only).",
+    )
+    parser.add_argument(
+        "--rows-path",
+        dest="rows_path",
+        help="Path to a per-row output JSONL to score (mechinterp score-gates only).",
+    )
+    parser.add_argument(
+        "--arm-field",
+        dest="arm_field",
+        default="arm",
+        help="Row field naming the arm for gate grouping (mechinterp score-gates).",
+    )
+    parser.add_argument(
+        "--i-know-this-runs-on-gpu",
+        dest="i_know_this_runs_on_gpu",
+        action="store_true",
+        help="Acknowledge that mechinterp extract/steer load a model and use a GPU.",
+    )
+    parser.add_argument(
+        "--force-full-run",
+        dest="force_full_run",
+        action="store_true",
+        help="Skip the smoke gate and run the full mechinterp steer arms directly.",
+    )
 
     # Experiment loop flags
     parser.add_argument(

--- a/tuner/cli/router.py
+++ b/tuner/cli/router.py
@@ -175,6 +175,12 @@ def route_command(args: Namespace) -> int:
         handler = MLHandler(args=args)
         return handler.handle()
 
+    # Special handling for mechinterp command (has subcommand)
+    if command == 'mechinterp':
+        from tuner.handlers.mechinterp_handler import MechInterpHandler
+        handler = MechInterpHandler(args=args)
+        return handler.handle()
+
     # Special handling for flywheel command (has subcommand)
     if command == 'flywheel':
         handler = FlywheelHandler(args=args)

--- a/tuner/handlers/mechinterp_handler.py
+++ b/tuner/handlers/mechinterp_handler.py
@@ -1,0 +1,157 @@
+"""
+Mech-interp handler for the Synaptic Tuner CLI.
+
+Purpose: orchestrate the MechInterp verbs (extract, probe-fit, steer, score-gates)
+Used by: router when the 'mechinterp' command is invoked.
+
+Each sub-command is recipe-YAML driven, mirroring the other config-first verbs.
+The handler is thin: it loads and validates the recipe, then delegates to the
+MechInterp CLI layer. GPU-touching verbs (extract, steer) require an explicit
+acknowledgement flag.
+
+Sub-commands:
+  extract      generate + capture hidden states to safetensors + manifest
+  probe-fit    fit a linear readout and freeze a direction JSON
+  steer        run the six-block steer cell (smoke-gated)
+  score-gates  evaluate a gates.yaml against a per-row output JSONL
+  list-configs show bundled example recipes
+"""
+
+import logging
+from argparse import Namespace
+from pathlib import Path
+from typing import Optional
+
+from tuner.handlers.base import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+TEMPLATES_REL = Path("MechInterp") / "configs" / "templates"
+
+
+class MechInterpHandler(BaseHandler):
+    """Handler for mechanistic-interpretation cells."""
+
+    def __init__(self, args: Optional[Namespace] = None):
+        super().__init__(args=args)
+
+    @property
+    def name(self) -> str:
+        return "mechinterp"
+
+    def can_handle_direct_mode(self) -> bool:
+        return True
+
+    def _templates_dir(self) -> Path:
+        return self.repo_root / TEMPLATES_REL
+
+    def _arg(self, key: str, default=None):
+        return getattr(self.args, key, default) if self.args else default
+
+    def handle(self) -> int:
+        sub = self._arg("subcommand")
+        if sub == "list-configs":
+            return self._handle_list_configs()
+        if sub == "extract":
+            return self._handle_extract()
+        if sub == "probe-fit":
+            return self._handle_probe_fit()
+        if sub == "steer":
+            return self._handle_steer()
+        if sub == "score-gates":
+            return self._handle_score_gates()
+
+        msg = (
+            "mechinterp requires a sub-command: extract, probe-fit, steer, "
+            "score-gates, list-configs"
+        )
+        if self.json_mode:
+            self.output_error(msg, code="SUBCOMMAND_REQUIRED")
+        else:
+            print(msg)
+        return 1
+
+    def _handle_list_configs(self) -> int:
+        tdir = self._templates_dir()
+        templates = (
+            [{"name": p.stem, "path": str(p)} for p in sorted(tdir.glob("*.yaml"))]
+            if tdir.is_dir()
+            else []
+        )
+        if self.json_mode:
+            self.output_list(templates, "mechinterp_configs")
+            return 0
+        if not templates:
+            print(f"No recipes found. Add YAML recipes to: {tdir}")
+            return 0
+        print("MechInterp example recipes:")
+        for t in templates:
+            print(f"  - {t['name']}  ({t['path']})")
+        return 0
+
+    def _require(self, key: str, label: str) -> Optional[str]:
+        val = self._arg(key)
+        if not val:
+            msg = f"{label} is required"
+            if self.json_mode:
+                self.output_error(msg, code="ARG_REQUIRED")
+            else:
+                print(f"Error: {msg}")
+            return None
+        return val
+
+    def _handle_extract(self) -> int:
+        from MechInterp.cli import run_extract
+        from MechInterp.config import load_extract_config
+
+        config_path = self._require("mechinterp_config", "--mi-config")
+        model = self._require("model", "--model")
+        if not config_path or not model:
+            return 1
+        config = load_extract_config(config_path)
+        return run_extract(
+            config,
+            model_name=model,
+            adapter=self._arg("adapter"),
+            gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
+        )
+
+    def _handle_probe_fit(self) -> int:
+        from MechInterp.cli import run_probe_fit
+        from MechInterp.config import load_probe_fit_config
+
+        config_path = self._require("mechinterp_config", "--mi-config")
+        if not config_path:
+            return 1
+        config = load_probe_fit_config(config_path)
+        return run_probe_fit(config)
+
+    def _handle_steer(self) -> int:
+        from MechInterp.cli import run_steer
+        from MechInterp.config import load_steer_config
+
+        config_path = self._require("mechinterp_config", "--mi-config")
+        model = self._require("model", "--model")
+        render_fn = self._require("render_fn", "--render-fn")
+        if not config_path or not model or not render_fn:
+            return 1
+        config = load_steer_config(config_path)
+        return run_steer(
+            config,
+            model_name=model,
+            adapter=self._arg("adapter"),
+            render_fn_spec=render_fn,
+            gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
+            force=bool(self._arg("force_full_run", False)),
+        )
+
+    def _handle_score_gates(self) -> int:
+        from MechInterp.cli import run_score_gates
+
+        gates_path = self._require("gates_config", "--gates-config")
+        rows_path = self._require("rows_path", "--rows-path")
+        if not gates_path or not rows_path:
+            return 1
+        return run_score_gates(
+            gates_path, rows_path, arm_field=self._arg("arm_field", "arm") or "arm"
+        )


### PR DESCRIPTION
## Summary

Adds a project-agnostic **MechInterp** package to the tuner so any researcher can run the common mechanistic-interpretation loop through recipe-driven CLI verbs: capture hidden states, fit a linear readout, intervene along it, and adjudicate with declarative gates. Nothing in the package is tied to a specific model, dataset, or research question; the vocabulary is neutral throughout (direction, readout, selection score, intervention, cell).

## What landed

- **Intervention engine** (`MechInterp/intervention/`): forward-hook edits to a decoder layer output with two laws, additive push `h += alpha*d` and erase-and-write setpoint `h' = h - (h.c)c + g*sigma*c`. Per-row selection (inactive rows pass through), per-batch-element strength, position policies (`anchor` / `anchor_onward` / `final` / `answer_window`), and readback instrumentation (commanded vs measured projection, off-target parity). The `final` policy resolves each row's last non-pad token correctly under left AND right padding. A `GenerationInterventionController` gates prefill vs decode for KV-cache-correct steering. Ships a batched-vs-unbatched equivalence self-check.
- **Extraction** (`MechInterp/extraction/`): generation + hidden-state capture at configurable positions (anchor / first-visible / answer-end / every-k) and layer ranges, to safetensors with a manifest.
- **Probe fitting** (`MechInterp/probe/`): configurable dim-reduction + classifier (PCA-k randomized + saga logistic default), out-of-fold AUROC scoring with PCA fit on train folds only, layer sweep, and direction freezing to a self-describing JSON (layer, vector, mu, sigma, calibration, provenance).
- **Gates** (`MechInterp/stats/`): seeded primitives (`count_flips`, `kill_diff_vs_control` with row-bootstrap CI, `permutation_p`, `auroc_floor` with Hanley-McNeil SE + bootstrap CI-LB) and a declarative `gates.yaml` evaluator over per-row provenance.
- **Pluggable grading** (`MechInterp/grading/`): a thin `module.path:callable` interface (row dict in, grade dict out) plus a trivial example grader. No grading semantics in the tuner.
- **Six-block steer cell** (`MechInterp/cell.py` + `cli.py`): surface / readouts / law / arms / execution / smoke. Named arms with fixed / score-threshold / flag / seeded-permuted-control selection, dose ladders, resume-from-output, config-sha pinning, and a smoke gate that must pass before the full arms run (overridable with `--force-full-run`).
- **CLI**: new `mechinterp` command with `extract` / `probe-fit` / `steer` / `score-gates` / `list-configs`, wired through a thin handler mirroring the other config-first verbs. GPU-touching verbs require `--i-know-this-runs-on-gpu`.
- **Recipes + docs**: bundled example recipes under `MechInterp/configs/templates/` and an external-researcher docs page (`docs/MECH_INTERP_CELLS.md`) with a worked generic example.

## Tests

93 CPU-only tests (`tests/mech_interp/`) covering hook math (setpoint lands exactly at `g*sigma` with orthogonal complement preserved; final-position under left and right padding; additive push incl. multi-column shared mask), gate primitives against hand-computed fixtures, config validation, arm resolution + seeded permuted control, resume/smoke gating, probe fitting, the gate evaluator, extraction position resolution, and the equivalence check. All green; the existing `tests/cli/` suite (42) still passes.

## Out of scope

- No root-repo integration (that comes after this merges); no root-repo files were touched.
- No Modal/cloud lanes for these verbs; no GPU used (all tests CPU-only).
- Generalized from the root reference `confidence_steer.py` and the AN setpoint harness with fresh generic implementations; batched final-position + per-element-strength semantics preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD