### PR TITLE
mechinterp-runner: add accelerate 1.14.0 to the pinned package set

### DIFF
--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -36,7 +36,9 @@ RUN python3.10 -m venv /opt/venv
 # scikit-learn is capped at 1.7.2, the newest release that still supports
 # Python 3.10 (1.8+ requires >=3.11); numpy is capped at 2.2.6 for the same
 # reason (2.3+ requires >=3.11, 2.5+ requires >=3.12); the base image ships
-# Ubuntu 22.04's stock Python 3.10.
+# Ubuntu 22.04's stock Python 3.10. accelerate is required by transformers'
+# device_map= loading path (from_pretrained raises without it); 1.14.0 is the
+# newest release this venv's Python 3.10 pip resolves.
 RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
     && /opt/venv/bin/pip install --no-cache-dir \
         torch==2.9.1 \
@@ -48,7 +50,8 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         scikit-learn==1.7.2 \
         numpy==2.2.6 \
         pyyaml==6.0.3 \
-        huggingface_hub==1.23.0
+        huggingface_hub==1.23.0 \
+        accelerate==1.14.0
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY print_provenance.py /usr/local/bin/print_provenance.py


### PR DESCRIPTION
One commit, two lines of Dockerfile plus a comment.

transformers' `device_map=` loading path raises at `from_pretrained` without `accelerate` present. The mechinterp-runner image ships transformers 5.12.1 with no accelerate, so any consumer whose loader passes `device_map="auto"` fails at model load inside the pinned image. First hit in practice: the Epistemic-Humility kv-seam experiment's `model_lib.py`, whose signed loader uses `device_map="auto"` for every family — every GPU stage of that experiment fails identically without this.

Pinned at `1.14.0`, the newest release the image's own Python 3.10 pip resolves. Added as a reviewed pin bump per the README's explicit instruction, rather than installed inside a running container (which the README forbids).

Generic infrastructure; nothing project-specific enters the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD
