### PR TITLE
mechinterp-runner: pin requests, peft, pandas in the runner image

### DIFF
--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -60,7 +60,10 @@ RUN python3.10 -m venv /opt/venv
 # newest release this venv's Python 3.10 pip resolves. pydantic is required
 # by MechInterp.config (BaseModel/field_validator imports at module load, so
 # any consumer of MechInterp.cell needs it); v2 API, pinned to the version
-# validated on the local stack.
+# validated on the local stack. requests is imported by the MechInterp.cli
+# router at dispatch time and peft by _load_model_and_tokenizer whenever
+# --adapter is passed, so a local extract against an adapter-bearing
+# checkpoint needs both; pinned to the versions validated on the local stack.
 RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
     && /opt/venv/bin/pip install --no-cache-dir \
         torch==2.9.1 \
@@ -74,7 +77,9 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         pyyaml==6.0.3 \
         huggingface_hub==1.23.0 \
         accelerate==1.14.0 \
-        pydantic==2.12.4
+        pydantic==2.12.4 \
+        requests==2.32.3 \
+        peft==0.18.1
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY print_provenance.py /usr/local/bin/print_provenance.py

--- a/docker/mechinterp-runner/Dockerfile
+++ b/docker/mechinterp-runner/Dockerfile
@@ -64,6 +64,10 @@ RUN python3.10 -m venv /opt/venv
 # router at dispatch time and peft by _load_model_and_tokenizer whenever
 # --adapter is passed, so a local extract against an adapter-bearing
 # checkpoint needs both; pinned to the versions validated on the local stack.
+# pandas is imported by five cloud/experiment handler modules that
+# router.route_command eagerly imports before dispatching ANY verb, so even
+# a pure mechinterp verb fails without it; the full 22-handler import sweep
+# found pandas to be the only remaining gap.
 RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
     && /opt/venv/bin/pip install --no-cache-dir \
         torch==2.9.1 \
@@ -79,7 +83,8 @@ RUN /opt/venv/bin/pip install --no-cache-dir --upgrade pip==26.1.2 \
         accelerate==1.14.0 \
         pydantic==2.12.4 \
         requests==2.32.3 \
-        peft==0.18.1
+        peft==0.18.1 \
+        pandas==2.2.3
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY print_provenance.py /usr/local/bin/print_provenance.py


### PR DESCRIPTION
Two commits closing the dependency gaps found when the mechinterp-runner image was first exercised end-to-end by a consumer project:

- `requests==2.32.3` (imported by the MechInterp.cli router at dispatch time) and `peft==0.18.1` (imported by `_load_model_and_tokenizer` whenever `--adapter` is passed).
- `pandas==2.2.3`: `router.route_command` eagerly imports all 22 handler modules before dispatching ANY verb, and five cloud/experiment handlers import pandas at module scope, so even a pure mechinterp verb fails without it. A full 22-handler import sweep confirmed pandas was the only remaining gap.

All pins exact-version, consistent with the image's pin-everything policy. The consumer project has been running the rebuilt image (torch 2.9.1+cu128, transformers 5.12.1) through multiple production extractions since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD