### PR TITLE
Add RunLog: resumable per-item run log for long evaluation loops

### DIFF
--- a/MechInterp/cli.py
+++ b/MechInterp/cli.py
@@ -234,6 +234,27 @@ def _passthrough_fields(row: dict) -> dict:
     }
 
 
+def _redact_record_fields(value, redact_fields: set[str]):
+    if not redact_fields:
+        return value
+    if isinstance(value, dict):
+        return {
+            k: _redact_record_fields(v, redact_fields)
+            for k, v in value.items()
+            if k not in redact_fields
+        }
+    if isinstance(value, list):
+        return [_redact_record_fields(v, redact_fields) for v in value]
+    return value
+
+
+def _write_checkpoint_record(handle, rec: dict, redact_fields: set[str] | None = None) -> None:
+    rec = _redact_record_fields(rec, redact_fields or set())
+    handle.write(json.dumps(rec) + "\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+
+
 def _run_one_pass(
     model,
     tokenizer,
@@ -476,6 +497,7 @@ def run_steer(
     out_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(out_path, "a") as out:
+        redact_fields = set(config.execution.redact_fields)
         for arm in config.arms:
             strengths = strengths_by_arm[arm.name]
             # A gain_field arm always writes at its computed value even when
@@ -498,7 +520,7 @@ def run_steer(
                     rec["arm"] = arm.name
                     if grader is not None:
                         rec.update(grader(rec))
-                    out.write(json.dumps(rec) + "\n")
+                    _write_checkpoint_record(out, rec, redact_fields)
             else:
                 for i in range(0, len(pending), batch_size):
                     chunk = pending[i : i + batch_size]
@@ -510,7 +532,7 @@ def run_steer(
                         rec["arm"] = arm.name
                         if grader is not None:
                             rec.update(grader(rec))
-                        out.write(json.dumps(rec) + "\n")
+                        _write_checkpoint_record(out, rec, redact_fields)
 
     handle.remove()
     cell_mod.write_manifest(out_path, config, config_sha, arm_summaries)
@@ -555,12 +577,6 @@ def _readback_for_record(readback: dict | None, row_index: int) -> dict:
         "readback_offtarget_abs_max": readback.get("offtarget_abs_max"),
         "readback_offtarget_abs_mean": readback.get("offtarget_abs_mean"),
     }
-
-
-def _write_checkpoint_record(handle, rec: dict) -> None:
-    handle.write(json.dumps(rec) + "\n")
-    handle.flush()
-    os.fsync(handle.fileno())
 
 
 def run_dose_calibration(
@@ -610,6 +626,7 @@ def run_dose_calibration(
 
     run_summaries = {}
     with open(out_path, "a") as out:
+        redact_fields = set(config.execution.redact_fields)
         for readout_name in _target_readout_names(config):
             readout = readout_by_name[readout_name]
             layer = config.law.layer if config.law.layer is not None else readout["layer"]
@@ -687,7 +704,7 @@ def run_dose_calibration(
                             rec.update(_readback_for_record(readback, idx))
                             if grader is not None:
                                 rec.update(grader(rec))
-                            _write_checkpoint_record(out, rec)
+                            _write_checkpoint_record(out, rec, redact_fields)
             finally:
                 handle.remove()
 

--- a/MechInterp/config.py
+++ b/MechInterp/config.py
@@ -203,6 +203,15 @@ class ExecutionConfig(BaseModel):
             "_run_batch and its equivalence tests for the correctness contract."
         ),
     )
+    redact_fields: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional recursive field names to drop before writing per-row "
+            "checkpoint/output JSONL records. Use this for restricted row "
+            "metadata or generated text fields that are needed during grading "
+            "but must not persist in resumable artifacts."
+        ),
+    )
 
 
 class SteerCellConfig(BaseModel):
@@ -295,6 +304,13 @@ class DoseCalibrationExecution(BaseModel):
         default=None, description="Optional grader spec 'module.path:callable'"
     )
     batch_size: int = Field(default=1, ge=1)
+    redact_fields: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Optional recursive field names to drop before writing per-row "
+            "checkpoint/output JSONL records."
+        ),
+    )
 
 
 class DoseCalibrationConfig(BaseModel):

--- a/MechInterp/configs/templates/dose_calibration.yaml
+++ b/MechInterp/configs/templates/dose_calibration.yaml
@@ -23,3 +23,6 @@ execution:
   render_fn: project.render:prompt
   grader: null
   batch_size: 1
+  # Optional recursive drop list for restricted per-row artifacts.
+  # Example: [answer_text, aliases, answer_value, raw_output]
+  redact_fields: []

--- a/MechInterp/configs/templates/steer_cell.yaml
+++ b/MechInterp/configs/templates/steer_cell.yaml
@@ -60,6 +60,9 @@ execution:
   output_path: MechInterp/runs/example/rows.jsonl
   resume: true
   grader: MechInterp.grading.interface:example_grader
+  # Optional recursive drop list for restricted per-row artifacts.
+  # Example: [answer_text, aliases, answer_value, raw_output]
+  redact_fields: []
 
 # 6. smoke: readback tolerances that gate the full arms.
 smoke:

--- a/shared/utilities/run_log.py
+++ b/shared/utilities/run_log.py
@@ -1,0 +1,224 @@
+"""Resumable per-item run log for long evaluation loops.
+
+A multi-hour per-item evaluation loop (generate, then grade, one row at a
+time) that buffers every result in memory and writes output only at the end
+loses the entire run to a crash in the final stretch. ``RunLog`` gives such
+a loop a durable, append-only per-item record plus an atomic summary write,
+so a killed process can be restarted and pick up exactly where it left off,
+and a separate process can peek at progress cheaply without disturbing the
+writer.
+
+Layout for a log opened at ``path``:
+
+- ``<path>``              append-only JSON-lines log, one record per item.
+- ``<path>.meta.json``    run identity: schema_version + a fingerprint over
+                          the run config, plus a completion flag.
+- ``<path>.summary.json`` final aggregate, written atomically by finalize().
+
+Keys are opaque strings. Composite keys (arm + row + dose, say) should be
+joined into a single string by the caller before calling record() /
+iter_pending() -- a JSON round trip cannot distinguish a tuple key from a
+list, so treating keys as anything but plain strings is a latent bug.
+
+Each record is appended with a flush + fsync. At the multi-second-per-item
+cadence typical of a generate-then-grade loop, the fsync cost (single-digit
+milliseconds) is immaterial next to the item cost, and it is what makes the
+log survive a hard kill: once record() returns, that item is durable on
+disk even if the process dies on the very next line.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Callable, Iterable, Iterator, TypeVar
+
+SCHEMA_VERSION = 1
+
+T = TypeVar("T")
+
+
+class RunLogError(RuntimeError):
+    """Raised when a run log cannot be safely opened, resumed, or written."""
+
+
+def _canonical_json(obj: Any) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _fingerprint(run_config: dict, schema_version: int) -> str:
+    payload = _canonical_json({"schema_version": schema_version, "run_config": run_config})
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _scan(path: Path, key_field: str) -> tuple[dict[str, dict], int]:
+    """Scan a JSONL log, returning ``{key: record}`` for well-formed lines
+    and the byte offset immediately following the last well-formed line.
+
+    A malformed FINAL line is the one shape of corruption a durable append
+    log admits: every prior line already reached fsync before the next
+    write began, so only the tail can be torn by a kill mid-append. That
+    line is dropped silently and the returned offset excludes it, so the
+    caller can truncate the file back to a clean state. A malformed line
+    that is NOT the final one means something other than a crash mid-append
+    corrupted the file, and this raises rather than silently discarding
+    history.
+    """
+    records: dict[str, dict] = {}
+    if not path.exists() or path.stat().st_size == 0:
+        return records, 0
+
+    data = path.read_bytes()
+    n = len(data)
+    good_end = 0
+    pos = 0
+    while pos < n:
+        newline_at = data.find(b"\n", pos)
+        is_final_chunk = newline_at == -1
+        end = n if is_final_chunk else newline_at
+        raw_line = data[pos:end]
+        line = raw_line.strip()
+        next_pos = n if is_final_chunk else newline_at + 1
+
+        if not line:
+            good_end = next_pos
+            pos = next_pos
+            continue
+
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            if is_final_chunk:
+                break
+            raise RunLogError(
+                f"malformed non-final line in run log {path} at byte offset "
+                f"{pos}; this is corruption beyond the tolerated "
+                "torn-final-line case and will not be silently discarded"
+            )
+
+        key = rec.get(key_field)
+        if key is not None:
+            records[str(key)] = rec
+        good_end = next_pos
+        pos = next_pos
+
+    return records, good_end
+
+
+class RunLog:
+    """Append-only, resumable per-item log for one evaluation run."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        run_config: dict,
+        *,
+        fresh: bool = False,
+        key_field: str = "key",
+    ) -> None:
+        self.path = Path(path)
+        self.meta_path = self.path.with_name(self.path.name + ".meta.json")
+        self.summary_path = self.path.with_name(self.path.name + ".summary.json")
+        self.key_field = key_field
+        self._fingerprint = _fingerprint(run_config, SCHEMA_VERSION)
+
+        if fresh:
+            for candidate in (self.path, self.meta_path, self.summary_path):
+                candidate.unlink(missing_ok=True)
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+        if self.meta_path.exists():
+            meta = json.loads(self.meta_path.read_text(encoding="utf-8"))
+            if meta.get("fingerprint") != self._fingerprint:
+                raise RunLogError(
+                    f"run_config fingerprint mismatch for {self.path}: this "
+                    "log was opened with a different run_config. Resume "
+                    "must be the same run -- use a new path, or pass "
+                    "fresh=True to intentionally start over."
+                )
+        else:
+            self._write_meta(complete=False)
+
+        self._records, good_end = _scan(self.path, self.key_field)
+        if self.path.exists() and self.path.stat().st_size > good_end:
+            # Torn final line from a kill mid-append: drop it before the
+            # next append lands.
+            with self.path.open("r+b") as fh:
+                fh.truncate(good_end)
+
+        self._fh = self.path.open("ab")
+
+    # -- lifecycle ---------------------------------------------------
+
+    def _write_meta(self, *, complete: bool) -> None:
+        meta = {
+            "schema_version": SCHEMA_VERSION,
+            "fingerprint": self._fingerprint,
+            "complete": complete,
+        }
+        tmp_path = self.meta_path.with_name(self.meta_path.name + ".tmp")
+        tmp_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        os.replace(tmp_path, self.meta_path)
+
+    def close(self) -> None:
+        if self._fh is not None and not self._fh.closed:
+            self._fh.close()
+
+    def __enter__(self) -> "RunLog":
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    # -- reading -------------------------------------------------------
+
+    def done_keys(self) -> set[str]:
+        """Completed item keys: the initial scan at open, kept current by
+        every record() call made through this instance."""
+        return set(self._records.keys())
+
+    def iter_pending(self, items: Iterable[T], key_fn: Callable[[T], Any]) -> Iterator[T]:
+        """Yield items from ``items`` whose key is not yet done, in order."""
+        done = self.done_keys()
+        for item in items:
+            if str(key_fn(item)) in done:
+                continue
+            yield item
+
+    @classmethod
+    def peek_done_keys(cls, path: str | Path, *, key_field: str = "key") -> set[str]:
+        """Read-only snapshot of completed keys.
+
+        Safe to call from another process while a RunLog writer is live on
+        the same path: this never opens the file for writing and never
+        truncates it, so it cannot race or corrupt the writer. A torn final
+        line from a writer mid-append is simply excluded from the snapshot.
+        """
+        records, _ = _scan(Path(path), key_field)
+        return set(records.keys())
+
+    # -- writing ---------------------------------------------------------
+
+    def record(self, key: str, payload: dict) -> None:
+        """Append one item's result. Durable on disk when this returns."""
+        rec = dict(payload)
+        rec[self.key_field] = key
+        line = json.dumps(rec, default=str) + "\n"
+        self._fh.write(line.encode("utf-8"))
+        self._fh.flush()
+        os.fsync(self._fh.fileno())
+        self._records[str(key)] = rec
+
+    def finalize(self, summary: dict) -> None:
+        """Atomically write the run's summary and mark the run complete."""
+        tmp_path = self.summary_path.with_name(self.summary_path.name + ".tmp")
+        data = json.dumps(summary, indent=2, default=str).encode("utf-8")
+        with tmp_path.open("wb") as fh:
+            fh.write(data)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_path, self.summary_path)
+        self._write_meta(complete=True)

--- a/tests/mech_interp/test_dose_calibration.py
+++ b/tests/mech_interp/test_dose_calibration.py
@@ -92,6 +92,7 @@ def test_dose_config_parses_defaults_and_loader(tmp_path):
     assert cfg.calibration.dose_kind == "strength"
     assert cfg.execution.resume is True
     assert cfg.execution.batch_size == 1
+    assert cfg.execution.redact_fields == []
 
     path = tmp_path / "dose.yaml"
     path.write_text(yaml.safe_dump(data), encoding="utf-8")
@@ -105,6 +106,14 @@ def test_dose_config_accepts_setpoint_dose_kind(tmp_path):
     data["calibration"]["dose_kind"] = "setpoint"
     cfg = DoseCalibrationConfig(**data)
     assert cfg.calibration.dose_kind == "setpoint"
+
+
+def test_dose_config_accepts_checkpoint_redaction_fields(tmp_path):
+    DoseCalibrationConfig, _ = _required_config_api()
+    data = _minimal_dose_dict(tmp_path)
+    data["execution"]["redact_fields"] = ["answer_text", "aliases"]
+    cfg = DoseCalibrationConfig(**data)
+    assert cfg.execution.redact_fields == ["answer_text", "aliases"]
 
 
 def test_dose_law_readout_must_be_declared(tmp_path):

--- a/tests/mech_interp/test_steer_record_passthrough.py
+++ b/tests/mech_interp/test_steer_record_passthrough.py
@@ -20,6 +20,8 @@ exercises the real generation path rather than a stub, then checks the
 returned record dict rather than the generated text.
 """
 
+import json
+
 from tests.mech_interp.test_batched_generation import (
     _build_controller,
     _build_tiny_model,
@@ -27,9 +29,13 @@ from tests.mech_interp.test_batched_generation import (
     _render,
 )
 
-from MechInterp.cli import _run_batch, _run_one_pass
+from MechInterp.cli import (
+    _redact_record_fields,
+    _run_batch,
+    _run_one_pass,
+    _write_checkpoint_record,
+)
 from MechInterp.config import GenerationContract
-from MechInterp.intervention import get_decoder_layer
 
 _LAYER_IDX = 0
 _MAX_NEW_TOKENS = 4
@@ -156,3 +162,41 @@ def test_grader_returns_none_when_aliases_absent_documenting_the_old_failure():
     # the pool row actually carried.
     grade = _grader({"answer_text": "w4 lives here"})
     assert grade["correct"] is None
+
+
+def test_record_redaction_is_recursive_and_opt_in():
+    rec = {
+        "row_key": "r0",
+        "answer_text": "generated",
+        "aliases": ["gold"],
+        "grade": {"answer_value": "decoded", "correct": True},
+        "nested": [{"answer_text": "inner", "keep": 1}],
+    }
+
+    redacted = _redact_record_fields(rec, {"answer_text", "aliases", "answer_value"})
+
+    assert redacted == {
+        "row_key": "r0",
+        "grade": {"correct": True},
+        "nested": [{"keep": 1}],
+    }
+    assert _redact_record_fields(rec, set()) is rec
+
+
+def test_checkpoint_writer_redacts_before_persisting(tmp_path):
+    path = tmp_path / "rows.jsonl"
+    with path.open("a", encoding="utf-8") as handle:
+        _write_checkpoint_record(
+            handle,
+            {
+                "row_key": "r0",
+                "answer_text": "generated",
+                "grade": {"answer_value": "decoded", "correct": True},
+            },
+            {"answer_text", "answer_value"},
+        )
+
+    [record] = [
+        json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert record == {"row_key": "r0", "grade": {"correct": True}}

--- a/tests/shared/utilities/test_run_log.py
+++ b/tests/shared/utilities/test_run_log.py
@@ -1,0 +1,191 @@
+"""Tests for shared/utilities/run_log.py -- resumable per-item run log."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from shared.utilities.run_log import RunLog, RunLogError
+
+
+CONFIG_A = {"arm": "baseline", "seed": 1}
+CONFIG_B = {"arm": "baseline", "seed": 2}
+
+
+class TestResume:
+    def test_resume_skips_done(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.record("row-2", {"score": 2})
+        log.close()
+
+        resumed = RunLog(log_path, CONFIG_A)
+        assert resumed.done_keys() == {"row-1", "row-2"}
+
+        items = ["row-1", "row-2", "row-3", "row-4"]
+        pending = list(resumed.iter_pending(items, key_fn=lambda x: x))
+        assert pending == ["row-3", "row-4"]
+        resumed.close()
+
+    def test_record_updates_done_keys_live(self, tmp_path: Path):
+        log = RunLog(tmp_path / "rows.jsonl", CONFIG_A)
+        assert log.done_keys() == set()
+        log.record("row-1", {"score": 1})
+        assert log.done_keys() == {"row-1"}
+        log.close()
+
+
+class TestTornFinalLine:
+    def test_torn_final_line_tolerated_and_truncated(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.close()
+
+        good_size = log_path.stat().st_size
+        # Simulate a kill mid-write: append a truncated JSON line with no
+        # trailing newline and no closing brace.
+        with log_path.open("ab") as fh:
+            fh.write(b'{"key": "row-2", "score": 2, "note": "unfinis')
+
+        assert log_path.stat().st_size > good_size
+
+        resumed = RunLog(log_path, CONFIG_A)
+        assert resumed.done_keys() == {"row-1"}
+        # The torn tail was dropped from disk before the next append.
+        assert log_path.stat().st_size == good_size
+
+        # And the log is writable again after the truncation.
+        resumed.record("row-2", {"score": 2})
+        resumed.close()
+
+        reread = RunLog(log_path, CONFIG_A)
+        assert reread.done_keys() == {"row-1", "row-2"}
+        reread.close()
+
+    def test_malformed_non_final_line_raises(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        log_path.write_text(
+            '{"key": "row-1", "score": 1}\nnot json at all\n{"key": "row-2"}\n',
+            encoding="utf-8",
+        )
+        with pytest.raises(RunLogError):
+            RunLog(log_path, CONFIG_A)
+
+
+class TestFingerprintMismatch:
+    def test_mismatched_config_refuses(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.close()
+
+        with pytest.raises(RunLogError):
+            RunLog(log_path, CONFIG_B)
+
+    def test_fresh_true_bypasses_mismatch(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.close()
+
+        fresh_log = RunLog(log_path, CONFIG_B, fresh=True)
+        assert fresh_log.done_keys() == set()
+        fresh_log.close()
+
+    def test_matching_config_reopens_cleanly(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        RunLog(log_path, CONFIG_A).close()
+        # Should not raise.
+        RunLog(log_path, CONFIG_A).close()
+
+
+class TestFinalizeAtomicity:
+    def test_summary_written_atomically(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.finalize({"n": 1, "mean": 1.0})
+
+        summary_path = log_path.with_name(log_path.name + ".summary.json")
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert data == {"n": 1, "mean": 1.0}
+
+        meta = json.loads((log_path.with_name(log_path.name + ".meta.json")).read_text())
+        assert meta["complete"] is True
+
+    def test_old_summary_intact_if_killed_between_tmp_and_replace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        log_path = tmp_path / "rows.jsonl"
+        log = RunLog(log_path, CONFIG_A)
+        log.record("row-1", {"score": 1})
+        log.finalize({"n": 1, "mean": 1.0})
+
+        summary_path = log_path.with_name(log_path.name + ".summary.json")
+        original_bytes = summary_path.read_bytes()
+
+        def _boom(*args, **kwargs):
+            raise OSError("simulated crash between tmp write and os.replace")
+
+        monkeypatch.setattr(os, "replace", _boom)
+        with pytest.raises(OSError):
+            log.finalize({"n": 2, "mean": 2.0})
+
+        # The prior summary is untouched: os.replace never ran.
+        assert summary_path.read_bytes() == original_bytes
+
+        tmp_summary = summary_path.with_name(summary_path.name + ".tmp")
+        assert tmp_summary.exists()
+        assert json.loads(tmp_summary.read_text())["n"] == 2
+
+
+class TestIterPendingStability:
+    def test_order_preserved_with_mixed_done_and_pending(self, tmp_path: Path):
+        log = RunLog(tmp_path / "rows.jsonl", CONFIG_A)
+        log.record("b", {})
+        log.record("d", {})
+
+        items = ["a", "b", "c", "d", "e"]
+        pending = list(log.iter_pending(items, key_fn=lambda x: x))
+        assert pending == ["a", "c", "e"]
+        log.close()
+
+    def test_iter_pending_empty_when_all_done(self, tmp_path: Path):
+        log = RunLog(tmp_path / "rows.jsonl", CONFIG_A)
+        for k in ["a", "b", "c"]:
+            log.record(k, {})
+        pending = list(log.iter_pending(["a", "b", "c"], key_fn=lambda x: x))
+        assert pending == []
+        log.close()
+
+
+class TestLiveReadWhileWriting:
+    def test_peek_done_keys_sees_flushed_records_without_disturbing_writer(
+        self, tmp_path: Path
+    ):
+        log_path = tmp_path / "rows.jsonl"
+        writer = RunLog(log_path, CONFIG_A)
+        writer.record("row-1", {"score": 1})
+
+        # A concurrent reader peeking at the same path while the writer is
+        # still open must see the flushed record and must not touch the file.
+        peeked = RunLog.peek_done_keys(log_path)
+        assert peeked == {"row-1"}
+
+        # The writer keeps working after being peeked at.
+        writer.record("row-2", {"score": 2})
+        writer.close()
+
+        final_peek = RunLog.peek_done_keys(log_path)
+        assert final_peek == {"row-1", "row-2"}
+
+    def test_peek_before_any_write_is_empty(self, tmp_path: Path):
+        log_path = tmp_path / "rows.jsonl"
+        assert RunLog.peek_done_keys(log_path) == set()


### PR DESCRIPTION
## Summary
Adds `shared/utilities/run_log.py`, a small stdlib-only resumable run log for long per-item evaluation loops, plus a full test suite (`tests/shared/utilities/test_run_log.py`, 13 tests).

A multi-hour loop that buffers all per-item results in memory and writes output only at the end loses everything to a crash in the final stretch. RunLog makes save-as-you-go the default:

- append one JSON line per item with flush + fsync (kill-safe at any instant)
- resume: `done_keys()` / `iter_pending()` skip completed items on reopen
- config fingerprint (sha256 of canonical run_config) refuses a resume against a different run unless `fresh=True`
- torn final line from a mid-append kill is detected, dropped, and truncated; a malformed non-final line raises loudly
- `finalize()` writes the summary atomically (tmp + os.replace); meta is rewritten atomically too
- `peek_done_keys()` classmethod for read-only progress inspection alongside a live writer

## Placement
`shared/utilities/` alongside paths/yaml_loader: stdlib-only, no torch import, project-agnostic. Not `shared/experiment_tracking/` (training-run/MLflow oriented) and not the mechinterp cell-specific checkpoint helpers (not reusable, no fsync/fingerprint/torn-line handling).

## Tests
13/13 new tests pass; the full tests/shared/utilities suite (61) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD