### PR TITLE
fix(modal): preserve pinned launcher bytes on Windows checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,6 +16,7 @@
 
 # Hash-bound launcher inputs must retain committed bytes on Windows
 requirements-hf-training-smoke.lock text eol=lf
+requirements/modal-launcher-v1.lock text eol=lf
 Datasets/tools_datasets/non_thinking/contentManager/smoke_tools_v2.5.jsonl text eol=lf
 
 # Windows scripts use CRLF

--- a/tests/contract/test_modal_runtime_lock.py
+++ b/tests/contract/test_modal_runtime_lock.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
+import subprocess
 
 import jsonschema
 
@@ -19,3 +20,39 @@ def test_modal_runtime_lock_schema_and_file_digests_are_exact():
     for member in lock["locked_files"].values():
         assert hashlib.sha256((ROOT / member["path"]).read_bytes()).hexdigest() == member["sha256"]
     assert lock["registry_reference"].endswith("@sha256:5266c57be21059bfb407d80dc2f448868a5c2e2dbe7b2aa27780f48b48cbec39")
+
+
+def test_modal_launcher_lock_checkout_preserves_hash_bound_lf_bytes(tmp_path):
+    source = ROOT / "requirements/modal-launcher-v1.lock"
+    expected = source.read_bytes()
+    assert b"\r" not in expected
+
+    repository = tmp_path / "checkout"
+    repository.mkdir()
+
+    def git(*arguments: str) -> None:
+        subprocess.run(
+            ["git", *arguments], cwd=repository, check=True,
+            text=True, capture_output=True,
+        )
+
+    git("init", "--quiet")
+    git("config", "core.autocrlf", "true")
+    git("config", "user.name", "Modal lock test")
+    git("config", "user.email", "modal-lock-test@example.invalid")
+    (repository / ".gitattributes").write_bytes(
+        (ROOT / ".gitattributes").read_bytes()
+    )
+    lock = repository / "requirements/modal-launcher-v1.lock"
+    lock.parent.mkdir()
+    lock.write_bytes(expected)
+    control = repository / "native-checkout.txt"
+    control.write_bytes(b"one\ntwo\n")
+    git("add", ".gitattributes", "requirements/modal-launcher-v1.lock", "native-checkout.txt")
+    git("commit", "--quiet", "-m", "fixture")
+    lock.unlink()
+    control.unlink()
+    git("checkout", "--quiet", "--", "requirements/modal-launcher-v1.lock", "native-checkout.txt")
+
+    assert control.read_bytes() == b"one\r\ntwo\r\n"
+    assert lock.read_bytes() == expected


### PR DESCRIPTION
Readiness follow-up targeting feat/submodule-cloud-api-v1 only; main is out of scope. Adds an explicit LF attribute for the hash-bound Modal launcher lock and a real autocrlf checkout regression. Lock content and all dependency/runtime hashes are unchanged. Independent source review passed. Independent native Windows Git first-checkout validation used core.autocrlf=true without a core.eol override: the ordinary text control became CRLF, while the Modal lock stayed LF with working/blob SHA256 8273b49a3b613bed82905ac349d2028935269c4d369dd5781a5eb0bad23b874e. The exact 18-module Modal/offline SFT suite ran against committed head 3ea52d23de2b52b2d4fa86ecc4b8b2bc0cc5554d from a clean released Host cwd: 366 collected, 366 passed in 9.08 seconds. No cloud calls, credentials, dependency upgrades, or training behavior changes.