### PR TITLE
Pin vLLM model runner selection

### DIFF
--- a/tests/batch/test_vllm_engine.py
+++ b/tests/batch/test_vllm_engine.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 import types
 
@@ -86,6 +87,7 @@ def test_vllm_refuses_unpinned_or_mismatched_version(monkeypatch):
         VLLMGenerateEngine(
             "model",
             expected_vllm_version="0.17.1",
+            vllm_model_runner="v1",
             min_compute_capability="8.0",
         )
     with pytest.raises(ValueError, match="min-compute-capability"):
@@ -134,6 +136,7 @@ def test_vllm_pins_engine_schema_sampling_and_prompt_evidence(monkeypatch):
         structured_output_backend="xgrammar",
         structured_output_disable_any_whitespace=True,
         expected_vllm_version="0.23.0",
+        vllm_model_runner="v1",
         min_compute_capability="8.0",
         tensor_parallel_size=2,
         max_num_seqs=64,
@@ -182,6 +185,7 @@ def test_vllm_pins_engine_schema_sampling_and_prompt_evidence(monkeypatch):
     assert engine.provenance() == {
         "vllm_version": "0.23.0",
         "vllm_batch_invariant": True,
+        "vllm_model_runner": "v1",
         "structured_outputs": True,
         "structured_output_backend": "xgrammar",
         "structured_output_disable_any_whitespace": True,
@@ -189,6 +193,7 @@ def test_vllm_pins_engine_schema_sampling_and_prompt_evidence(monkeypatch):
         "documented_compute_capability_floor": "8.0",
         "effective_compute_capability_floor": "8.0",
     }
+    assert os.environ["VLLM_USE_V2_MODEL_RUNNER"] == "0"
 
     original_generate = engine.llm.generate
     oom_calls = []

--- a/tuner/batch/engines/vllm_engine.py
+++ b/tuner/batch/engines/vllm_engine.py
@@ -150,6 +150,7 @@ class VLLMGenerateEngine(GenerateEngine):
         structured_output_backend: str = "auto",
         structured_output_disable_any_whitespace: bool = False,
         expected_vllm_version: Optional[str] = None,
+        vllm_model_runner: Optional[str] = None,
         min_compute_capability: Optional[str] = None,
         tensor_parallel_size: int = 1,
         max_num_seqs: Optional[int] = None,
@@ -174,6 +175,14 @@ class VLLMGenerateEngine(GenerateEngine):
                 "--engine vllm requires --min-compute-capability so the batch-"
                 "invariance hardware requirement is checked before model load."
             )
+        if vllm_model_runner not in {"v1", "v2"}:
+            raise ValueError(
+                "--engine vllm requires --vllm-model-runner to pin v1 or v2 "
+                "before model construction."
+            )
+        os.environ["VLLM_USE_V2_MODEL_RUNNER"] = (
+            "1" if vllm_model_runner == "v2" else "0"
+        )
         vllm = _require_vllm()
         installed_version = getattr(vllm, "__version__", None)
         if installed_version != expected_vllm_version:
@@ -208,6 +217,7 @@ class VLLMGenerateEngine(GenerateEngine):
 
         self._SamplingParams = SamplingParams
         self._vllm_version = installed_version
+        self._vllm_model_runner = vllm_model_runner
         self._json_schema = json_schema
         self._structured_output_backend = structured_output_backend
         self._structured_output_disable_any_whitespace = bool(
@@ -361,6 +371,7 @@ class VLLMGenerateEngine(GenerateEngine):
         return {
             "vllm_version": self._vllm_version,
             "vllm_batch_invariant": True,
+            "vllm_model_runner": self._vllm_model_runner,
             "structured_outputs": self._json_schema is not None,
             "structured_output_backend": self._structured_output_backend,
             "structured_output_disable_any_whitespace": (

--- a/tuner/batch/runner.py
+++ b/tuner/batch/runner.py
@@ -82,6 +82,7 @@ def run_batch_generate(
     structured_output_backend: str = "auto",
     structured_output_disable_any_whitespace: bool = False,
     expected_vllm_version: Optional[str] = None,
+    vllm_model_runner: Optional[str] = None,
     min_compute_capability: Optional[str] = None,
     tensor_parallel_size: int = 1,
     max_num_seqs: Optional[int] = None,
@@ -185,6 +186,7 @@ def run_batch_generate(
             structured_output_disable_any_whitespace if engine == "vllm" else None
         ),
         "expected_vllm_version": expected_vllm_version,
+        "vllm_model_runner": vllm_model_runner if engine == "vllm" else None,
         "min_compute_capability": (
             min_compute_capability if engine == "vllm" else None
         ),
@@ -257,6 +259,7 @@ def run_batch_generate(
                 structured_output_disable_any_whitespace
             ),
             expected_vllm_version=expected_vllm_version,
+            vllm_model_runner=vllm_model_runner,
             min_compute_capability=min_compute_capability,
             tensor_parallel_size=tensor_parallel_size,
             max_num_seqs=max_num_seqs,

--- a/tuner/cli/parser.py
+++ b/tuner/cli/parser.py
@@ -603,6 +603,13 @@ Examples:
         help="Disallow arbitrary JSON whitespace in supported vLLM backends.",
     )
     parser.add_argument("--expected-vllm-version", dest="expected_vllm_version", help="Exact installed vLLM version required by --engine vllm.")
+    parser.add_argument(
+        "--vllm-model-runner",
+        choices=["v1", "v2"],
+        default=None,
+        dest="vllm_model_runner",
+        help="Pinned vLLM GPU model-runner implementation (v1 or v2).",
+    )
     parser.add_argument("--min-compute-capability", dest="min_compute_capability", help="Minimum CUDA compute capability required for the pinned vLLM batch-invariance runtime, for example 8.0.")
     parser.add_argument("--tensor-parallel-size", type=int, default=1, dest="tensor_parallel_size", help="vLLM tensor parallel size (default: 1).")
     parser.add_argument("--max-num-seqs", type=int, default=None, dest="max_num_seqs", help="Pinned vLLM scheduler maximum concurrent sequences.")

--- a/tuner/handlers/batch_generate_handler.py
+++ b/tuner/handlers/batch_generate_handler.py
@@ -104,6 +104,7 @@ class BatchGenerateHandler(BaseHandler):
                     args, "structured_output_disable_any_whitespace", False
                 ),
                 expected_vllm_version=getattr(args, "expected_vllm_version", None),
+                vllm_model_runner=getattr(args, "vllm_model_runner", None),
                 min_compute_capability=getattr(args, "min_compute_capability", None),
                 tensor_parallel_size=getattr(args, "tensor_parallel_size", 1),
                 max_num_seqs=getattr(args, "max_num_seqs", None),


### PR DESCRIPTION
## Summary

- expose an explicit v1/v2 model-runner choice for batch-generate
- set VLLM_USE_V2_MODEL_RUNNER before importing vLLM
- bind the choice into resume hashes and runtime provenance

## Verification

- 38 explicit batch tests passed
- 43 consuming experiment instrument tests passed
- exact vLLM 0.23.0 image smoke passed on Gemma-4-E4B-it and Qwen3-4B with model runner v1