### PR TITLE
answer_window: genuine generated-token window + reference-parity tests

### DIFF
--- a/MechInterp/intervention/hooks.py
+++ b/MechInterp/intervention/hooks.py
@@ -137,7 +137,17 @@ def _column_mask_for_policy(
 ) -> torch.Tensor:
     """Return a length-seq_len bool column mask for shared-position policies.
 
-    Used by anchor and anchor_onward; final is per-row and handled separately.
+    Used by anchor, anchor_onward, and answer_window; final is per-row and handled
+    separately.
+
+    answer_window is a genuinely narrowed window, not an alias of anchor_onward:
+    it steers only the columns at and after window_start, which the caller sets to
+    the first generated (visible) token index so the prompt is excluded. It
+    requires an explicit window_start and refuses to silently fall back to column
+    zero, so a misconfigured answer_window fails loudly rather than steering the
+    whole prompt. To also exclude a leading thinking or reasoning span, advance
+    window_start past that span; the engine cannot locate a thinking boundary on
+    its own because that marker is tokenizer-specific.
     """
     mask = torch.zeros(seq_len, dtype=torch.bool, device=device)
     if policy == "anchor":
@@ -148,8 +158,12 @@ def _column_mask_for_policy(
         start = (window_start or 0) % seq_len if window_start else 0
         mask[start:] = True
     elif policy == "answer_window":
-        start = (window_start or 0)
-        start = max(0, min(start, seq_len))
+        if window_start is None:
+            raise ValueError(
+                "answer_window requires an explicit window_start (the first "
+                "generated-token index); it does not default to the full sequence"
+            )
+        start = max(0, min(window_start, seq_len))
         mask[start:] = True
     else:
         raise ValueError(f"policy {policy!r} is not a shared-column policy")

--- a/docs/MECH_INTERP_CELLS.md
+++ b/docs/MECH_INTERP_CELLS.md
@@ -40,8 +40,15 @@ are scored separately so a run and its adjudication stay independent.
      post-write projection equals `strength * sigma` exactly while the orthogonal
      complement is untouched.
    - `position` selects which token columns are edited: `anchor` (the last prompt
-     token), `anchor_onward`, `final` (each row's true last non-pad token), or
-     `answer_window`.
+     token), `anchor_onward` (from a column to the end), `final` (each row's true
+     last non-pad token, correct under left and right padding), or `answer_window`
+     (only the generated tokens, from `window_start` onward). `answer_window` is a
+     genuinely narrowed window rather than an alias of `anchor_onward`: the caller
+     sets `window_start` to the first generated-token index so the prompt is
+     excluded, and the engine refuses an `answer_window` with no `window_start`
+     instead of silently steering the whole sequence. To also exclude a leading
+     thinking span, advance `window_start` past it; the engine cannot find a
+     thinking boundary itself because that marker is tokenizer-specific.
    - `generation_mode` selects how the edit propagates during `generate()`:
      `anchor` (edit only the prefill anchor; the KV cache carries it forward) or
      `gen_stream` (edit every decode step).

--- a/tests/mech_interp/test_gates.py
+++ b/tests/mech_interp/test_gates.py
@@ -48,6 +48,14 @@ def test_kill_diff_ci_excludes_zero_when_strongly_separated():
     assert res["ci_lo"] > 0
 
 
+def test_kill_diff_identical_arms_diff_zero_ci_straddles():
+    # paired bootstrap: identical arms give exactly diff 0 and a CI that includes 0
+    arm = [1, 0, 1, 1, 0, 1, 0, 0]
+    res = kill_diff_vs_control(arm, list(arm), seed=3, n_boot=500)
+    assert res["diff"] == pytest.approx(0.0)
+    assert res["ci_lo"] <= 0.0 <= res["ci_hi"]
+
+
 def test_kill_diff_reproducible_by_seed():
     primary = [1, 0, 1, 0, 1, 0]
     control = [0, 1, 0, 1, 0, 1]

--- a/tests/mech_interp/test_intervention_hooks.py
+++ b/tests/mech_interp/test_intervention_hooks.py
@@ -168,6 +168,28 @@ def test_hook_anchor_onward_additive_over_full_sequence():
     assert all(out[0, c, 0].item() == pytest.approx(1.5) for c in range(3))
 
 
+def test_answer_window_excludes_prompt():
+    # window_start = first generated token, so prompt columns are not steered.
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=2.0, position="answer_window")
+    hook.window_start = 3  # prompt is columns 0..2, generated tokens start at 3
+    hidden = torch.zeros(1, 5, 2)
+    out = hook(None, None, hidden.clone())
+    # prompt columns untouched
+    assert all(out[0, c, 0].item() == 0.0 for c in (0, 1, 2))
+    # answer columns steered
+    assert all(out[0, c, 0].item() == pytest.approx(2.0) for c in (3, 4))
+
+
+def test_answer_window_requires_window_start():
+    d = _unit([1.0, 0.0])
+    hook = InterventionHook("additive", d, strength=1.0, position="answer_window")
+    hidden = torch.zeros(1, 4, 2)
+    # window_start defaults to None -> must raise, never silently steer the prompt
+    with pytest.raises(ValueError):
+        hook(None, None, hidden)
+
+
 def test_strength_length_mismatch_raises():
     d = _unit([1.0, 0.0])
     hook = InterventionHook("additive", d, strength=[1.0, 2.0, 3.0], position="final")


### PR DESCRIPTION
Follow-up to #131 (this commit raced the merge): answer_window now steers only columns >= window_start (prompt excluded, refuses a missing window_start rather than silently steering the whole sequence), plus paired-bootstrap null and prompt-exclusion regression tests. 96 CPU tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD