### PR TITLE
Add config-first mechinterp pipeline runner

### DIFF
--- a/MechInterp/cloud/modal_runner.py
+++ b/MechInterp/cloud/modal_runner.py
@@ -1,0 +1,247 @@
+"""Generic Modal runner for config-driven MechInterp pipelines.
+
+This module is intentionally experiment-agnostic. It clones a repository at an
+exact commit, restores configured checkpoint artifacts from a Modal Volume, then
+executes `python tuner.py mechinterp run --provider local --config ...` inside
+the remote container.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+
+try:
+    import modal
+except ImportError as exc:  # pragma: no cover - local import diagnostic
+    raise SystemExit("Install Modal first: pip install modal") from exc
+
+
+HOURS = 60 * 60
+APP_NAME = os.environ.get("MI_MODAL_APP_NAME", "mechinterp-pipeline")
+IMAGE = os.environ.get("MI_MODAL_IMAGE", "vllm/vllm-openai:latest")
+GPU = os.environ.get("MI_MODAL_GPU", "A10G")
+TIMEOUT_HOURS = float(os.environ.get("MI_MODAL_TIMEOUT_HOURS", "3"))
+VOLUME_NAME = os.environ.get("MI_MODAL_VOLUME", "mechinterp-pipeline")
+MOUNT_PATH = os.environ.get("MI_MODAL_MOUNT", "/vol/mechinterp")
+CHECKPOINT_INTERVAL_SEC = int(os.environ.get("MI_MODAL_CHECKPOINT_INTERVAL_SEC", "120"))
+PIP = [item for item in os.environ.get("MI_MODAL_PIP", "pyyaml\npydantic").splitlines() if item]
+APT = [item for item in os.environ.get("MI_MODAL_APT", "git").splitlines() if item]
+
+
+def _image():
+    img = (
+        modal.Image.from_registry(IMAGE, add_python=None)
+        .entrypoint([])
+        .env({"HF_HUB_DISABLE_XET": "1", "HF_HUB_ENABLE_HF_TRANSFER": "0"})
+    )
+    if APT:
+        img = img.apt_install(*APT)
+    if PIP:
+        img = img.pip_install(*PIP)
+    return img
+
+
+app = modal.App(APP_NAME, image=_image())
+vol = modal.Volume.from_name(VOLUME_NAME, create_if_missing=True)
+
+
+def _sh(cmd: list[str], *, cwd: str | None = None, check: bool = True) -> int:
+    print(f"[mechinterp-modal] $ {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, cwd=cwd)
+    if check and result.returncode != 0:
+        raise RuntimeError(f"command failed ({result.returncode}): {' '.join(cmd)}")
+    return result.returncode
+
+
+def _checkpoint_paths(workspace: str, config: str) -> list[str]:
+    try:
+        import yaml
+
+        with open(os.path.join(workspace, config), encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        artifacts = data.get("artifacts", {}) if isinstance(data, dict) else {}
+        paths = artifacts.get("checkpoint_paths", []) if isinstance(artifacts, dict) else []
+        return [str(path) for path in paths]
+    except Exception as exc:  # noqa: BLE001
+        print(f"[mechinterp-modal] checkpoint path load failed (non-fatal): {exc}", flush=True)
+        return []
+
+
+def _copy_path(src: Path, dst: Path) -> int:
+    if not src.exists():
+        return 0
+    if src.is_file():
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        tmp = dst.with_suffix(dst.suffix + ".tmp")
+        shutil.copyfile(src, tmp)
+        os.replace(tmp, dst)
+        return 1
+    count = 0
+    for root, _dirs, files in os.walk(src):
+        rel_root = Path(root).relative_to(src)
+        for filename in files:
+            s = Path(root) / filename
+            d = dst / rel_root / filename
+            d.parent.mkdir(parents=True, exist_ok=True)
+            tmp = d.with_suffix(d.suffix + ".tmp")
+            shutil.copyfile(s, tmp)
+            os.replace(tmp, d)
+            count += 1
+    return count
+
+
+def _restore_checkpoints(workspace: str, config: str, paths: list[str]) -> None:
+    root = Path(MOUNT_PATH) / "ckpt" / Path(config).stem
+    restored = 0
+    for rel in paths:
+        restored += _copy_path(root / rel, Path(workspace) / rel)
+    print(f"[mechinterp-modal] restored {restored} checkpoint files", flush=True)
+
+
+def _commit_checkpoints(workspace: str, config: str, paths: list[str], tag: str = "") -> None:
+    root = Path(MOUNT_PATH) / "ckpt" / Path(config).stem
+    copied = 0
+    for rel in paths:
+        copied += _copy_path(Path(workspace) / rel, root / rel)
+    vol.commit()
+    print(f"[mechinterp-modal] committed {copied} checkpoint files {tag}".rstrip(), flush=True)
+
+
+def _run_with_periodic_checkpoint(cmd: list[str], *, cwd: str, config: str, paths: list[str]) -> int:
+    print(f"[mechinterp-modal] $ {' '.join(cmd)}", flush=True)
+    proc = subprocess.Popen(cmd, cwd=cwd)
+    while True:
+        rc = proc.poll()
+        if rc is not None:
+            _commit_checkpoints(cwd, config, paths, "(final)")
+            return rc
+        time.sleep(CHECKPOINT_INTERVAL_SEC)
+        _commit_checkpoints(cwd, config, paths, "(periodic)")
+
+
+@app.function(
+    gpu=GPU,
+    timeout=int(TIMEOUT_HOURS * HOURS),
+    volumes={MOUNT_PATH: vol},
+    secrets=[
+        modal.Secret.from_dict(
+            {
+                "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
+                "HF_API_KEY": os.environ.get("HF_API_KEY", ""),
+                "WANDB_API_KEY": os.environ.get("WANDB_API_KEY", ""),
+                "HF_HUB_DISABLE_XET": "1",
+                "HF_HUB_ENABLE_HF_TRANSFER": "0",
+            }
+        )
+    ],
+    retries=modal.Retries(max_retries=3, backoff_coefficient=1.0, initial_delay=10.0),
+)
+def run_pipeline(
+    *,
+    config: str,
+    repo_url: str,
+    repo_branch: str,
+    repo_commit: str,
+    only_step: str = "",
+    from_step: str = "",
+    skip_steps: list[str] | None = None,
+    gpu_ack: bool = False,
+    force_full_run: bool = False,
+) -> dict:
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "0"
+    os.environ.setdefault("HF_HOME", "/root/.cache/huggingface")
+
+    workspace = "/workspace/repo"
+    if not os.path.isdir(os.path.join(workspace, ".git")):
+        _sh(["git", "clone", repo_url, workspace])
+    _sh(["git", "fetch", "origin"], cwd=workspace, check=False)
+    if repo_branch:
+        _sh(["git", "checkout", repo_branch], cwd=workspace, check=False)
+    _sh(["git", "checkout", repo_commit], cwd=workspace)
+
+    checkpoint_paths = _checkpoint_paths(workspace, config)
+    _restore_checkpoints(workspace, config, checkpoint_paths)
+
+    cmd = [
+        "python",
+        "tuner.py",
+        "mechinterp",
+        "run",
+        "--config",
+        config,
+        "--provider",
+        "local",
+        "--yes",
+    ]
+    if only_step:
+        cmd.extend(["--only-step", only_step])
+    if from_step:
+        cmd.extend(["--from-step", from_step])
+    for step in skip_steps or []:
+        cmd.extend(["--skip-step", step])
+    if gpu_ack:
+        cmd.append("--i-know-this-runs-on-gpu")
+    if force_full_run:
+        cmd.append("--force-full-run")
+
+    rc = _run_with_periodic_checkpoint(
+        cmd, cwd=workspace, config=config, paths=checkpoint_paths
+    )
+    done_dir = Path(MOUNT_PATH) / "done"
+    done_dir.mkdir(parents=True, exist_ok=True)
+    marker = done_dir / f"{repo_commit[:12]}-{Path(config).stem}.txt"
+    marker.write_text(f"repo_commit={repo_commit}\nconfig={config}\nreturncode={rc}\n")
+    vol.commit()
+    return {"returncode": rc, "repo_commit": repo_commit, "config": config}
+
+
+@app.local_entrypoint()
+def main(
+    config: str,
+    repo_url: str,
+    repo_branch: str = "main",
+    repo_commit: str = "",
+    only_step: str = "",
+    from_step: str = "",
+    skip_step: list[str] | None = None,
+    i_know_this_runs_on_gpu: bool = False,
+    force_full_run: bool = False,
+) -> None:
+    if not repo_commit:
+        raise SystemExit("--repo-commit is required for Modal mechinterp runs")
+    call = run_pipeline.spawn(
+        config=config,
+        repo_url=repo_url,
+        repo_branch=repo_branch,
+        repo_commit=repo_commit,
+        only_step=only_step,
+        from_step=from_step,
+        skip_steps=skip_step or [],
+        gpu_ack=i_know_this_runs_on_gpu,
+        force_full_run=force_full_run,
+    )
+    print(f"[mechinterp-modal] spawned {call.object_id}", flush=True)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", required=True)
+    parser.add_argument("--repo-url", required=True)
+    parser.add_argument("--repo-branch", default="main")
+    parser.add_argument("--repo-commit", required=True)
+    parser.add_argument("--only-step", default="")
+    parser.add_argument("--from-step", default="")
+    parser.add_argument("--skip-step", action="append", default=[])
+    parser.add_argument("--i-know-this-runs-on-gpu", action="store_true")
+    parser.add_argument("--force-full-run", action="store_true")
+    args = parser.parse_args()
+    raise SystemExit(
+        "Run through Modal: modal run --detach MechInterp/cloud/modal_runner.py --config ..."
+    )

--- a/MechInterp/config.py
+++ b/MechInterp/config.py
@@ -181,6 +181,14 @@ class ExecutionConfig(BaseModel):
 
     output_path: str = Field(..., min_length=1, description="Per-row output JSONL")
     resume: bool = True
+    render_fn: Optional[str] = Field(
+        default=None,
+        description=(
+            "Prompt render callable 'module.path:callable'. Kept here so a "
+            "steer cell can be fully config-driven; the CLI --render-fn flag "
+            "remains a development override."
+        ),
+    )
     grader: Optional[str] = Field(
         default=None, description="Grader spec 'module.path:callable'"
     )

--- a/MechInterp/configs/templates/local_smoke.yaml
+++ b/MechInterp/configs/templates/local_smoke.yaml
@@ -1,0 +1,24 @@
+# Minimal local pipeline smoke.
+#
+# This does not download a model or touch a GPU. It validates config -> CLI ->
+# local pipeline execution -> artifact creation.
+
+schema_version: mechinterp-pipeline/v1
+name: local-cli-smoke
+
+runtime:
+  provider: local
+  python: python
+  workdir: .
+
+artifacts:
+  checkpoint_paths:
+    - outputs/local_smoke.txt
+
+stages:
+  - name: hello
+    kind: command
+    command:
+      - python
+      - -c
+      - "import pathlib, platform; p=pathlib.Path('outputs/local_smoke.txt'); p.parent.mkdir(exist_ok=True); p.write_text('local smoke ok\\n' + platform.python_version() + '\\n'); print(p.read_text())"

--- a/MechInterp/configs/templates/pipeline.yaml
+++ b/MechInterp/configs/templates/pipeline.yaml
@@ -1,0 +1,65 @@
+# Example config-first MechInterp pipeline.
+#
+# Run locally:
+#   python tuner.py mechinterp run --config MechInterp/configs/templates/pipeline.yaml --provider local --dry-run
+#
+# Submit on Modal after replacing model/config paths with real repo files and
+# passing an exact pushed commit:
+#   python tuner.py mechinterp run --config path/to/pipeline.yaml --provider modal --repo-commit <sha> --dry-run
+
+schema_version: mechinterp-pipeline/v1
+name: example-mechinterp-pipeline
+model: Qwen/Qwen3-4B
+
+runtime:
+  provider: local
+  python: python
+  workdir: .
+  # Add project plug-in directories here when render/grader callables live
+  # outside the tuner package, for example ["plugins/renders", "plugins/graders"].
+  pythonpath: []
+
+repo:
+  # Optional for local. Modal can also receive these via CLI flags.
+  url:
+  branch:
+  commit:
+
+modal:
+  app_name: example-mechinterp-pipeline
+  image: vllm/vllm-openai:latest
+  gpu: A10G
+  timeout_hours: 3
+  checkpoint_interval_sec: 120
+  volume_name: mechinterp-pipeline
+  mount_path: /vol/mechinterp
+  pip:
+    - pyyaml
+    - pydantic
+    - safetensors
+    - scikit-learn
+    - scipy
+  apt:
+    - git
+
+artifacts:
+  checkpoint_paths: []
+
+stages:
+  - name: extract
+    kind: mechinterp.extract
+    config: MechInterp/configs/templates/extract.yaml
+
+  - name: fit
+    kind: mechinterp.probe-fit
+    config: MechInterp/configs/templates/probe_fit.yaml
+
+  - name: steer
+    kind: mechinterp.steer
+    config: MechInterp/configs/templates/steer_cell.yaml
+    render_fn: example_render:render
+
+  - name: gates
+    kind: mechinterp.score-gates
+    gates_config: MechInterp/configs/templates/gates.yaml
+    rows_path: outputs/rows_out.jsonl

--- a/MechInterp/pipeline.py
+++ b/MechInterp/pipeline.py
@@ -1,0 +1,335 @@
+"""Config-first MechInterp pipeline runner.
+
+The pipeline layer keeps experiment orchestration declarative: a YAML file names
+the stages and their recipe files, while CLI flags provide only late-bound
+runtime facts such as provider, exact commit, and operator approval.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, Field, model_validator
+
+
+StageKind = Literal[
+    "command",
+    "mechinterp.extract",
+    "mechinterp.probe-fit",
+    "mechinterp.steer",
+    "mechinterp.score-gates",
+]
+
+
+class RuntimeConfig(BaseModel):
+    provider: Literal["local", "modal"] = "local"
+    python: str = Field(default_factory=lambda: sys.executable)
+    workdir: str = "."
+    env: dict[str, str] = Field(default_factory=dict)
+    pythonpath: list[str] = Field(default_factory=list)
+
+
+class RepoConfig(BaseModel):
+    url: Optional[str] = None
+    branch: Optional[str] = None
+    commit: Optional[str] = None
+
+
+class ModalConfig(BaseModel):
+    app_name: Optional[str] = None
+    image: str = "vllm/vllm-openai:latest"
+    gpu: str = "A10G"
+    timeout_hours: float = 3.0
+    checkpoint_interval_sec: int = 120
+    volume_name: str = "mechinterp-pipeline"
+    mount_path: str = "/vol/mechinterp"
+    pip: list[str] = Field(default_factory=lambda: ["pyyaml", "pydantic"])
+    apt: list[str] = Field(default_factory=lambda: ["git"])
+
+
+class ArtifactConfig(BaseModel):
+    checkpoint_paths: list[str] = Field(default_factory=list)
+
+
+class StageConfig(BaseModel):
+    name: str = Field(..., min_length=1)
+    kind: StageKind
+    config: Optional[str] = None
+    model: Optional[str] = None
+    adapter: Optional[str] = None
+    render_fn: Optional[str] = None
+    gates_config: Optional[str] = None
+    rows_path: Optional[str] = None
+    arm_field: str = "arm"
+    command: Optional[str | list[str]] = None
+    shell: bool = False
+    workdir: Optional[str] = None
+    env: dict[str, str] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _required_fields(self) -> "StageConfig":
+        if self.kind == "command" and self.command is None:
+            raise ValueError(f"stage {self.name}: command is required")
+        if (
+            self.kind == "command"
+            and isinstance(self.command, str)
+            and not self.shell
+        ):
+            raise ValueError(
+                f"stage {self.name}: string commands require shell: true; "
+                "use a list argv for shell-free execution"
+            )
+        if self.kind in {"mechinterp.extract", "mechinterp.probe-fit", "mechinterp.steer"} and not self.config:
+            raise ValueError(f"stage {self.name}: config is required")
+        if self.kind == "mechinterp.score-gates" and (
+            not self.gates_config or not self.rows_path
+        ):
+            raise ValueError(
+                f"stage {self.name}: gates_config and rows_path are required"
+            )
+        return self
+
+
+class PipelineConfig(BaseModel):
+    schema_version: str = "mechinterp-pipeline/v1"
+    name: str = Field(..., min_length=1)
+    model: Optional[str] = None
+    adapter: Optional[str] = None
+    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
+    repo: RepoConfig = Field(default_factory=RepoConfig)
+    modal: ModalConfig = Field(default_factory=ModalConfig)
+    artifacts: ArtifactConfig = Field(default_factory=ArtifactConfig)
+    stages: list[StageConfig] = Field(..., min_length=1)
+
+    @model_validator(mode="after")
+    def _unique_stage_names(self) -> "PipelineConfig":
+        names = [stage.name for stage in self.stages]
+        if len(names) != len(set(names)):
+            raise ValueError("stage names must be unique")
+        return self
+
+
+def load_pipeline_config(path: str | Path) -> PipelineConfig:
+    with open(path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"MechInterp pipeline config must be a YAML object: {path}")
+    return PipelineConfig(**data)
+
+
+def select_stages(
+    cfg: PipelineConfig,
+    *,
+    only_step: str | None = None,
+    from_step: str | None = None,
+    skip_steps: list[str] | None = None,
+) -> list[StageConfig]:
+    skip = set(skip_steps or [])
+    stages = list(cfg.stages)
+    names = [stage.name for stage in stages]
+    for requested in [only_step, from_step, *skip]:
+        if requested and requested not in names:
+            raise ValueError(f"unknown pipeline stage: {requested}")
+    if only_step:
+        stages = [stage for stage in stages if stage.name == only_step]
+    elif from_step:
+        start = names.index(from_step)
+        stages = stages[start:]
+    if skip:
+        stages = [stage for stage in stages if stage.name not in skip]
+    return stages
+
+
+def _stage_model(cfg: PipelineConfig, stage: StageConfig) -> str:
+    model = stage.model or cfg.model
+    if not model:
+        raise ValueError(f"stage {stage.name}: model is required")
+    return model
+
+
+def _stage_adapter(cfg: PipelineConfig, stage: StageConfig) -> str | None:
+    return stage.adapter if stage.adapter is not None else cfg.adapter
+
+
+def _repo_path(repo_root: Path, path: str) -> Path:
+    p = Path(path)
+    return p if p.is_absolute() else repo_root / p
+
+
+def _steer_render_fn(stage: StageConfig, repo_root: Path) -> str | None:
+    if stage.render_fn:
+        return stage.render_fn
+    if not stage.config:
+        return None
+    try:
+        from MechInterp.config import load_steer_config
+
+        return load_steer_config(_repo_path(repo_root, stage.config)).execution.render_fn
+    except Exception:
+        return None
+
+
+def compile_stage_command(
+    cfg: PipelineConfig,
+    stage: StageConfig,
+    *,
+    repo_root: Path,
+    gpu_ack: bool = False,
+    force: bool = False,
+) -> list[str] | str:
+    python = cfg.runtime.python or sys.executable
+    tuner = str(repo_root / "tuner.py")
+    if stage.kind == "command":
+        if isinstance(stage.command, list):
+            return [str(item) for item in stage.command]
+        return str(stage.command)
+
+    if stage.kind == "mechinterp.extract":
+        cmd = [
+            python,
+            tuner,
+            "mechinterp",
+            "extract",
+            "--mi-config",
+            str(stage.config),
+            "--model",
+            _stage_model(cfg, stage),
+        ]
+        adapter = _stage_adapter(cfg, stage)
+        if adapter:
+            cmd.extend(["--adapter", adapter])
+        if gpu_ack:
+            cmd.append("--i-know-this-runs-on-gpu")
+        return cmd
+
+    if stage.kind == "mechinterp.probe-fit":
+        return [
+            python,
+            tuner,
+            "mechinterp",
+            "probe-fit",
+            "--mi-config",
+            str(stage.config),
+        ]
+
+    if stage.kind == "mechinterp.steer":
+        cmd = [
+            python,
+            tuner,
+            "mechinterp",
+            "steer",
+            "--mi-config",
+            str(stage.config),
+            "--model",
+            _stage_model(cfg, stage),
+        ]
+        adapter = _stage_adapter(cfg, stage)
+        render_fn = _steer_render_fn(stage, repo_root)
+        if adapter:
+            cmd.extend(["--adapter", adapter])
+        if render_fn:
+            cmd.extend(["--render-fn", render_fn])
+        if gpu_ack:
+            cmd.append("--i-know-this-runs-on-gpu")
+        if force:
+            cmd.append("--force-full-run")
+        return cmd
+
+    if stage.kind == "mechinterp.score-gates":
+        return [
+            python,
+            tuner,
+            "mechinterp",
+            "score-gates",
+            "--gates-config",
+            str(stage.gates_config),
+            "--rows-path",
+            str(stage.rows_path),
+            "--arm-field",
+            stage.arm_field,
+        ]
+
+    raise ValueError(f"unsupported stage kind: {stage.kind}")
+
+
+def build_pipeline_plan(
+    cfg: PipelineConfig,
+    *,
+    repo_root: Path,
+    provider: str,
+    only_step: str | None = None,
+    from_step: str | None = None,
+    skip_steps: list[str] | None = None,
+    gpu_ack: bool = False,
+    force: bool = False,
+) -> dict[str, Any]:
+    stages = select_stages(
+        cfg, only_step=only_step, from_step=from_step, skip_steps=skip_steps
+    )
+    return {
+        "name": cfg.name,
+        "schema_version": cfg.schema_version,
+        "provider": provider,
+        "model": cfg.model,
+        "adapter": cfg.adapter,
+        "runtime": cfg.runtime.model_dump(),
+        "modal": cfg.modal.model_dump() if provider == "modal" else None,
+        "artifacts": cfg.artifacts.model_dump(),
+        "stages": [
+            {
+                "name": stage.name,
+                "kind": stage.kind,
+                "workdir": stage.workdir or cfg.runtime.workdir,
+                "command": compile_stage_command(
+                    cfg,
+                    stage,
+                    repo_root=repo_root,
+                    gpu_ack=gpu_ack,
+                    force=force,
+                ),
+                "shell": stage.shell,
+            }
+            for stage in stages
+        ],
+    }
+
+
+def _env_for_stage(cfg: PipelineConfig, stage: StageConfig, repo_root: Path) -> dict[str, str]:
+    env = {**os.environ, **cfg.runtime.env, **stage.env}
+    paths = [str(repo_root / p) if not Path(p).is_absolute() else p for p in cfg.runtime.pythonpath]
+    if paths:
+        env["PYTHONPATH"] = os.pathsep.join(paths + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else []))
+    return env
+
+
+def run_local_pipeline(
+    cfg: PipelineConfig,
+    *,
+    repo_root: Path,
+    only_step: str | None = None,
+    from_step: str | None = None,
+    skip_steps: list[str] | None = None,
+    gpu_ack: bool = False,
+    force: bool = False,
+) -> int:
+    for stage in select_stages(
+        cfg, only_step=only_step, from_step=from_step, skip_steps=skip_steps
+    ):
+        cmd = compile_stage_command(
+            cfg, stage, repo_root=repo_root, gpu_ack=gpu_ack, force=force
+        )
+        cwd = repo_root / (stage.workdir or cfg.runtime.workdir)
+        env = _env_for_stage(cfg, stage, repo_root)
+        print(f"[mechinterp-run] stage={stage.name} kind={stage.kind}")
+        if isinstance(cmd, list):
+            result = subprocess.run(cmd, cwd=cwd, env=env)
+        else:
+            result = subprocess.run(cmd, cwd=cwd, env=env, shell=stage.shell)
+        if result.returncode != 0:
+            return result.returncode
+    return 0

--- a/tests/cli/test_parser.py
+++ b/tests/cli/test_parser.py
@@ -255,6 +255,36 @@ def test_bucket_push_command_parses():
     assert args.dest == "runs/manual_uploads/"
 
 
+def test_mechinterp_run_config_flags_parse():
+    parser = create_parser()
+
+    args = parser.parse_args(
+        [
+            "mechinterp",
+            "run",
+            "--config",
+            "MechInterp/configs/pipeline.yaml",
+            "--provider",
+            "modal",
+            "--from-step",
+            "extract",
+            "--skip-step",
+            "fit",
+            "--i-know-this-runs-on-gpu",
+            "--yes",
+        ]
+    )
+
+    assert args.command == "mechinterp"
+    assert args.subcommand == "run"
+    assert args.ml_config == "MechInterp/configs/pipeline.yaml"
+    assert args.provider == "modal"
+    assert args.from_step == "extract"
+    assert args.skip_step == ["fit"]
+    assert args.i_know_this_runs_on_gpu is True
+    assert args.auto_confirm is True
+
+
 def test_flywheel_export_fixtures_command_parses():
     parser = create_parser()
 

--- a/tests/mech_interp/test_pipeline.py
+++ b/tests/mech_interp/test_pipeline.py
@@ -1,0 +1,114 @@
+"""CPU tests for config-first MechInterp pipelines."""
+
+from __future__ import annotations
+
+import yaml
+import pytest
+
+from MechInterp.config import SteerCellConfig
+from MechInterp.pipeline import (
+    PipelineConfig,
+    build_pipeline_plan,
+    load_pipeline_config,
+    select_stages,
+)
+
+
+def _cell(path):
+    data = {
+        "surface": {"rows_path": "rows.jsonl"},
+        "readouts": [{"name": "axis", "path": "direction.json"}],
+        "law": {"kind": "additive", "readout": "axis"},
+        "arms": [{"name": "baseline", "strength": 0.0}],
+        "execution": {"output_path": "rows_out.jsonl", "render_fn": "render:prompt"},
+    }
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+
+def _pipeline(tmp_path):
+    cell = tmp_path / "cell.yaml"
+    _cell(cell)
+    return PipelineConfig(
+        name="smoke",
+        model="Tiny/Model",
+        runtime={"python": "python", "pythonpath": ["plugins"]},
+        stages=[
+            {"name": "extract", "kind": "mechinterp.extract", "config": "extract.yaml"},
+            {"name": "fit", "kind": "mechinterp.probe-fit", "config": "probe.yaml"},
+            {"name": "steer", "kind": "mechinterp.steer", "config": str(cell)},
+            {
+                "name": "gates",
+                "kind": "mechinterp.score-gates",
+                "gates_config": "gates.yaml",
+                "rows_path": "rows_out.jsonl",
+            },
+        ],
+    )
+
+
+def test_pipeline_config_loads(tmp_path):
+    path = tmp_path / "pipeline.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "demo",
+                "model": "Tiny/Model",
+                "stages": [
+                    {
+                        "name": "say",
+                        "kind": "command",
+                        "command": ["python", "-c", "print('ok')"],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cfg = load_pipeline_config(path)
+    assert cfg.name == "demo"
+    assert cfg.stages[0].kind == "command"
+
+
+def test_command_string_requires_shell_true():
+    with pytest.raises(ValueError):
+        PipelineConfig(
+            name="bad",
+            stages=[{"name": "say", "kind": "command", "command": "echo bad"}],
+        )
+
+
+def test_select_stages_supports_only_from_and_skip(tmp_path):
+    cfg = _pipeline(tmp_path)
+    assert [s.name for s in select_stages(cfg, only_step="fit")] == ["fit"]
+    assert [s.name for s in select_stages(cfg, from_step="fit")] == ["fit", "steer", "gates"]
+    assert [s.name for s in select_stages(cfg, skip_steps=["fit"])] == ["extract", "steer", "gates"]
+    with pytest.raises(ValueError):
+        select_stages(cfg, only_step="missing")
+
+
+def test_plan_compiles_mechinterp_commands_and_config_render_fn(tmp_path):
+    cfg = _pipeline(tmp_path)
+    plan = build_pipeline_plan(
+        cfg,
+        repo_root=tmp_path,
+        provider="local",
+        gpu_ack=True,
+        force=True,
+    )
+    commands = {stage["name"]: stage["command"] for stage in plan["stages"]}
+    assert commands["extract"][-1] == "--i-know-this-runs-on-gpu"
+    assert "--render-fn" in commands["steer"]
+    assert "render:prompt" in commands["steer"]
+    assert "--force-full-run" in commands["steer"]
+    assert commands["gates"][-1] == "arm"
+
+
+def test_steer_execution_render_fn_parses():
+    cfg = SteerCellConfig(
+        surface={"rows_path": "rows.jsonl"},
+        readouts=[{"name": "axis", "path": "direction.json"}],
+        law={"kind": "additive", "readout": "axis"},
+        arms=[{"name": "baseline", "strength": 0.0}],
+        execution={"output_path": "rows_out.jsonl", "render_fn": "render:prompt"},
+    )
+    assert cfg.execution.render_fn == "render:prompt"

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -123,6 +123,7 @@ Examples:
   python tuner.py status --json    # JSON output for AI parsing
   python tuner.py cloud-run --job-config Trainers/recipes/job.yaml --yes
   python tuner.py local-run --job-config Trainers/recipes/job.yaml --yes
+  python tuner.py mechinterp run --config MechInterp/configs/my_pipeline.yaml --provider local --yes
   python tuner.py cloud-jobs list
   python tuner.py bucket analyze --path runs/hf_jobs/sft/<run-prefix>/
   python tuner.py bucket read --path runs/hf_jobs/sft/<run-prefix>/logs/training_latest.jsonl --jsonl-latest --pretty
@@ -186,7 +187,7 @@ Examples:
     parser.add_argument(
         "--config",
         dest="ml_config",
-        help="Path to ML training config YAML (only used with 'ml train')"
+        help="Path to config YAML (ml train or mechinterp run)."
     )
 
     # Flywheel-specific flags
@@ -393,6 +394,11 @@ Examples:
     parser.add_argument("--env-exec-config", help="Custom environment execution YAML for cloud-eval/cloud-gym.")
     parser.add_argument("--job-config", help="Config-driven job YAML (cloud-run or local-run workflow).")
     parser.add_argument(
+        "--provider",
+        choices=["local", "modal"],
+        help="Execution provider for config-driven mechinterp run.",
+    )
+    parser.add_argument(
         "--stop",
         action="store_true",
         help="Stop (but keep) the persistent container for the given --job-config (local-run only).",
@@ -424,6 +430,11 @@ Examples:
         "--mi-config",
         dest="mechinterp_config",
         help="Path to a MechInterp recipe YAML (mechinterp extract/probe-fit/steer)",
+    )
+    parser.add_argument(
+        "--pipeline-config",
+        dest="pipeline_config",
+        help="Path to a multi-stage MechInterp pipeline YAML (mechinterp run).",
     )
     parser.add_argument(
         "--render-fn",
@@ -462,6 +473,22 @@ Examples:
         dest="force_full_run",
         action="store_true",
         help="Skip the smoke gate and run the full mechinterp steer arms directly.",
+    )
+    parser.add_argument(
+        "--only-step",
+        dest="only_step",
+        help="Run only one named stage from a mechinterp pipeline.",
+    )
+    parser.add_argument(
+        "--from-step",
+        dest="from_step",
+        help="Start a mechinterp pipeline at this named stage.",
+    )
+    parser.add_argument(
+        "--skip-step",
+        dest="skip_step",
+        action="append",
+        help="Skip a named stage from a mechinterp pipeline. May be repeated.",
     )
 
     # Experiment loop flags

--- a/tuner/handlers/mechinterp_handler.py
+++ b/tuner/handlers/mechinterp_handler.py
@@ -10,6 +10,7 @@ MechInterp CLI layer. GPU-touching verbs (extract, steer) require an explicit
 acknowledgement flag.
 
 Sub-commands:
+  run          run a multi-stage mechinterp pipeline from one config
   extract      generate + capture hidden states to safetensors + manifest
   probe-fit    fit a linear readout and freeze a direction JSON
   steer        run the six-block steer cell (smoke-gated)
@@ -18,6 +19,8 @@ Sub-commands:
 """
 
 import logging
+import os
+import subprocess
 from argparse import Namespace
 from pathlib import Path
 from typing import Optional
@@ -52,6 +55,8 @@ class MechInterpHandler(BaseHandler):
         sub = self._arg("subcommand")
         if sub == "list-configs":
             return self._handle_list_configs()
+        if sub == "run":
+            return self._handle_run()
         if sub == "extract":
             return self._handle_extract()
         if sub == "probe-fit":
@@ -62,7 +67,7 @@ class MechInterpHandler(BaseHandler):
             return self._handle_score_gates()
 
         msg = (
-            "mechinterp requires a sub-command: extract, probe-fit, steer, "
+            "mechinterp requires a sub-command: run, extract, probe-fit, steer, "
             "score-gates, list-configs"
         )
         if self.json_mode:
@@ -100,6 +105,150 @@ class MechInterpHandler(BaseHandler):
             return None
         return val
 
+    def _pipeline_config_arg(self) -> Optional[str]:
+        return (
+            self._arg("pipeline_config")
+            or self._arg("ml_config")
+            or self._arg("mechinterp_config")
+        )
+
+    def _handle_run(self) -> int:
+        from MechInterp.pipeline import (
+            build_pipeline_plan,
+            load_pipeline_config,
+            run_local_pipeline,
+        )
+
+        config_path = self._pipeline_config_arg()
+        if not config_path:
+            self.output_error(
+                "mechinterp run requires --config <pipeline.yaml>",
+                code="ARG_REQUIRED",
+            )
+            return 1
+
+        try:
+            cfg = load_pipeline_config(config_path)
+            provider = self._arg("provider") or cfg.runtime.provider
+            plan = build_pipeline_plan(
+                cfg,
+                repo_root=self.repo_root,
+                provider=provider,
+                only_step=self._arg("only_step"),
+                from_step=self._arg("from_step"),
+                skip_steps=self._arg("skip_step") or [],
+                gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
+                force=bool(self._arg("force_full_run", False)),
+            )
+        except Exception as exc:
+            self.output_error(str(exc), code="MECHINTERP_PIPELINE_CONFIG")
+            return 1
+
+        if self._arg("dry_run", False):
+            self.output(plan, "MechInterp pipeline dry-run plan:")
+            return 0
+
+        if provider == "local":
+            if not self._arg("auto_confirm", False):
+                self.output_error(
+                    "Refusing to run without --yes. Use --dry-run to inspect the plan first.",
+                    code="CONFIRMATION_REQUIRED",
+                )
+                return 2
+            try:
+                return run_local_pipeline(
+                    cfg,
+                    repo_root=self.repo_root,
+                    only_step=self._arg("only_step"),
+                    from_step=self._arg("from_step"),
+                    skip_steps=self._arg("skip_step") or [],
+                    gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
+                    force=bool(self._arg("force_full_run", False)),
+                )
+            except Exception as exc:
+                self.output_error(str(exc), code="MECHINTERP_PIPELINE_RUN_FAILED")
+                return 1
+
+        if provider == "modal":
+            if not self._arg("auto_confirm", False):
+                self.output_error(
+                    "Refusing to submit Modal work without --yes. Use --dry-run first.",
+                    code="CONFIRMATION_REQUIRED",
+                )
+                return 2
+            return self._submit_modal_pipeline(config_path, cfg)
+
+        self.output_error(f"Unsupported mechinterp provider: {provider}", code="BAD_PROVIDER")
+        return 1
+
+    def _git_value(self, args: list[str], default: str = "") -> str:
+        try:
+            return subprocess.check_output(
+                ["git", *args],
+                cwd=self.repo_root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+            ).strip()
+        except Exception:
+            return default
+
+    def _submit_modal_pipeline(self, config_path: str, cfg) -> int:
+        repo_url = self._arg("repo_url") or cfg.repo.url or self._git_value(["config", "--get", "remote.origin.url"])
+        repo_branch = self._arg("repo_branch") or cfg.repo.branch or self._git_value(["branch", "--show-current"], "main")
+        repo_commit = self._arg("repo_commit") or cfg.repo.commit or self._git_value(["rev-parse", "HEAD"])
+        if not repo_url or not repo_commit:
+            self.output_error(
+                "Modal mechinterp runs require a repo URL and exact commit. Pass --repo-url/--repo-commit or set repo.* in config.",
+                code="REPO_SOURCE_REQUIRED",
+            )
+            return 1
+
+        modal_cfg = cfg.modal
+        env = {
+            **os.environ,
+            "MI_MODAL_APP_NAME": modal_cfg.app_name or f"mechinterp-{cfg.name}",
+            "MI_MODAL_IMAGE": modal_cfg.image,
+            "MI_MODAL_GPU": self._arg("gpu") or modal_cfg.gpu,
+            "MI_MODAL_TIMEOUT_HOURS": str(self._arg("timeout_hours") or modal_cfg.timeout_hours),
+            "MI_MODAL_CHECKPOINT_INTERVAL_SEC": str(modal_cfg.checkpoint_interval_sec),
+            "MI_MODAL_VOLUME": modal_cfg.volume_name,
+            "MI_MODAL_MOUNT": modal_cfg.mount_path,
+            "MI_MODAL_PIP": "\n".join(modal_cfg.pip),
+            "MI_MODAL_APT": "\n".join(modal_cfg.apt),
+        }
+
+        runner = self.repo_root / "MechInterp" / "cloud" / "modal_runner.py"
+        cmd = [
+            "modal",
+            "run",
+            "--detach",
+            str(runner),
+            "--config",
+            config_path,
+            "--repo-url",
+            repo_url,
+            "--repo-branch",
+            repo_branch,
+            "--repo-commit",
+            repo_commit,
+        ]
+        if self._arg("only_step"):
+            cmd.extend(["--only-step", self._arg("only_step")])
+        if self._arg("from_step"):
+            cmd.extend(["--from-step", self._arg("from_step")])
+        for step in self._arg("skip_step") or []:
+            cmd.extend(["--skip-step", step])
+        if self._arg("i_know_this_runs_on_gpu", False):
+            cmd.append("--i-know-this-runs-on-gpu")
+        if self._arg("force_full_run", False):
+            cmd.append("--force-full-run")
+
+        try:
+            return subprocess.run(cmd, cwd=self.repo_root, env=env).returncode
+        except FileNotFoundError:
+            self.output_error("Modal CLI not found. Install with: pip install modal", code="MODAL_NOT_FOUND")
+            return 1
+
     def _handle_extract(self) -> int:
         from MechInterp.cli import run_extract
         from MechInterp.config import load_extract_config
@@ -132,10 +281,16 @@ class MechInterpHandler(BaseHandler):
 
         config_path = self._require("mechinterp_config", "--mi-config")
         model = self._require("model", "--model")
-        render_fn = self._require("render_fn", "--render-fn")
-        if not config_path or not model or not render_fn:
+        if not config_path or not model:
             return 1
         config = load_steer_config(config_path)
+        render_fn = self._arg("render_fn") or config.execution.render_fn
+        if not render_fn:
+            self.output_error(
+                "steer requires execution.render_fn in the cell config or --render-fn",
+                code="ARG_REQUIRED",
+            )
+            return 1
         return run_steer(
             config,
             model_name=model,


### PR DESCRIPTION
## Summary
- add a generic mechinterp-pipeline/v1 runner and stage compiler
- add local and Modal provider paths for config-driven mechinterp workflows
- add generic pipeline/local-smoke templates and focused parser/pipeline tests

## Validation
- python -m pytest tests\\mech_interp\\test_pipeline.py tests\\cli\\test_parser.py
- python -m py_compile MechInterp\\pipeline.py MechInterp\\cloud\\modal_runner.py tuner\\handlers\\mechinterp_handler.py tuner\\cli\\parser.py MechInterp\\config.py
- python tuner.py mechinterp run --config MechInterp\\configs\\templates\\local_smoke.yaml --provider local --yes
- python tuner.py mechinterp run --config MechInterp\\configs\\templates\\pipeline.yaml --provider modal --dry-run --json --repo-commit 0123456789abcdef0123456789abcdef01234567 --i-know-this-runs-on-gpu