### PR TITLE
Add generic mechinterp dose calibration

### DIFF
--- a/MechInterp/cell.py
+++ b/MechInterp/cell.py
@@ -38,7 +38,12 @@ from typing import Optional
 
 import numpy as np
 
-from MechInterp.config import ArmConfig, SteerCellConfig
+from MechInterp.config import (
+    ArmConfig,
+    DoseCalibrationConfig,
+    DoseCalibrationSelection,
+    SteerCellConfig,
+)
 
 
 def load_jsonl(path: str | Path) -> list[dict]:
@@ -58,7 +63,7 @@ def row_key_of(row: dict) -> str:
     raise KeyError("row has no row_key / id / key field")
 
 
-def compute_config_sha(config: SteerCellConfig) -> str:
+def compute_config_sha(config: SteerCellConfig | DoseCalibrationConfig) -> str:
     """Deterministic sha256 over the canonicalized config (readouts by path).
 
     surface.expected_config_sha is excluded from the payload before hashing:
@@ -219,6 +224,172 @@ def pending_rows(
         rr["_active"] = selected and (val != 0.0 or write_at_zero)
         pending.append(rr)
     return pending
+
+
+# --------------------------------------------------------------------------
+# Dose calibration state and summaries
+# --------------------------------------------------------------------------
+
+
+def _dose_key(dose: float | str) -> str:
+    return f"{float(dose):.17g}"
+
+
+def _dose_record_key(rec: dict) -> tuple[str, str, str]:
+    return (
+        str(rec.get("readout")),
+        _dose_key(rec.get("dose", 0.0)),
+        str(rec.get("row_key")),
+    )
+
+
+def dose_completed_keys(output_path: str | Path) -> set[tuple[str, str, str]]:
+    """Return completed (readout, dose, row_key) cells from a checkpoint JSONL."""
+    path = Path(output_path)
+    if not path.exists():
+        return set()
+    done = set()
+    for rec in load_jsonl(path):
+        if "readout" in rec and "dose" in rec and "row_key" in rec:
+            done.add(_dose_record_key(rec))
+    return done
+
+
+def dose_selection_active(selection: DoseCalibrationSelection, row: dict) -> bool:
+    """Whether a row should receive the current calibration dose."""
+    if selection.flag_field is not None:
+        return bool(row.get(selection.flag_field))
+    if selection.score_field is not None:
+        value = row.get(selection.score_field)
+        return value is not None and float(value) >= float(selection.threshold)
+    return True
+
+
+def dose_pending_rows(
+    rows: list[dict],
+    output_path: str | Path,
+    *,
+    resume: bool,
+    readout: str,
+    dose: float,
+    strength: float,
+    selection: DoseCalibrationSelection,
+    write_at_zero: bool = False,
+) -> list[dict]:
+    """Rows still needing a specific readout+dose calibration checkpoint."""
+    done = dose_completed_keys(output_path) if resume else set()
+    pending = []
+    dose_id = _dose_key(dose)
+    for row in rows:
+        rk = row_key_of(row)
+        if (str(readout), dose_id, rk) in done:
+            continue
+        active = dose_selection_active(selection, row)
+        rr = dict(row)
+        rr["_strength"] = float(strength)
+        rr["_active"] = bool(active and (float(strength) != 0.0 or write_at_zero))
+        pending.append(rr)
+    return pending
+
+
+_SUMMARY_EXCLUDED_BOOL_FIELDS = frozenset(
+    {"active", "readback_within_tolerance"}
+)
+
+
+def _mean(values: list[float]) -> float | None:
+    return (sum(values) / len(values)) if values else None
+
+
+def summarize_dose_calibration(records_or_path) -> dict:
+    """Aggregate a dose-calibration checkpoint JSONL.
+
+    The summary is deliberately schema-light: project graders can add arbitrary
+    boolean outcome fields, and each boolean is reported as a true-rate by
+    readout+dose group. Numeric readback fields get means when present.
+    """
+    if isinstance(records_or_path, (str, Path)):
+        records = load_jsonl(records_or_path)
+    else:
+        records = list(records_or_path)
+
+    groups: dict[tuple[str, str], dict] = {}
+    for rec in records:
+        if "readout" not in rec or "dose" not in rec:
+            continue
+        key = (str(rec["readout"]), _dose_key(rec["dose"]))
+        group = groups.setdefault(
+            key,
+            {
+                "readout": str(rec["readout"]),
+                "dose": float(rec["dose"]),
+                "n": 0,
+                "n_active": 0,
+                "_strengths": [],
+                "_readback_measured": [],
+                "_readback_commanded": [],
+                "_bool_counts": {},
+            },
+        )
+        group["n"] += 1
+        if bool(rec.get("active", False)):
+            group["n_active"] += 1
+        if rec.get("strength") is not None:
+            group["_strengths"].append(float(rec["strength"]))
+        if rec.get("readback_measured") is not None:
+            group["_readback_measured"].append(float(rec["readback_measured"]))
+        if rec.get("readback_commanded") is not None:
+            group["_readback_commanded"].append(float(rec["readback_commanded"]))
+        for field, value in rec.items():
+            if isinstance(value, bool) and field not in _SUMMARY_EXCLUDED_BOOL_FIELDS:
+                counts = group["_bool_counts"].setdefault(field, {"true": 0, "false": 0})
+                counts["true" if value else "false"] += 1
+
+    out_groups = []
+    for _, group in sorted(groups.items(), key=lambda item: (item[0][0], float(item[0][1]))):
+        bool_metrics = {}
+        for field, counts in sorted(group["_bool_counts"].items()):
+            total = counts["true"] + counts["false"]
+            bool_metrics[field] = {
+                "true": counts["true"],
+                "false": counts["false"],
+                "rate": (counts["true"] / total) if total else None,
+            }
+        out_groups.append(
+            {
+                "readout": group["readout"],
+                "dose": group["dose"],
+                "n": group["n"],
+                "n_active": group["n_active"],
+                "strength_mean": _mean(group["_strengths"]),
+                "readback_measured_mean": _mean(group["_readback_measured"]),
+                "readback_commanded_mean": _mean(group["_readback_commanded"]),
+                "bool_metrics": bool_metrics,
+            }
+        )
+    return {"n_records": len(records), "groups": out_groups}
+
+
+def write_dose_manifest(
+    output_path: str | Path,
+    config: DoseCalibrationConfig,
+    config_sha: str,
+    run_summaries: dict,
+) -> Path:
+    """Write a dose-calibration manifest next to the checkpoint JSONL."""
+    p = Path(output_path)
+    manifest_path = p.with_suffix(p.suffix + ".manifest.json")
+    manifest = {
+        "config_sha": config_sha,
+        "law": config.law.model_dump(mode="json"),
+        "readouts": [r.model_dump(mode="json") for r in config.readouts],
+        "calibration": config.calibration.model_dump(mode="json"),
+        "surface": config.surface.model_dump(mode="json"),
+        "runs": run_summaries,
+    }
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+    return manifest_path
 
 
 # --------------------------------------------------------------------------

--- a/MechInterp/cli.py
+++ b/MechInterp/cli.py
@@ -11,6 +11,7 @@ Verbs:
   extract     generate + capture hidden states to safetensors + manifest.
   probe_fit   fit a linear readout from extracted activations and freeze it.
   steer       run the six-block steer cell (smoke-gated).
+  dose_calibrate run a resumable dose ladder over frozen readouts.
   score_gates evaluate a gates.yaml against a per-row output JSONL.
 
 The steer and extract verbs touch a GPU; they refuse to run without an explicit
@@ -20,6 +21,7 @@ acknowledgement flag so a recipe never surprises a shared machine.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Callable, Optional
 
@@ -27,9 +29,11 @@ import numpy as np
 
 from MechInterp import cell as cell_mod
 from MechInterp.config import (
+    DoseCalibrationConfig,
     SteerCellConfig,
     ExtractConfig,
     ProbeFitConfig,
+    load_dose_calibration_config,
     load_steer_config,
     load_extract_config,
     load_probe_fit_config,
@@ -511,6 +515,191 @@ def run_steer(
     handle.remove()
     cell_mod.write_manifest(out_path, config, config_sha, arm_summaries)
     print(f"Steer cell complete. Output {out_path}, config_sha {config_sha}")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# dose_calibrate
+# --------------------------------------------------------------------------
+
+
+def _target_readout_names(config: DoseCalibrationConfig) -> list[str]:
+    if config.law.readout == "*":
+        return [readout.name for readout in config.readouts]
+    return [config.law.readout]
+
+
+def _strength_for_dose(config: DoseCalibrationConfig, dose: float, sigma: float) -> float:
+    if config.calibration.dose_kind == "strength":
+        return float(dose)
+    if config.law.kind == "erase_write":
+        return float(dose) / float(sigma or 1.0)
+    return float(dose)
+
+
+def _readback_for_record(readback: dict | None, row_index: int) -> dict:
+    if not readback:
+        return {}
+    active_rows = [int(i) for i in readback.get("active_rows", [])]
+    if row_index not in active_rows:
+        return {
+            "readback_offtarget_abs_max": readback.get("offtarget_abs_max"),
+            "readback_offtarget_abs_mean": readback.get("offtarget_abs_mean"),
+        }
+    idx = active_rows.index(row_index)
+    commanded = readback.get("commanded", [])
+    measured = readback.get("measured", [])
+    return {
+        "readback_commanded": commanded[idx] if idx < len(commanded) else None,
+        "readback_measured": measured[idx] if idx < len(measured) else None,
+        "readback_offtarget_abs_max": readback.get("offtarget_abs_max"),
+        "readback_offtarget_abs_mean": readback.get("offtarget_abs_mean"),
+    }
+
+
+def _write_checkpoint_record(handle, rec: dict) -> None:
+    handle.write(json.dumps(rec) + "\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
+def run_dose_calibration(
+    config: DoseCalibrationConfig,
+    model_name: str,
+    adapter: Optional[str],
+    render_fn_spec: str,
+    gpu_ack: bool,
+) -> int:
+    guard = _require_gpu_ack(gpu_ack)
+    if guard is not None:
+        return guard
+    import torch
+
+    from MechInterp.intervention import (
+        GenerationInterventionController,
+        InterventionHook,
+        get_decoder_layer,
+    )
+    from MechInterp.grading import load_grader
+    from MechInterp.probe import load_frozen_direction
+
+    config_sha = cell_mod.compute_config_sha(config)
+    if (
+        config.surface.expected_config_sha
+        and config.surface.expected_config_sha != config_sha
+    ):
+        print(
+            f"Config sha mismatch: expected {config.surface.expected_config_sha}, "
+            f"got {config_sha}. Aborting."
+        )
+        return 3
+
+    rows = cell_mod.load_jsonl(config.surface.rows_path)
+    render_fn = _load_callable(render_fn_spec)
+    grader = load_grader(config.execution.grader) if config.execution.grader else None
+    readout_by_name = {
+        readout.name: load_frozen_direction(readout.path)
+        for readout in config.readouts
+    }
+
+    model, tokenizer = _load_model_and_tokenizer(model_name, adapter)
+    out_path = Path(config.execution.output_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path = Path(config.execution.summary_path)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+
+    run_summaries = {}
+    with open(out_path, "a") as out:
+        for readout_name in _target_readout_names(config):
+            readout = readout_by_name[readout_name]
+            layer = config.law.layer if config.law.layer is not None else readout["layer"]
+            sigma = float(readout.get("sigma", 1.0))
+            direction = _direction_tensor(readout)
+            hook = InterventionHook(
+                law=config.law.kind,
+                direction=direction,
+                sigma=sigma,
+                position=config.law.position,
+                measure_readback=True,
+            )
+            controller = GenerationInterventionController(hook)
+            layer_module = get_decoder_layer(model, layer)
+            handle = layer_module.register_forward_hook(controller)
+            try:
+                for dose in config.calibration.doses:
+                    strength = _strength_for_dose(config, float(dose), sigma)
+                    pending = cell_mod.dose_pending_rows(
+                        rows,
+                        out_path,
+                        resume=config.execution.resume,
+                        readout=readout_name,
+                        dose=float(dose),
+                        strength=strength,
+                        selection=config.calibration.selection,
+                        write_at_zero=False,
+                    )
+                    run_summaries[f"{readout_name}:{float(dose):.17g}"] = {
+                        "layer": layer,
+                        "sigma": sigma,
+                        "strength": strength,
+                        "n_pending": len(pending),
+                    }
+                    for start in range(0, len(pending), config.execution.batch_size):
+                        chunk = pending[start : start + config.execution.batch_size]
+                        hook.last_readback = None
+                        if len(chunk) == 1:
+                            recs = [
+                                _run_one_pass(
+                                    model,
+                                    tokenizer,
+                                    controller,
+                                    chunk[0],
+                                    config.surface.generation,
+                                    config.law.generation_mode,
+                                    render_fn,
+                                )
+                            ]
+                        else:
+                            recs = _run_batch(
+                                model,
+                                tokenizer,
+                                controller,
+                                chunk,
+                                config.surface.generation,
+                                config.law.generation_mode,
+                                render_fn,
+                            )
+                        readback = hook.last_readback
+                        for idx, rec in enumerate(recs):
+                            rec.update(
+                                {
+                                    "readout": readout_name,
+                                    "readout_path": next(
+                                        r.path for r in config.readouts if r.name == readout_name
+                                    ),
+                                    "layer": layer,
+                                    "dose": float(dose),
+                                    "dose_kind": config.calibration.dose_kind,
+                                    "sigma": sigma,
+                                    "config_sha": config_sha,
+                                }
+                            )
+                            rec.update(_readback_for_record(readback, idx))
+                            if grader is not None:
+                                rec.update(grader(rec))
+                            _write_checkpoint_record(out, rec)
+            finally:
+                handle.remove()
+
+    summary = cell_mod.summarize_dose_calibration(out_path)
+    summary["config_sha"] = config_sha
+    with open(summary_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    cell_mod.write_dose_manifest(out_path, config, config_sha, run_summaries)
+    print(
+        f"Dose calibration complete. Output {out_path}, summary {summary_path}, "
+        f"config_sha {config_sha}"
+    )
     return 0
 
 

--- a/MechInterp/config.py
+++ b/MechInterp/config.py
@@ -234,6 +234,89 @@ class SteerCellConfig(BaseModel):
 
 
 # --------------------------------------------------------------------------
+# Dose calibration
+# --------------------------------------------------------------------------
+
+
+class DoseCalibrationSelection(BaseModel):
+    """Optional row-selection rule for applying a calibration dose.
+
+    Every row is still emitted to the checkpoint JSONL. The selection rule only
+    decides whether the intervention law is active for that row at the current
+    dose. With no selector, every row is active.
+    """
+
+    score_field: Optional[str] = None
+    threshold: Optional[float] = None
+    flag_field: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _valid_selection(self) -> "DoseCalibrationSelection":
+        if self.score_field is not None and self.threshold is None:
+            raise ValueError("dose calibration selection: score_field requires threshold")
+        if self.score_field is not None and self.flag_field is not None:
+            raise ValueError(
+                "dose calibration selection: score_field and flag_field are mutually exclusive"
+            )
+        return self
+
+
+class DoseCalibrationBlock(BaseModel):
+    """Dose ladder and optional selection rule for a calibration run."""
+
+    doses: list[float] = Field(..., min_length=1)
+    dose_kind: Literal["setpoint", "strength"] = Field(
+        default="setpoint",
+        description=(
+            "For erase_write, setpoint means each dose is an absolute projection "
+            "target and is converted to strength=dose/sigma. strength passes "
+            "the dose directly to the intervention hook."
+        ),
+    )
+    selection: DoseCalibrationSelection = Field(
+        default_factory=DoseCalibrationSelection
+    )
+
+
+class DoseCalibrationExecution(BaseModel):
+    """Run controls for generic dose calibration."""
+
+    output_path: str = Field(
+        ..., min_length=1, description="Per-row checkpoint JSONL"
+    )
+    summary_path: str = Field(
+        ..., min_length=1, description="Aggregated summary JSON"
+    )
+    resume: bool = True
+    render_fn: Optional[str] = Field(
+        default=None, description="Prompt render callable 'module.path:callable'"
+    )
+    grader: Optional[str] = Field(
+        default=None, description="Optional grader spec 'module.path:callable'"
+    )
+    batch_size: int = Field(default=1, ge=1)
+
+
+class DoseCalibrationConfig(BaseModel):
+    """Generic resumable dose calibration over readouts and dose rungs."""
+
+    surface: SurfaceConfig
+    readouts: list[ReadoutRef] = Field(..., min_length=1)
+    law: LawConfig
+    calibration: DoseCalibrationBlock
+    execution: DoseCalibrationExecution
+
+    @model_validator(mode="after")
+    def _readout_exists(self) -> "DoseCalibrationConfig":
+        names = {r.name for r in self.readouts}
+        if self.law.readout != "*" and self.law.readout not in names:
+            raise ValueError(
+                f"law.readout {self.law.readout!r} is not a declared readout"
+            )
+        return self
+
+
+# --------------------------------------------------------------------------
 # Extraction and probe-fit
 # --------------------------------------------------------------------------
 
@@ -289,3 +372,7 @@ def load_extract_config(path: str | Path) -> ExtractConfig:
 
 def load_probe_fit_config(path: str | Path) -> ProbeFitConfig:
     return ProbeFitConfig(**_load_yaml(path))
+
+
+def load_dose_calibration_config(path: str | Path) -> DoseCalibrationConfig:
+    return DoseCalibrationConfig(**_load_yaml(path))

--- a/MechInterp/configs/templates/dose_calibration.yaml
+++ b/MechInterp/configs/templates/dose_calibration.yaml
@@ -1,0 +1,25 @@
+surface:
+  rows_path: data/calibration_rows.jsonl
+  seed: 0
+  generation:
+    max_new_tokens: 96
+    do_sample: false
+readouts:
+  - name: axis
+    path: artifacts/direction.json
+law:
+  kind: erase_write
+  readout: "*"
+  position: anchor_onward
+  generation_mode: gen_stream
+calibration:
+  doses: [25, 50, 75, 100]
+  dose_kind: setpoint
+  selection: {}
+execution:
+  output_path: runs/dose_calibration/checkpoints.jsonl
+  summary_path: runs/dose_calibration/summary.json
+  resume: true
+  render_fn: project.render:prompt
+  grader: null
+  batch_size: 1

--- a/MechInterp/pipeline.py
+++ b/MechInterp/pipeline.py
@@ -22,6 +22,7 @@ StageKind = Literal[
     "mechinterp.extract",
     "mechinterp.probe-fit",
     "mechinterp.steer",
+    "mechinterp.dose-calibrate",
     "mechinterp.score-gates",
 ]
 
@@ -84,7 +85,12 @@ class StageConfig(BaseModel):
                 f"stage {self.name}: string commands require shell: true; "
                 "use a list argv for shell-free execution"
             )
-        if self.kind in {"mechinterp.extract", "mechinterp.probe-fit", "mechinterp.steer"} and not self.config:
+        if self.kind in {
+            "mechinterp.extract",
+            "mechinterp.probe-fit",
+            "mechinterp.steer",
+            "mechinterp.dose-calibrate",
+        } and not self.config:
             raise ValueError(f"stage {self.name}: config is required")
         if self.kind == "mechinterp.score-gates" and (
             not self.gates_config or not self.rows_path
@@ -161,14 +167,21 @@ def _repo_path(repo_root: Path, path: str) -> Path:
     return p if p.is_absolute() else repo_root / p
 
 
-def _steer_render_fn(stage: StageConfig, repo_root: Path) -> str | None:
+def _execution_render_fn(stage: StageConfig, repo_root: Path) -> str | None:
     if stage.render_fn:
         return stage.render_fn
     if not stage.config:
         return None
     try:
-        from MechInterp.config import load_steer_config
+        from MechInterp.config import (
+            load_dose_calibration_config,
+            load_steer_config,
+        )
 
+        if stage.kind == "mechinterp.dose-calibrate":
+            return load_dose_calibration_config(
+                _repo_path(repo_root, stage.config)
+            ).execution.render_fn
         return load_steer_config(_repo_path(repo_root, stage.config)).execution.render_fn
     except Exception:
         return None
@@ -229,7 +242,7 @@ def compile_stage_command(
             _stage_model(cfg, stage),
         ]
         adapter = _stage_adapter(cfg, stage)
-        render_fn = _steer_render_fn(stage, repo_root)
+        render_fn = _execution_render_fn(stage, repo_root)
         if adapter:
             cmd.extend(["--adapter", adapter])
         if render_fn:
@@ -238,6 +251,27 @@ def compile_stage_command(
             cmd.append("--i-know-this-runs-on-gpu")
         if force:
             cmd.append("--force-full-run")
+        return cmd
+
+    if stage.kind == "mechinterp.dose-calibrate":
+        cmd = [
+            python,
+            tuner,
+            "mechinterp",
+            "dose-calibrate",
+            "--mi-config",
+            str(stage.config),
+            "--model",
+            _stage_model(cfg, stage),
+        ]
+        adapter = _stage_adapter(cfg, stage)
+        render_fn = _execution_render_fn(stage, repo_root)
+        if adapter:
+            cmd.extend(["--adapter", adapter])
+        if render_fn:
+            cmd.extend(["--render-fn", render_fn])
+        if gpu_ack:
+            cmd.append("--i-know-this-runs-on-gpu")
         return cmd
 
     if stage.kind == "mechinterp.score-gates":

--- a/tests/mech_interp/test_config.py
+++ b/tests/mech_interp/test_config.py
@@ -5,6 +5,7 @@ import yaml
 
 from MechInterp.config import (
     SteerCellConfig,
+    load_dose_calibration_config,
     load_steer_config,
     load_extract_config,
     load_probe_fit_config,
@@ -130,6 +131,8 @@ def test_bundled_templates_parse(tmp_path):
     assert extract.families
     probe = load_probe_fit_config(tdir / "probe_fit.yaml")
     assert probe.n_components > 0
+    dose = load_dose_calibration_config(tdir / "dose_calibration.yaml")
+    assert dose.calibration.doses
 
 
 def test_load_steer_config_roundtrip(tmp_path):

--- a/tests/mech_interp/test_dose_calibration.py
+++ b/tests/mech_interp/test_dose_calibration.py
@@ -1,0 +1,296 @@
+"""CPU expectation tests for generic MechInterp dose calibration."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import yaml
+
+from MechInterp import cell as cell_mod
+from MechInterp import config as config_mod
+from MechInterp.pipeline import PipelineConfig, build_pipeline_plan
+
+
+def _required_config_api():
+    names = [
+        "DoseCalibrationConfig",
+        "DoseCalibrationSelection",
+        "DoseCalibrationBlock",
+        "DoseCalibrationExecution",
+        "load_dose_calibration_config",
+    ]
+    missing = [name for name in names if not hasattr(config_mod, name)]
+    assert not missing, f"missing dose calibration config API: {missing}"
+    return config_mod.DoseCalibrationConfig, config_mod.load_dose_calibration_config
+
+
+def _required_cell_api():
+    names = [
+        "dose_completed_keys",
+        "dose_pending_rows",
+        "summarize_dose_calibration",
+        "write_dose_manifest",
+    ]
+    missing = [name for name in names if not hasattr(cell_mod, name)]
+    assert not missing, f"missing dose calibration cell API: {missing}"
+    return {name: getattr(cell_mod, name) for name in names}
+
+
+def _minimal_dose_dict(tmp_path):
+    return {
+        "surface": {
+            "rows_path": str(tmp_path / "rows.jsonl"),
+            "generation": {"max_new_tokens": 8, "do_sample": False},
+            "seed": 7,
+        },
+        "readouts": [
+            {"name": "axis", "path": str(tmp_path / "axis.json")},
+            {"name": "other", "path": str(tmp_path / "other.json")},
+        ],
+        "law": {
+            "kind": "additive",
+            "readout": "axis",
+            "position": "anchor",
+            "generation_mode": "anchor",
+        },
+        "calibration": {
+            "doses": [0.0, 0.5, 1.0],
+            "dose_kind": "strength",
+            "selection": {},
+        },
+        "execution": {
+            "output_path": str(tmp_path / "dose_rows.jsonl"),
+            "summary_path": str(tmp_path / "dose_summary.json"),
+            "render_fn": "tests.fixtures:render",
+            "grader": "tests.fixtures:grade",
+        },
+    }
+
+
+def _rows():
+    return [
+        {"row_key": "a", "question": "A?"},
+        {"row_key": "b", "question": "B?"},
+    ]
+
+
+def _write_jsonl(path, records):
+    path.write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def test_dose_config_parses_defaults_and_loader(tmp_path):
+    DoseCalibrationConfig, load_dose_calibration_config = _required_config_api()
+    data = _minimal_dose_dict(tmp_path)
+    cfg = DoseCalibrationConfig(**data)
+
+    assert cfg.law.readout == "axis"
+    assert cfg.calibration.doses == [0.0, 0.5, 1.0]
+    assert cfg.calibration.dose_kind == "strength"
+    assert cfg.execution.resume is True
+    assert cfg.execution.batch_size == 1
+
+    path = tmp_path / "dose.yaml"
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    loaded = load_dose_calibration_config(path)
+    assert loaded.execution.output_path == str(tmp_path / "dose_rows.jsonl")
+
+
+def test_dose_config_accepts_setpoint_dose_kind(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    data = _minimal_dose_dict(tmp_path)
+    data["calibration"]["dose_kind"] = "setpoint"
+    cfg = DoseCalibrationConfig(**data)
+    assert cfg.calibration.dose_kind == "setpoint"
+
+
+def test_dose_law_readout_must_be_declared(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    data = _minimal_dose_dict(tmp_path)
+    data["law"]["readout"] = "missing"
+    with pytest.raises(ValueError):
+        DoseCalibrationConfig(**data)
+
+
+def test_dose_completed_keys_are_readout_dose_row_triples(tmp_path):
+    api = _required_cell_api()
+    out = tmp_path / "dose_rows.jsonl"
+    _write_jsonl(
+        out,
+        [
+            {"readout": "axis", "dose": 0.5, "row_key": "a"},
+            {"readout": "axis", "dose": 1.0, "row_key": "a"},
+            {"readout": "other", "dose": 0.5, "row_key": "a"},
+        ],
+    )
+
+    assert api["dose_completed_keys"](out) == {
+        ("axis", "0.5", "a"),
+        ("axis", "1", "a"),
+        ("other", "0.5", "a"),
+    }
+
+
+def test_dose_pending_rows_skip_only_completed_readout_dose_row_keys(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    api = _required_cell_api()
+    cfg = DoseCalibrationConfig(**_minimal_dose_dict(tmp_path))
+    out = tmp_path / "dose_rows.jsonl"
+    _write_jsonl(out, [{"readout": "axis", "dose": 0.5, "row_key": "a"}])
+
+    selection = cfg.calibration.selection
+    pending_axis_half = api["dose_pending_rows"](
+        _rows(),
+        out,
+        resume=True,
+        readout="axis",
+        dose=0.5,
+        strength=0.5,
+        selection=selection,
+    )
+    pending_axis_one = api["dose_pending_rows"](
+        _rows(),
+        out,
+        resume=True,
+        readout="axis",
+        dose=1.0,
+        strength=1.0,
+        selection=selection,
+    )
+    pending_other_half = api["dose_pending_rows"](
+        _rows(),
+        out,
+        resume=True,
+        readout="other",
+        dose=0.5,
+        strength=0.5,
+        selection=selection,
+    )
+
+    assert {r["row_key"] for r in pending_axis_half} == {"b"}
+    assert {r["row_key"] for r in pending_axis_one} == {"a", "b"}
+    assert {r["row_key"] for r in pending_other_half} == {"a", "b"}
+
+
+def test_dose_pending_rows_no_resume_runs_all_combinations(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    api = _required_cell_api()
+    cfg = DoseCalibrationConfig(**_minimal_dose_dict(tmp_path))
+    out = tmp_path / "dose_rows.jsonl"
+    _write_jsonl(out, [{"readout": "axis", "dose": 0.5, "row_key": "a"}])
+
+    pending = api["dose_pending_rows"](
+        _rows(),
+        out,
+        resume=False,
+        readout="axis",
+        dose=0.5,
+        strength=0.5,
+        selection=cfg.calibration.selection,
+    )
+
+    assert {r["row_key"] for r in pending} == {"a", "b"}
+
+
+def test_dose_summary_aggregates_boolean_grader_fields_by_readout_and_dose(tmp_path):
+    api = _required_cell_api()
+    out = tmp_path / "dose_rows.jsonl"
+    _write_jsonl(
+        out,
+        [
+            {
+                "readout": "axis",
+                "dose": 0.5,
+                "row_key": "a",
+                "active": True,
+                "correct": True,
+                "refusal": False,
+            },
+            {
+                "readout": "axis",
+                "dose": 0.5,
+                "row_key": "b",
+                "active": True,
+                "correct": False,
+                "refusal": False,
+            },
+            {
+                "readout": "axis",
+                "dose": 1.0,
+                "row_key": "a",
+                "active": True,
+                "correct": True,
+                "refusal": True,
+            },
+            {
+                "readout": "other",
+                "dose": 0.5,
+                "row_key": "a",
+                "active": True,
+                "correct": True,
+                "refusal": False,
+            },
+        ],
+    )
+
+    summary = api["summarize_dose_calibration"](out)
+
+    groups = {
+        (group["readout"], group["dose"]): group for group in summary["groups"]
+    }
+
+    assert summary["n_records"] == 4
+    assert groups[("axis", 0.5)]["n"] == 2
+    assert groups[("axis", 0.5)]["bool_metrics"]["correct"]["true"] == 1
+    assert groups[("axis", 0.5)]["bool_metrics"]["correct"]["rate"] == pytest.approx(0.5)
+    assert groups[("axis", 0.5)]["bool_metrics"]["refusal"]["true"] == 0
+    assert groups[("axis", 1.0)]["bool_metrics"]["refusal"]["rate"] == pytest.approx(1.0)
+    assert groups[("other", 0.5)]["bool_metrics"]["correct"]["rate"] == pytest.approx(1.0)
+
+
+def test_write_dose_manifest_records_config_and_summary_paths(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    api = _required_cell_api()
+    cfg = DoseCalibrationConfig(**_minimal_dose_dict(tmp_path))
+    summary = {"axis": {"0.5": {"n": 2}}}
+
+    manifest_path = api["write_dose_manifest"](
+        cfg.execution.output_path,
+        cfg,
+        config_sha="abc123",
+        run_summaries=summary,
+    )
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["config_sha"] == "abc123"
+    assert manifest["calibration"]["doses"] == [0.0, 0.5, 1.0]
+    assert manifest["runs"] == summary
+
+
+def test_pipeline_compiles_dose_calibrate_with_gpu_ack(tmp_path):
+    cfg_path = tmp_path / "dose.yaml"
+    cfg_path.write_text(yaml.safe_dump(_minimal_dose_dict(tmp_path)), encoding="utf-8")
+    cfg = PipelineConfig(
+        name="dose",
+        model="Tiny/Model",
+        runtime={"python": "python"},
+        stages=[
+            {
+                "name": "dose",
+                "kind": "mechinterp.dose-calibrate",
+                "config": str(cfg_path),
+            }
+        ],
+    )
+
+    plan = build_pipeline_plan(cfg, repo_root=tmp_path, provider="local", gpu_ack=True)
+    cmd = plan["stages"][0]["command"]
+
+    assert cmd[:4] == ["python", str(tmp_path / "tuner.py"), "mechinterp", "dose-calibrate"]
+    assert "--mi-config" in cmd
+    assert str(cfg_path) in cmd
+    assert cmd[cmd.index("--model") + 1] == "Tiny/Model"
+    assert "--i-know-this-runs-on-gpu" in cmd

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -425,11 +425,11 @@ Examples:
     parser.add_argument("--dirs-only", action="store_true", help="For bucket list, show directories only.")
     parser.add_argument("--follow", action="store_true", help="Stream live logs for cloud-jobs logs.")
 
-    # MechInterp flags (extract / probe-fit / steer / score-gates sub-commands)
+    # MechInterp flags (extract / probe-fit / steer / dose-calibrate / score-gates sub-commands)
     parser.add_argument(
         "--mi-config",
         dest="mechinterp_config",
-        help="Path to a MechInterp recipe YAML (mechinterp extract/probe-fit/steer)",
+        help="Path to a MechInterp recipe YAML (mechinterp extract/probe-fit/steer/dose-calibrate)",
     )
     parser.add_argument(
         "--pipeline-config",
@@ -439,7 +439,7 @@ Examples:
     parser.add_argument(
         "--render-fn",
         dest="render_fn",
-        help="Prompt render callable 'module.path:callable' (mechinterp steer/extract)",
+        help="Prompt render callable 'module.path:callable' (mechinterp steer/extract/dose-calibrate)",
     )
     parser.add_argument(
         "--adapter",
@@ -466,7 +466,7 @@ Examples:
         "--i-know-this-runs-on-gpu",
         dest="i_know_this_runs_on_gpu",
         action="store_true",
-        help="Acknowledge that mechinterp extract/steer load a model and use a GPU.",
+        help="Acknowledge that mechinterp extract/steer/dose-calibrate load a model and use a GPU.",
     )
     parser.add_argument(
         "--force-full-run",

--- a/tuner/handlers/mechinterp_handler.py
+++ b/tuner/handlers/mechinterp_handler.py
@@ -1,7 +1,8 @@
 """
 Mech-interp handler for the Synaptic Tuner CLI.
 
-Purpose: orchestrate the MechInterp verbs (extract, probe-fit, steer, score-gates)
+Purpose: orchestrate the MechInterp verbs (extract, probe-fit, steer,
+dose-calibrate, score-gates)
 Used by: router when the 'mechinterp' command is invoked.
 
 Each sub-command is recipe-YAML driven, mirroring the other config-first verbs.
@@ -14,6 +15,7 @@ Sub-commands:
   extract      generate + capture hidden states to safetensors + manifest
   probe-fit    fit a linear readout and freeze a direction JSON
   steer        run the six-block steer cell (smoke-gated)
+  dose-calibrate resumable dose ladder over one or more frozen readouts
   score-gates  evaluate a gates.yaml against a per-row output JSONL
   list-configs show bundled example recipes
 """
@@ -63,12 +65,14 @@ class MechInterpHandler(BaseHandler):
             return self._handle_probe_fit()
         if sub == "steer":
             return self._handle_steer()
+        if sub == "dose-calibrate":
+            return self._handle_dose_calibrate()
         if sub == "score-gates":
             return self._handle_score_gates()
 
         msg = (
             "mechinterp requires a sub-command: run, extract, probe-fit, steer, "
-            "score-gates, list-configs"
+            "dose-calibrate, score-gates, list-configs"
         )
         if self.json_mode:
             self.output_error(msg, code="SUBCOMMAND_REQUIRED")
@@ -298,6 +302,30 @@ class MechInterpHandler(BaseHandler):
             render_fn_spec=render_fn,
             gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
             force=bool(self._arg("force_full_run", False)),
+        )
+
+    def _handle_dose_calibrate(self) -> int:
+        from MechInterp.cli import run_dose_calibration
+        from MechInterp.config import load_dose_calibration_config
+
+        config_path = self._require("mechinterp_config", "--mi-config")
+        model = self._require("model", "--model")
+        if not config_path or not model:
+            return 1
+        config = load_dose_calibration_config(config_path)
+        render_fn = self._arg("render_fn") or config.execution.render_fn
+        if not render_fn:
+            self.output_error(
+                "dose-calibrate requires execution.render_fn in the config or --render-fn",
+                code="ARG_REQUIRED",
+            )
+            return 1
+        return run_dose_calibration(
+            config,
+            model_name=model,
+            adapter=self._arg("adapter"),
+            render_fn_spec=render_fn,
+            gpu_ack=bool(self._arg("i_know_this_runs_on_gpu", False)),
         )
 
     def _handle_score_gates(self) -> int:


### PR DESCRIPTION
## Summary
- Add a config-driven `mechinterp dose-calibrate` verb for frozen readout dose ladders
- Write per-row JSONL checkpoints keyed by readout/dose/row for crash-safe resume
- Emit aggregate summaries/manifests and support `mechinterp.dose-calibrate` pipeline stages
- Add a bundled dose-calibration template and CPU tests

## Tests
- `pytest tests/mech_interp -q`