### PR TITLE
mechinterp: configurable gen_stream firing-probe strength

### DIFF
--- a/MechInterp/cli.py
+++ b/MechInterp/cli.py
@@ -438,7 +438,13 @@ def run_steer(
             smoke_enc = tokenizer(render_fn(rows[0]), return_tensors="pt").to(
                 next(model.parameters()).device
             )
-            gen_stream_fired = gen_stream_fires(model, controller, smoke_enc)
+            gen_stream_fired = gen_stream_fires(
+                model,
+                controller,
+                smoke_enc,
+                strength=config.smoke.gen_stream_probe_strength
+                or _GEN_STREAM_SMOKE_STRENGTH,
+            )
             if not gen_stream_fired:
                 verdict["passed"] = False
         verdict["gen_stream_fired"] = gen_stream_fired
@@ -508,10 +514,13 @@ def run_steer(
     return 0
 
 
-# A strength this large relative to any real dose ladder in a recipe makes a
-# missing decode-hook firing unambiguous: if it produces byte-identical output
-# to "off" mode, the hook did not fire, not merely "fired too weakly to move
-# the argmax token."
+# Default firing-probe strength. The premise is that it is large relative to any
+# real dose ladder, so byte-identical output to "off" mode unambiguously means
+# the hook did not fire (not merely "fired too weakly to move the argmax token").
+# That premise breaks on high-activation-scale substrates (e.g. bnb-4bit bases)
+# whose coherent doses run into the hundreds, where 100.0 sits in the inert
+# regime and false-negatives. Override per cell via
+# SmokeConfig.gen_stream_probe_strength when the dose ladder exceeds this.
 _GEN_STREAM_SMOKE_STRENGTH = 100.0
 _GEN_STREAM_SMOKE_MAX_NEW_TOKENS = 8
 

--- a/MechInterp/config.py
+++ b/MechInterp/config.py
@@ -160,6 +160,20 @@ class SmokeConfig(BaseModel):
     offtarget_tol: float = Field(
         default=1e-3, description="Max allowed movement of inactive rows."
     )
+    gen_stream_probe_strength: float | None = Field(
+        default=None,
+        description=(
+            "Strength used only by the gen_stream decode-hook firing probe "
+            "(not a real arm dose). The probe must be large RELATIVE TO this "
+            "cell's dose ladder so a byte-identical output unambiguously means "
+            "'hook did not fire' rather than 'fired too weakly to move the "
+            "argmax'. The built-in default (100.0) assumes real doses are well "
+            "below 100, which is false on high-activation-scale substrates "
+            "(e.g. bnb-4bit bases, where coherent doses run into the hundreds); "
+            "set this to a value at or above this cell's top dose there. None "
+            "keeps the built-in default."
+        ),
+    )
 
 
 class ExecutionConfig(BaseModel):


### PR DESCRIPTION
## Problem
The gen_stream decode-hook firing guard (`gen_stream_fires`) probes at a hardcoded `_GEN_STREAM_SMOKE_STRENGTH = 100.0`. Its premise is that 100 is *large relative to any real dose ladder*, so byte-identical output to "off" mode unambiguously means the hook did not fire. That premise breaks on high-activation-scale substrates (e.g. bnb-4bit bases), where coherent steering doses run into the hundreds and 100.0 sits in the *inert* regime — so the guard false-negatives and aborts every direction before any arm runs.

## Fix
- Add optional `SmokeConfig.gen_stream_probe_strength: float | None = None` (default `None` -> unchanged 100.0 behavior).
- Thread it into `gen_stream_fires` from `cli.py`: `config.smoke.gen_stream_probe_strength or _GEN_STREAM_SMOKE_STRENGTH`.
- A cell on a high-scale substrate sets this at/above its own top dose.

Generic, backward-compatible, experiment-agnostic. Verified: `SmokeConfig` default is `None`, override accepted; `cli.py` parses; `test_config_loader.py` 3/4 pass (the 1 failure — `storageManager_move` tool-name mismatch — is pre-existing on clean main, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD