### PR TITLE
mechinterp-runner: parameterize the transformers version as a build arg

### DIFF
--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -11,6 +11,16 @@ FROM nvidia/cuda@sha256:4a801ef9232d2b05e69df4eb8aa054dbbe2824e5499e1e6e857320bb
 
 ARG MECHINTERP_RUNNER_GIT_REVISION=unknown
 ENV MECHINTERP_RUNNER_GIT_REVISION=${MECHINTERP_RUNNER_GIT_REVISION}
+
+# transformers is parameterized because an instrument validated against one
+# modeling implementation is not automatically valid under another: internal
+# model attributes (e.g. Gemma4's KV-sharing layout) change between releases,
+# and a consumer whose patches/hooks read those internals must run under the
+# version it was validated against. The default stays the image's standard
+# stack; a consumer overrides it at build time and records the resulting
+# image digest plus this version in its run provenance.
+ARG TRANSFORMERS_VERSION=5.12.1
+ENV MECHINTERP_RUNNER_TRANSFORMERS_VERSION=${TRANSFORMERS_VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 ENV VIRTUAL_ENV=/opt/venv
@@ -44,7 +54,7 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         torch==2.9.1 \
         --index-url https://download.pytorch.org/whl/cu128 \
     && /opt/venv/bin/pip install --no-cache-dir \
-        transformers==5.12.1 \
+        transformers==${TRANSFORMERS_VERSION} \
         flash-linear-attention==0.5.1 \
         safetensors==0.8.0 \
         scikit-learn==1.7.2 \


### PR DESCRIPTION
One commit. Adds `ARG TRANSFORMERS_VERSION=5.12.1` and uses it in the pip install; default unchanged, so every existing consumer rebuilds an identical stack.

Rationale: an instrument validated against one modeling implementation is not automatically valid under another. `Gemma4TextAttention` lost its `kv_shared_layer_index` attribute between transformers 5.5.0 and 5.12.1 (the KV-sharing machinery was refactored to derive donor routing from `first_kv_shared_layer_idx`/`layer_types`), which crashes any consumer whose hooks read the 5.5-era attribute — concretely, the signed kv-seam experiment's `kv_seam_patch.py`, validated and dose-calibrated under 5.5.0. That experiment will build with `--build-arg TRANSFORMERS_VERSION=5.5.0` and record the digest + version in its run provenance (`print_provenance.py` already reports the installed version, so the override is self-recording).

Generic, project-agnostic; user-approved direction (align runtime to the validated version rather than rewrite a signed instrument against new internals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD
