### PR TITLE
Add model.language_model.layers to decoder-layer path search

### DIFF
--- a/MechInterp/intervention/hooks.py
+++ b/MechInterp/intervention/hooks.py
@@ -50,6 +50,10 @@ _LAYER_PATHS = (
     "model.decoder.layers",
     "transformer.h",
     "model.model.layers",
+    # transformers 5.x multimodal wrappers (e.g. Gemma4ForConditionalGeneration)
+    # nest the text decoder directly under model.language_model, with sibling
+    # vision/audio towers; this path names the text stack unambiguously.
+    "model.language_model.layers",
 )
 
 


### PR DESCRIPTION
One commit (`7a44eb3`), 4 lines, append-only.

transformers 5.x multimodal wrappers (e.g. `Gemma4ForConditionalGeneration`) nest the text decoder directly under `model.language_model`, with sibling vision/audio towers. `_LAYER_PATHS` in `MechInterp/intervention/hooks.py` predates this layout, so `get_decoder_layer` raises `AttributeError` on Gemma-4 and the intervention engine cannot locate its decoder blocks at all.

The new path is appended last, so no existing architecture's resolution order changes.

Context: this is a registered prerequisite of the Epistemic-Humility `gemma4-e4b-kv-seam-quarantine` experiment, whose amendment records that the unmerged-branch state of this fix has twice made "at or after 7a44eb3" misleading (mainline pins `b1ea382` and `901dbe80` both postdate the fix and lack it). Merging closes that permanently; the consumer repo verifies structurally (grep for the path entry), not by version.

The branch is exactly one commit ahead of `main` (`901dbe80`) — a fast-forward.

Generic infrastructure change; nothing project-specific enters the tuner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD
