### PR TITLE
mechinterp steer: carry pool-row metadata into the output record

### DIFF
--- a/MechInterp/cli.py
+++ b/MechInterp/cli.py
@@ -199,6 +199,37 @@ def _direction_tensor(readout_record: dict):
     return torch.tensor(readout_record["vector_np"], dtype=torch.float32)
 
 
+# Keys _run_one_pass / _run_batch compute themselves; a same-named pool-row
+# field is never allowed to shadow them (see _passthrough_fields).
+_COMPUTED_RECORD_KEYS = frozenset(
+    {"row_key", "strength", "active", "answer_text", "prompt_len"}
+)
+
+
+def _passthrough_fields(row: dict) -> dict:
+    """Pool-row metadata to carry into the output record, verbatim.
+
+    Without this, the record _run_one_pass/_run_batch return is limited to the
+    fields those passes compute, so a grader (and mechinterp score-gates,
+    grouping by a project-chosen field like a class label) can only ever see
+    row_key/strength/active/answer_text/prompt_len -- never the pool row's own
+    metadata (e.g. gold-answer aliases or a class/cell label), no matter what
+    the recipe's rows_path actually puts on each row. Carrying every non-
+    internal field through keeps the grader interface generic: a project's
+    rows dictate what a project's grader can read, with no tuner-side
+    allowlist of "known" field names.
+
+    Excludes underscore-prefixed keys (internal bookkeeping set by
+    cell.pending_rows, e.g. _strength/_active) and the keys the pass itself
+    computes, so a pool row can never shadow those via a same-named field.
+    """
+    return {
+        k: v
+        for k, v in row.items()
+        if not k.startswith("_") and k not in _COMPUTED_RECORD_KEYS
+    }
+
+
 def _run_one_pass(
     model,
     tokenizer,
@@ -236,6 +267,7 @@ def _run_one_pass(
     prompt_len = enc["input_ids"].shape[1]
     text = tokenizer.decode(full[prompt_len:], skip_special_tokens=True)
     return {
+        **_passthrough_fields(row),
         "row_key": cell_mod.row_key_of(row),
         "strength": strength,
         "active": bool(row.get("_active", False)),
@@ -329,6 +361,7 @@ def _run_batch(
         text = tokenizer.decode(continuation, skip_special_tokens=True)
         records.append(
             {
+                **_passthrough_fields(row),
                 "row_key": cell_mod.row_key_of(row),
                 "strength": float(row.get("_strength", 0.0)),
                 "active": bool(row.get("_active", False)),

--- a/tests/mech_interp/test_steer_record_passthrough.py
+++ b/tests/mech_interp/test_steer_record_passthrough.py
@@ -1,0 +1,158 @@
+"""Regression guard: pool-row metadata must survive into the steer record.
+
+_run_one_pass and _run_batch (MechInterp/cli.py) used to return a record
+built ONLY from the fields those passes compute themselves (row_key,
+strength, active, answer_text, prompt_len). Any other field the recipe's
+rows_path put on a row -- a project's class label, a gold answer's aliases,
+anything a grader or a `mechinterp score-gates` group-by field needs -- was
+silently dropped before the grader ever saw it (run_steer calls
+`grader(rec)`, not `grader(row)`). That broke correctness grading (a grader
+that matches answer_text against aliases got None back) and score-gates
+grouping (no per-class field to group rows by) for any real recipe, even
+though both the grading interface docs and the example project grader's
+docstring already promised "any fields carried through from the input rows
+pool" (see MechInterp/grading/interface.py and
+experiments/common/graders/example_grader.py in the parent project).
+
+This module reuses the tiny offline GPT-2 + word-level tokenizer fixtures
+from test_batched_generation.py (same CPU-only, no-download setup) so it
+exercises the real generation path rather than a stub, then checks the
+returned record dict rather than the generated text.
+"""
+
+from tests.mech_interp.test_batched_generation import (
+    _build_controller,
+    _build_tiny_model,
+    _build_tiny_tokenizer,
+    _render,
+)
+
+from MechInterp.cli import _run_batch, _run_one_pass
+from MechInterp.config import GenerationContract
+from MechInterp.intervention import get_decoder_layer
+
+_LAYER_IDX = 0
+_MAX_NEW_TOKENS = 4
+
+# A pool row carrying the kind of project metadata a real recipe's rows_path
+# puts on every row: a class/cell label a score-gates group-by reads, and the
+# gold aliases a correctness grader reads, plus one arbitrary extra field to
+# confirm the pass-through is not a hard-coded allowlist of two names.
+_ROW = {
+    "row_key": "r0",
+    "_prompt": "w1 w2 w3",
+    "_strength": 1.5,
+    "_active": True,
+    "cell": "should_flip",
+    "aliases": ["w4", "w5"],
+    "category_canon": "geography",
+}
+
+
+def _grader(rec: dict) -> dict:
+    """Tiny fake grader: correct iff any gold alias appears in answer_text.
+
+    Mirrors the real contract (MechInterp/grading/interface.py): a callable
+    over the per-row output dict, returning fields to merge back in. Returns
+    None for `correct` when aliases are missing entirely, matching the
+    reported failure mode this test guards against.
+    """
+    aliases = rec.get("aliases")
+    if aliases is None:
+        return {"correct": None}
+    text = str(rec.get("answer_text", ""))
+    return {"correct": any(a in text for a in aliases)}
+
+
+def _fresh_row():
+    return dict(_ROW)
+
+
+def test_run_one_pass_carries_pool_row_metadata_through():
+    model = _build_tiny_model()
+    tokenizer = _build_tiny_tokenizer()
+    controller = _build_controller("erase_write")
+    generation = GenerationContract(max_new_tokens=_MAX_NEW_TOKENS, do_sample=False)
+
+    rec = _run_one_pass(
+        model, tokenizer, controller, _fresh_row(), generation, "anchor", _render
+    )
+
+    assert rec["cell"] == "should_flip"
+    assert rec["aliases"] == ["w4", "w5"]
+    assert rec["category_canon"] == "geography"
+
+
+def test_run_batch_carries_pool_row_metadata_through():
+    model = _build_tiny_model()
+    tokenizer = _build_tiny_tokenizer()
+    controller = _build_controller("erase_write")
+    generation = GenerationContract(max_new_tokens=_MAX_NEW_TOKENS, do_sample=False)
+
+    [rec] = _run_batch(
+        model, tokenizer, controller, [_fresh_row()], generation, "anchor", _render
+    )
+
+    assert rec["cell"] == "should_flip"
+    assert rec["aliases"] == ["w4", "w5"]
+    assert rec["category_canon"] == "geography"
+
+
+def test_no_internal_underscore_fields_leak_into_the_record():
+    model = _build_tiny_model()
+    tokenizer = _build_tiny_tokenizer()
+    controller = _build_controller("erase_write")
+    generation = GenerationContract(max_new_tokens=_MAX_NEW_TOKENS, do_sample=False)
+
+    rec_one = _run_one_pass(
+        model, tokenizer, controller, _fresh_row(), generation, "anchor", _render
+    )
+    [rec_batch] = _run_batch(
+        model, tokenizer, controller, [_fresh_row()], generation, "anchor", _render
+    )
+
+    for rec in (rec_one, rec_batch):
+        leaked = [k for k in rec if k.startswith("_")]
+        assert not leaked, f"internal fields leaked into the output record: {leaked}"
+
+
+def test_computed_keys_are_never_shadowed_by_a_same_named_pool_field():
+    # A pool row that happens to carry a field named "answer_text" must not
+    # clobber the generated text the pass itself computes.
+    row = _fresh_row()
+    row["answer_text"] = "SHOULD NOT SURVIVE"
+
+    model = _build_tiny_model()
+    tokenizer = _build_tiny_tokenizer()
+    controller = _build_controller("erase_write")
+    generation = GenerationContract(max_new_tokens=_MAX_NEW_TOKENS, do_sample=False)
+
+    rec = _run_one_pass(model, tokenizer, controller, row, generation, "anchor", _render)
+
+    assert rec["answer_text"] != "SHOULD NOT SURVIVE"
+
+
+def test_grader_can_now_read_aliases_carried_through_the_record():
+    model = _build_tiny_model()
+    tokenizer = _build_tiny_tokenizer()
+    controller = _build_controller("erase_write")
+    generation = GenerationContract(max_new_tokens=_MAX_NEW_TOKENS, do_sample=False)
+
+    rec = _run_one_pass(
+        model, tokenizer, controller, _fresh_row(), generation, "anchor", _render
+    )
+    rec.update(_grader(rec))
+
+    # Before the fix, aliases was absent from rec and the grader's `correct`
+    # came back None regardless of what the model generated -- exactly the
+    # failure mode reported against the real project grader.
+    assert rec["correct"] is not None
+    assert isinstance(rec["correct"], bool)
+
+
+def test_grader_returns_none_when_aliases_absent_documenting_the_old_failure():
+    # Same grader, but on a row with no aliases field at all: this is what
+    # EVERY row looked like at the grader before the fix, regardless of what
+    # the pool row actually carried.
+    grade = _grader({"answer_text": "w4 lives here"})
+    assert grade["correct"] is None


### PR DESCRIPTION
## Summary

- `_run_one_pass` and `_run_batch` (`MechInterp/cli.py`) built the per-row output record from only the fields they compute themselves: `row_key`, `strength`, `active`, `answer_text`, `prompt_len`. Every other field the recipe's `rows_path` pool put on a row (a project's class/cell label, a gold answer's aliases, anything else) was silently dropped before `run_steer` calls `grader(rec)`.
- This broke two real consumers: a grader that reads `aliases` to grade correctness got `None` back for every row, and `mechinterp score-gates` had no per-row group-by field (e.g. `cell`) to compute per-class gates against real data — even though the grading interface docs and the example project grader's docstring already promised "any fields carried through from the input rows pool."
- Fix: a new `_passthrough_fields(row)` helper merges every row field that is neither internal (`_`-prefixed, e.g. `_strength`/`_active` set by `cell.pending_rows`) nor one of the keys the pass computes itself into the record, applied *before* the computed fields so a same-named pool field can never shadow them. Wired into both `_run_one_pass` and `_run_batch`.
- Generic and grader-agnostic: no project-specific field names are hardcoded, no experiment code imported. A project's own rows dictate what its own grader/gates can read.

## Test plan

- [x] New regression module `tests/mech_interp/test_steer_record_passthrough.py` (CPU-only, reuses the existing tiny offline GPT-2 fixtures from `test_batched_generation.py` — no GPU, no model download):
  - `_run_one_pass` / `_run_batch` carry a pool row's `cell`, `aliases`, and an arbitrary extra field through into the record.
  - no `_`-prefixed internal field leaks into the output record.
  - a same-named pool field (`answer_text`) never shadows the computed field.
  - a fake grader that reads `aliases` now produces a non-`None` correctness field (and documents the `None` it got before the fix, on a row with no `aliases` at all).
- [x] Confirmed against pre-fix code (`git stash`) that 3 of 6 new tests fail with `KeyError: 'cell'` / `assert None is not None` — the tests actually catch the bug.
- [x] Full `tests/mech_interp/` suite green post-fix: `142 passed`.

```
/home/profsynapse/.conda/envs/unsloth_env/bin/python -m pytest tests/mech_interp/ -q
142 passed in 4.74s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD