### PR TITLE
Fix smoke off-target metric: measure movement, not natural projection

### DIFF
--- a/MechInterp/intervention/hooks.py
+++ b/MechInterp/intervention/hooks.py
@@ -393,6 +393,12 @@ class InterventionHook:
 
         active_override = _resolve_force_active(self.force_active, batch, device)
 
+        pre_proj = None
+        if self.measure_readback:
+            pre_proj = self._projections(
+                hidden, self.direction.detach().to(torch.float64), per_row, final_pos, columns
+            )
+
         if self.law == "additive":
             alpha = _strength_per_row(self.strength, batch, device, dtype)
             hidden = additive_push(
@@ -411,49 +417,50 @@ class InterventionHook:
 
         if self.measure_readback:
             self.last_readback = self._readback(
-                hidden, c, per_row, final_pos, columns, gain_for_readback, active_override
+                hidden, c, per_row, final_pos, columns, gain_for_readback,
+                pre_proj, active_override
             )
 
         if is_tuple:
             return (hidden,) + rest
         return hidden
 
-    def _readback(self, hidden, c, per_row, final_pos, columns, gain_row, active_override=None) -> dict:
-        """Measure realized projection onto the direction (float64) after the edit.
-
-        Returns per-row commanded vs measured projection for active rows and the
-        mean absolute projection of inactive rows (off-target parity check).
-        """
-        c64 = c.detach().to(torch.float64)
+    def _projections(self, hidden, c64, per_row, final_pos, columns) -> list:
+        """Float64 projection of every batch row onto the direction at its
+        measured position: the row's final position under the per-row policy,
+        else the first masked column for shared-column policies."""
         batch = hidden.shape[0]
         if per_row:
-            active = _resolve_active(gain_row, active_override)
-            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
-            inactive = torch.nonzero(~active, as_tuple=False).squeeze(1)
-            measured = []
-            for b in rows.tolist():
-                col = int(final_pos[b].item())
-                measured.append(
-                    float(hidden[b, col, :].to(torch.float64) @ c64)
-                )
-            off = []
-            for b in inactive.tolist():
-                col = int(final_pos[b].item())
-                off.append(abs(float(hidden[b, col, :].to(torch.float64) @ c64)))
-        else:
-            col_idx = torch.nonzero(columns, as_tuple=False).squeeze(1)
-            first_col = int(col_idx[0].item()) if col_idx.numel() else hidden.shape[1] - 1
-            active = _resolve_active(gain_row, active_override)
-            rows = torch.nonzero(active, as_tuple=False).squeeze(1)
-            inactive = torch.nonzero(~active, as_tuple=False).squeeze(1)
-            measured = [
-                float(hidden[b, first_col, :].to(torch.float64) @ c64)
-                for b in rows.tolist()
+            return [
+                float(hidden[b, int(final_pos[b].item()), :].to(torch.float64) @ c64)
+                for b in range(batch)
             ]
-            off = [
-                abs(float(hidden[b, first_col, :].to(torch.float64) @ c64))
-                for b in inactive.tolist()
-            ]
+        col_idx = torch.nonzero(columns, as_tuple=False).squeeze(1)
+        first_col = int(col_idx[0].item()) if col_idx.numel() else hidden.shape[1] - 1
+        return [
+            float(hidden[b, first_col, :].to(torch.float64) @ c64)
+            for b in range(batch)
+        ]
+
+    def _readback(self, hidden, c, per_row, final_pos, columns, gain_row, pre_proj, active_override=None) -> dict:
+        """Measure realized projection onto the direction (float64) after the edit.
+
+        Returns per-row commanded vs measured projection for active rows, and
+        the movement |post - pre| of inactive rows (off-target parity check).
+        Off-target is genuine movement against the pre-edit snapshot taken in
+        __call__ -- an untouched row reads exactly 0.0. The previous
+        implementation reported the inactive rows' NATURAL projection (no
+        before/after), which made any gated smoke arm fail the 1e-3 tolerance
+        on ~1-sigma natural projections while an ungated arm made the check
+        vacuous (empty inactive set).
+        """
+        c64 = c.detach().to(torch.float64)
+        active = _resolve_active(gain_row, active_override)
+        rows = torch.nonzero(active, as_tuple=False).squeeze(1)
+        inactive = torch.nonzero(~active, as_tuple=False).squeeze(1)
+        post = self._projections(hidden, c64, per_row, final_pos, columns)
+        measured = [post[b] for b in rows.tolist()]
+        off = [abs(post[b] - pre_proj[b]) for b in inactive.tolist()]
         if self.law == "erase_write":
             commanded = [float(gain_row[b].item()) * self.sigma for b in rows.tolist()]
         else:

--- a/tests/mech_interp/test_intervention_hooks.py
+++ b/tests/mech_interp/test_intervention_hooks.py
@@ -280,3 +280,58 @@ def test_strength_length_mismatch_raises():
     hook.attention_mask = torch.ones(2, 2, dtype=torch.long)
     with pytest.raises(ValueError):
         hook(None, None, hidden)
+
+
+def test_hook_readback_offtarget_zero_for_untouched_inactive_rows():
+    # Regression: off-target must measure MOVEMENT (|post - pre|), not the
+    # inactive row's natural projection onto the direction. A gated arm whose
+    # inactive rows carry large natural projections must read exactly 0.0
+    # off-target, because the hook never touches them. The old implementation
+    # reported the natural projection itself, failing any gated smoke arm on
+    # ~1-sigma projections against the 1e-3 tolerance (found via
+    # caution-install-bounded-site-sweep stage 6; same failure previously in
+    # aq-sycophancy-activation-actuator).
+    d = _unit([1.0, 0.0, 0.0, 0.0])
+    hook = InterventionHook(
+        "erase_write", d, strength=[2.0, 0.0, 0.0], sigma=3.0,
+        position="final", measure_readback=True,
+    )
+    # Row 0 active; rows 1-2 inactive with large natural projections (5.0, -4.0).
+    hidden = torch.zeros(3, 4, 4)
+    hidden[0, 3, 0] = 1.0
+    hidden[1, 3, 0] = 5.0
+    hidden[2, 3, 0] = -4.0
+    out = hook(None, None, hidden.clone())
+    rb = hook.last_readback
+    assert rb["active_rows"] == [0]
+    assert rb["offtarget_abs_max"] == 0.0
+    assert rb["offtarget_abs_mean"] == 0.0
+    # The active row still lands at its commanded setpoint.
+    assert rb["commanded"] == [pytest.approx(6.0)]
+    assert rb["measured"] == [pytest.approx(6.0)]
+    # And the inactive rows' values are genuinely untouched.
+    assert float(out[1, 3, 0]) == 5.0
+    assert float(out[2, 3, 0]) == -4.0
+
+
+def test_hook_readback_offtarget_catches_real_inactive_movement():
+    # The repaired metric must still catch a hook that DOES move a row it
+    # should not: force-activate a zero-gain row via active_override and
+    # confirm the movement of a row excluded from the readback's active set
+    # is visible as off-target. We simulate a buggy edit by comparing a
+    # readback computed against a stale pre-edit snapshot.
+    d = _unit([0.0, 1.0, 0.0, 0.0])
+    hook = InterventionHook(
+        "erase_write", d, strength=[2.0, 0.0], sigma=1.0,
+        position="final", measure_readback=True,
+    )
+    hidden = torch.zeros(2, 3, 4)
+    hidden[1, 2, 1] = 3.0
+    pre = hook._projections(hidden, d.to(torch.float64), True,
+                            torch.tensor([2, 2]), None)
+    # Mutate the inactive row as a buggy edit would, then read back.
+    moved = hidden.clone()
+    moved[1, 2, 1] = 5.0
+    rb = hook._readback(moved, d, True, torch.tensor([2, 2]), None,
+                        torch.tensor([2.0, 0.0]), pre)
+    assert rb["offtarget_abs_max"] == pytest.approx(2.0)


### PR DESCRIPTION
## Summary
- The intervention hook's smoke readback reported the **natural projection** of gate-inactive rows as "off-target" — no before/after comparison. Any gated smoke arm therefore false-failed the `1e-3` `offtarget_tol` on ~1σ natural projections; ungated arms made the check vacuous (empty inactive set). The metric could not measure what `config.py` documents ("Max allowed movement of inactive rows") in either direction.
- Fix: `__call__` snapshots pre-edit projections; `_readback` reports `|post − pre|` per inactive row. Untouched rows read exactly 0.0; a hook that moves a row it shouldn't now shows real movement.
- Found via `caution-install-bounded-site-sweep` stage 6 in the research repo (all 5 gated cells false-failed rc=4, zero rows generated); the same failure was previously worked around in `aq-sycophancy-activation-actuator` by row reordering. Downstream cells keep their reordering as belt-and-braces; this makes the metric itself honest.
- Two regression tests; mech_interp suite 162 passed.

Note for reviewers: the running experiment in the research repo stays on its pinned environment; this fix is not checked out into that environment until its sequence completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD