### PR TITLE
Add pinned CUDA runner image for local MechInterp GPU work

### DIFF
--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -33,6 +33,9 @@ RUN python3.10 -m venv /opt/venv
 # everything else resolves from PyPI. Versions were chosen to match the
 # already-validated Qwen3.5/Gemma-4 local stack (transformers 5.12.1, see
 # docs/sessions/0030 in the research repo) rather than picking latest-on-date.
+# scikit-learn is capped at 1.7.2, the newest release that still supports
+# Python 3.10 (1.8+ requires >=3.11); the base image ships Ubuntu 22.04's
+# stock Python 3.10.
 RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
     && /opt/venv/bin/pip install --no-cache-dir \
         torch==2.9.1 \
@@ -41,7 +44,7 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         transformers==5.12.1 \
         flash-linear-attention==0.5.1 \
         safetensors==0.8.0 \
-        scikit-learn==1.9.0 \
+        scikit-learn==1.7.2 \
         numpy==2.5.1 \
         pyyaml==6.0.3 \
         huggingface_hub==1.23.0

--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -34,8 +34,9 @@ RUN python3.10 -m venv /opt/venv
 # already-validated Qwen3.5/Gemma-4 local stack (transformers 5.12.1, see
 # docs/sessions/0030 in the research repo) rather than picking latest-on-date.
 # scikit-learn is capped at 1.7.2, the newest release that still supports
-# Python 3.10 (1.8+ requires >=3.11); the base image ships Ubuntu 22.04's
-# stock Python 3.10.
+# Python 3.10 (1.8+ requires >=3.11); numpy is capped at 2.2.6 for the same
+# reason (2.3+ requires >=3.11, 2.5+ requires >=3.12); the base image ships
+# Ubuntu 22.04's stock Python 3.10.
 RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
     && /opt/venv/bin/pip install --no-cache-dir \
         torch==2.9.1 \
@@ -45,7 +46,7 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         flash-linear-attention==0.5.1 \
         safetensors==0.8.0 \
         scikit-learn==1.7.2 \
-        numpy==2.5.1 \
+        numpy==2.2.6 \
         pyyaml==6.0.3 \
         huggingface_hub==1.23.0
 

--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -1,0 +1,56 @@
+# Generic CUDA runner for MechInterp-style pipelines: activation
+# reading/writing, probe fitting, and small-model inference/generation on a
+# single consumer GPU (validated against an RTX 3090 under WSL2). Intentionally
+# project-agnostic: no experiment paths, datasets, or configs baked in. Any
+# project that needs this runtime mounts its own workspace and code at run
+# time (see README.md).
+#
+# Base pinned by digest so the OS/CUDA userspace layer is reproducible
+# independent of what "ubuntu22.04" resolves to later.
+FROM nvidia/cuda@sha256:4a801ef9232d2b05e69df4eb8aa054dbbe2824e5499e1e6e857320bb01ac41a9
+
+ARG MECHINTERP_RUNNER_GIT_REVISION=unknown
+ENV MECHINTERP_RUNNER_GIT_REVISION=${MECHINTERP_RUNNER_GIT_REVISION}
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+ENV HF_HUB_ENABLE_HF_TRANSFER=0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3.10 \
+        python3.10-venv \
+        python3-pip \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3.10 -m venv /opt/venv
+
+# Every package below is pinned to an exact version. torch comes from the
+# PyTorch CUDA 12.8 wheel index to match the base image's CUDA runtime;
+# everything else resolves from PyPI. Versions were chosen to match the
+# already-validated Qwen3.5/Gemma-4 local stack (transformers 5.12.1, see
+# docs/sessions/0030 in the research repo) rather than picking latest-on-date.
+RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
+    && /opt/venv/bin/pip install --no-cache-dir \
+        torch==2.9.1 \
+        --index-url https://download.pytorch.org/whl/cu128 \
+    && /opt/venv/bin/pip install --no-cache-dir \
+        transformers==5.12.1 \
+        flash-linear-attention==0.5.1 \
+        safetensors==0.8.0 \
+        scikit-learn==1.9.0 \
+        numpy==2.5.1 \
+        pyyaml==6.0.3 \
+        huggingface_hub==1.23.0
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY print_provenance.py /usr/local/bin/print_provenance.py
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspace
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/docker/mechinterp-runner/README.md
+++ b/docker/mechinterp-runner/README.md
@@ -64,6 +64,15 @@ docker image inspect <registry>/mechinterp-runner:<tag> --format '{{index .RepoD
 
 ## Run pattern (WSL2 + NVIDIA)
 
+On a WSL2 host with Docker Desktop installed, the active Docker CLI context
+may be `desktop-linux`, a Windows named pipe that a Linux shell cannot reach
+(`docker ps` fails with `Failed to initialize: protocol not available`).
+Check `docker context ls` first; if the native WSL2 daemon is running as its
+own systemd service (`unix:///var/run/docker.sock`, usually named `default`),
+switch to it with `docker context use default` before building or running
+this image from a WSL2 shell. Confirm with `docker info | grep -i runtime`
+that an `nvidia` runtime is listed before assuming `--gpus all` will work.
+
 ```bash
 docker run --rm -it \
   --gpus all \

--- a/docker/mechinterp-runner/README.md
+++ b/docker/mechinterp-runner/README.md
@@ -1,0 +1,123 @@
+# MechInterp runner image
+
+A pinned CUDA runtime for local GPU experiment work: activation
+reading/writing, probe fitting, and small-model inference on a single
+consumer GPU. This image is intentionally generic. It carries no project
+paths, datasets, or configs; a calling project mounts its own workspace and
+code at run time.
+
+## Why this exists
+
+Local GPU runs previously used a shared, hand-maintained conda environment.
+That environment aged out silently: it kept working for older model
+architectures while its `transformers` version fell behind what newer
+architectures needed, and the mismatch was only caught mid-experiment. Files
+that feed an experiment are already sha256-pinned in `experiment.yaml`, but
+the runtime that executes them was not pinned at all, which left a gap in the
+provenance story. This image closes that gap for the local lane the same way
+the cloud lane is already closed: pin the runtime, print what it actually is
+at start time, and record that alongside the file pins.
+
+## What is pinned
+
+| Component | Version |
+| --- | --- |
+| Base image | `nvidia/cuda@sha256:4a801ef9232d2b05e69df4eb8aa054dbbe2824e5499e1e6e857320bb01ac41a9` (`12.8.1-runtime-ubuntu22.04`) |
+| Python | 3.10 (from the base image's Ubuntu 22.04 packages) |
+| torch | `2.9.1` (PyTorch CUDA 12.8 wheel index) |
+| transformers | `5.12.1` |
+| flash-linear-attention | `0.5.1` |
+| safetensors | `0.8.0` |
+| scikit-learn | `1.9.0` |
+| numpy | `2.5.1` |
+| pyyaml | `6.0.3` |
+| huggingface_hub | `1.23.0` |
+
+Every pin is an exact version, not a floor or a range. When a new
+architecture needs a newer runtime, bump the pins here in a reviewed change
+rather than upgrading packages inside a running container.
+
+## Build
+
+```bash
+cd docker/mechinterp-runner
+docker build \
+  --build-arg MECHINTERP_RUNNER_GIT_REVISION="$(git rev-parse HEAD)" \
+  -t mechinterp-runner:local \
+  .
+```
+
+## Capture the digest
+
+A locally built image that has not been pushed to a registry has a content
+digest (its Image ID) but no `RepoDigest`, since a `RepoDigest` is only
+assigned once a registry has the content. Either is a valid provenance
+reference; use whichever is available:
+
+```bash
+# Local build (no registry push): use the Image ID.
+docker image inspect mechinterp-runner:local --format '{{.Id}}'
+
+# After a registry push/pull: use the RepoDigest instead.
+docker image inspect <registry>/mechinterp-runner:<tag> --format '{{index .RepoDigests 0}}'
+```
+
+## Run pattern (WSL2 + NVIDIA)
+
+```bash
+docker run --rm -it \
+  --gpus all \
+  -v "$HOME/.cache/huggingface:/root/.cache/huggingface" \
+  -v "$(pwd):/workspace" \
+  --env IMAGE_DIGEST="$(docker image inspect mechinterp-runner:local --format '{{.Id}}')" \
+  --env HF_TOKEN \
+  mechinterp-runner:local \
+  python your_script.py
+```
+
+Notes on that invocation:
+
+- `--gpus all` requires the NVIDIA Container Toolkit registered with the
+  Docker daemon (`docker info` should list an `nvidia` runtime). Confirm this
+  before assuming a run has GPU access; a missing runtime fails at container
+  start, not silently.
+- The Hugging Face cache mount is read-write so repeated runs reuse
+  downloaded weights instead of re-fetching them per container.
+- `--env HF_TOKEN` (with no `=value`) passes the token through from the
+  calling shell's environment without baking it into the image or into any
+  committed file. Export it first, e.g.
+  `export HF_TOKEN=$(sed -n 's/^HF_TOKEN=//p' .env | tr -d '"\r\n')`, and
+  never `echo` it.
+- Mount the workspace read-write only when the run needs to write outputs
+  into it; a read-only mount (`-v "$(pwd):/workspace:ro"`) is safer when it
+  does not.
+
+## Provenance line
+
+The entrypoint runs `print_provenance.py` before the container command and
+prints one line of JSON to stdout, for example:
+
+```json
+{"event": "mechinterp_runner_provenance", "image_digest": "sha256:...", "image_git_revision": "86b134c...", "torch": "2.9.1+cu128", "cuda_available": true, "cuda_version": "12.8", "transformers": "5.12.1", "python": "3.10.12"}
+```
+
+`image_digest` reflects whatever `IMAGE_DIGEST` the caller passed at `docker
+run` time (see above); without it, the line reports `"unknown"` rather than
+guessing, since a digest cannot be recovered from inside a running container.
+`image_git_revision` is baked in at build time from the `git rev-parse HEAD`
+passed as `MECHINTERP_RUNNER_GIT_REVISION`, so the exact Dockerfile that
+produced the image is always recoverable even when the digest was not
+recorded.
+
+## How downstream projects should record the digest
+
+A downstream project (for example, an experiment's `experiment.yaml`) should
+capture, alongside its existing file hashes:
+
+- the image digest (Image ID or RepoDigest, per above),
+- the `image_git_revision` from the provenance line, and
+- the full provenance JSON line itself, appended to the run log.
+
+That gives a run record two independent ways to reconstruct the exact
+runtime: the digest for the content, and the git revision for the
+human-readable Dockerfile history behind that content.

--- a/docker/mechinterp-runner/README.md
+++ b/docker/mechinterp-runner/README.md
@@ -28,7 +28,7 @@ at start time, and record that alongside the file pins.
 | transformers | `5.12.1` |
 | flash-linear-attention | `0.5.1` |
 | safetensors | `0.8.0` |
-| scikit-learn | `1.9.0` |
+| scikit-learn | `1.7.2` (newest release supporting Python 3.10; 1.8+ needs >=3.11) |
 | numpy | `2.5.1` |
 | pyyaml | `6.0.3` |
 | huggingface_hub | `1.23.0` |

--- a/docker/mechinterp-runner/README.md
+++ b/docker/mechinterp-runner/README.md
@@ -29,7 +29,7 @@ at start time, and record that alongside the file pins.
 | flash-linear-attention | `0.5.1` |
 | safetensors | `0.8.0` |
 | scikit-learn | `1.7.2` (newest release supporting Python 3.10; 1.8+ needs >=3.11) |
-| numpy | `2.5.1` |
+| numpy | `2.2.6` (newest release supporting Python 3.10; 2.3+ needs >=3.11, 2.5+ needs >=3.12) |
 | pyyaml | `6.0.3` |
 | huggingface_hub | `1.23.0` |
 

--- a/docker/mechinterp-runner/entrypoint.sh
+++ b/docker/mechinterp-runner/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Prints one line of machine-readable runtime provenance, then execs the
+# container command. Downstream logs can grep this line to capture exactly
+# which image and package versions produced a run's artifacts.
+set -euo pipefail
+
+/opt/venv/bin/python /usr/local/bin/print_provenance.py
+
+exec "$@"

--- a/docker/mechinterp-runner/print_provenance.py
+++ b/docker/mechinterp-runner/print_provenance.py
@@ -1,0 +1,56 @@
+"""Print one line of runtime provenance JSON to stdout.
+
+Called by entrypoint.sh at container start. Kept as a standalone script
+(rather than inline shell) so any downstream project can invoke it directly,
+e.g. to append its output to a run log without re-deriving the same fields.
+
+The image digest is a property of a pulled/tagged reference, not something
+baked into the image filesystem, so it cannot be discovered by introspecting
+the running container alone. Callers that know the digest (see README.md)
+should pass it via IMAGE_DIGEST at `docker run` time. When absent, this
+script falls back to the git revision the image was built from, which is
+baked in at build time via a Dockerfile ARG/LABEL and is enough to locate the
+exact Dockerfile that produced the image, even if the digest itself is
+unrecorded.
+"""
+
+import json
+import os
+import sys
+
+
+def _versions():
+    out = {}
+    try:
+        import torch
+
+        out["torch"] = torch.__version__
+        out["cuda_available"] = bool(torch.cuda.is_available())
+        out["cuda_version"] = torch.version.cuda
+    except Exception as exc:  # pragma: no cover - diagnostic path
+        out["torch_error"] = str(exc)
+        out["cuda_available"] = False
+
+    try:
+        import transformers
+
+        out["transformers"] = transformers.__version__
+    except Exception as exc:  # pragma: no cover - diagnostic path
+        out["transformers_error"] = str(exc)
+
+    out["python"] = sys.version.split()[0]
+    return out
+
+
+def main():
+    record = {
+        "event": "mechinterp_runner_provenance",
+        "image_digest": os.environ.get("IMAGE_DIGEST", "unknown (pass IMAGE_DIGEST at `docker run`)"),
+        "image_git_revision": os.environ.get("MECHINTERP_RUNNER_GIT_REVISION", "unknown"),
+    }
+    record.update(_versions())
+    print(json.dumps(record, sort_keys=True), flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a pinned, reproducible Docker runner image for local GPU MechInterp runs: CUDA 12.8.1 base pinned by digest, torch 2.9.1+cu128, transformers 5.12.1 (parses `qwen3_5`), flash-linear-attention 0.5.1, numpy 2.2.6 and scikit-learn 1.7.2 (Python 3.10 caps).
- Entrypoint emits a machine-readable provenance JSON (image git revision, torch/transformers/CUDA versions, `cuda_available`) so every run log records the runtime it executed in.
- README documents the build, the WSL2 Docker Desktop context trap (use context `default`, not `desktop-linux`), and how to pass `IMAGE_DIGEST` at `docker run` for full digest provenance.

## Verification
- Image builds green locally (17.5 GB, `mechinterp-runner:local`).
- GPU smoke inside the container: `torch.cuda.is_available() == True` on RTX 3090, `AutoConfig.for_model('qwen3_5')` returns `Qwen3_5Config`, provenance JSON emitted.

Leave unmerged pending user review. Companion repo-side PR: EHR `infra/docker-local-lane`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2Xg1nGJ556Nbcpd2xEYTD