### PR TITLE
Fix device mismatch in readback pre-edit projection snapshot

### DIFF
--- a/MechInterp/intervention/hooks.py
+++ b/MechInterp/intervention/hooks.py
@@ -396,7 +396,9 @@ class InterventionHook:
         pre_proj = None
         if self.measure_readback:
             pre_proj = self._projections(
-                hidden, self.direction.detach().to(torch.float64), per_row, final_pos, columns
+                hidden,
+                self.direction.detach().to(device=hidden.device, dtype=torch.float64),
+                per_row, final_pos, columns,
             )
 
         if self.law == "additive":


### PR DESCRIPTION
The pre-edit `pre_proj` snapshot passed `self.direction.detach().to(torch.float64)` into `_projections`, converting dtype but not device. A CPU-resident direction (the common case when loaded from a JSON artifact) crashes with a cuda/cpu RuntimeError at the first dosed row whenever `measure_readback` is on. The post-edit readback already uses the device-aligned `c` built at hook entry via `.to(device=device, dtype=dtype)`; this aligns the pre-edit snapshot the same way. One line, generic, no experiment-specific logic.

Surfaced by a downstream steering run whose first hooked row crashed at `_projections` (hooks.py:441) while its baseline (unhooked) arm completed normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012M6wLjiA3PHuTRN3V72TWD