### PR TITLE
MechInterp: fix self-referential steer config-sha drift guard

### DIFF
--- a/MechInterp/cell.py
+++ b/MechInterp/cell.py
@@ -59,8 +59,17 @@ def row_key_of(row: dict) -> str:
 
 
 def compute_config_sha(config: SteerCellConfig) -> str:
-    """Deterministic sha256 over the canonicalized config (readouts by path)."""
+    """Deterministic sha256 over the canonicalized config (readouts by path).
+
+    surface.expected_config_sha is excluded from the payload before hashing:
+    that field holds the expected value of THIS hash, so including it would
+    make the hash a function of itself -- filling it in would shift the
+    computed sha out from under it, and the "expected == computed" guard in
+    run_steer could never be satisfied. Every other field is content, and
+    stays in.
+    """
     payload = config.model_dump(mode="json")
+    payload.get("surface", {}).pop("expected_config_sha", None)
     canon = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canon.encode("utf-8")).hexdigest()
 

--- a/tests/mech_interp/test_cell.py
+++ b/tests/mech_interp/test_cell.py
@@ -78,6 +78,22 @@ def test_config_sha_is_deterministic_and_content_sensitive():
     assert cell_mod.compute_config_sha(cfg2) != sha1
 
 
+def test_config_sha_ignores_its_own_expected_value():
+    """The drift guard (run_steer: expected_config_sha == compute_config_sha)
+    must be satisfiable. Filling in surface.expected_config_sha with the sha
+    computed from the unset config must not change the sha -- otherwise the
+    field meant to hold "the expected hash of this config" would itself be an
+    input to that hash, and no value written into it could ever match."""
+    cfg = _config()
+    unset_sha = cell_mod.compute_config_sha(cfg)
+
+    cfg.surface.expected_config_sha = unset_sha
+    assert cell_mod.compute_config_sha(cfg) == unset_sha
+
+    cfg.surface.expected_config_sha = "not-the-right-sha"
+    assert cell_mod.compute_config_sha(cfg) != cfg.surface.expected_config_sha
+
+
 def test_pending_rows_skips_completed_on_resume(tmp_path):
     out = tmp_path / "rows.jsonl"
     out.write_text(json.dumps({"arm": "primary", "row_key": "a"}) + "\n")


### PR DESCRIPTION
## Summary
- `compute_config_sha` hashed the whole parsed `SteerCellConfig`, including `surface.expected_config_sha` itself. Setting that field to any value changed the hash it was supposed to be compared against, so `run_steer`'s drift guard (`expected_config_sha == compute_config_sha(config)`) could never be satisfied by filling it in.
- Fix: exclude `surface.expected_config_sha` from the payload before hashing in `compute_config_sha` (`MechInterp/cell.py`). The guard is now self-consistent — pin the sha computed while the field is unset, and a later run with unchanged content matches.
- No other call site (`write_manifest`'s `surface.model_dump(...)`) is affected; the manifest still records whatever `expected_config_sha` was set to, for provenance.

## Test plan
- [x] New regression test `test_config_sha_ignores_its_own_expected_value` in `tests/mech_interp/test_cell.py`: computes the sha with `expected_config_sha` unset, sets the field to that value, asserts the sha is unchanged; asserts a wrong value still mismatches.
- [x] Confirmed the new test fails without the fix (stash-and-rerun): `AssertionError` on hash mismatch.
- [x] Full `tests/mech_interp/` suite green: 137 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD