### PR TITLE
Add bounded verified Modal artifact reads

### DIFF
--- a/synaptic_tuner/api/v1/modal.py
+++ b/synaptic_tuner/api/v1/modal.py
@@ -47,6 +47,10 @@ from tuner.execution.providers.modal.training import (
     ModalTrainingRepository,
     compose_modal_training_operations,
 )
+from tuner.execution.providers.modal.run_reads import (
+    ModalVerifiedRunsOperationsV1,
+    compose_modal_verified_run_reads,
+)
 
 __all__ = [
     "ModalDurablePreparationV1",
@@ -66,6 +70,7 @@ __all__ = [
     "ModalTrainingOperations",
     "ModalTrainingRepository",
     "ModalVerificationPolicyV1",
+    "ModalVerifiedRunsOperationsV1",
     "MountedCompletionProducerV1",
     "MountedModalWorkerV1",
     "EnvironmentHmacAuthenticator",
@@ -78,4 +83,5 @@ __all__ = [
     "modal_function_name",
     "compose_modal_source_finalizer",
     "compose_modal_training_operations",
+    "compose_modal_verified_run_reads",
 ]

--- a/tests/execution/providers/test_modal_run_reads.py
+++ b/tests/execution/providers/test_modal_run_reads.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError, replace
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+
+from synaptic_tuner.api.v1 import (
+    RunArtifactRequest,
+    RunListRequest,
+    RunOperationCode,
+    RunOperationError,
+    RunsAPI,
+    TrainingRunRef,
+    TrainingRunState,
+)
+from synaptic_tuner.api.v1.execution import ExecutionGrant
+from synaptic_tuner.api.v1.modal import compose_modal_verified_run_reads
+from tests.execution.providers.test_modal_sdk154_adapter import FakeVolume
+from tests.execution.providers.test_modal_training_operations import (
+    _publish_unrelated_completed_run,
+    operations,
+    profile,
+)
+from tuner.execution.providers.modal.contracts import ArtifactRole
+from tuner.runtime.verification import VerificationStatus as RuntimeVerificationStatus
+
+
+RUN = TrainingRunRef("run-1", "project-1")
+
+
+def _verified_reads(tmp_path):
+    training, repository, plan = operations(tmp_path)
+    submission = training.start(
+        plan, training.preflight(plan), ExecutionGrant("grant-run-1")
+    )
+    _publish_unrelated_completed_run(training, repository, tmp_path)
+    training._verify_semantics = (
+        lambda _preparation, _manifest: RuntimeVerificationStatus.VERIFIED
+    )
+    assert training.outcome(submission).status.state.value == "succeeded"
+    reads = compose_modal_verified_run_reads(
+        context=training._context,
+        repository=training._repository,
+        authenticator=training._ports.authenticator,
+        modal_reads=training._facade,
+        clock=training._ports.clock,
+    )
+    return RunsAPI(reads), reads, repository
+
+
+def test_projects_exact_verified_inventory_without_mutating_lifecycle(tmp_path):
+    api, _reads, repository = _verified_reads(tmp_path)
+    before = repository.load("project-1", "run-1").canonical_bytes
+
+    outcome = api.show(RUN)
+    verification = api.reverify(RUN)
+
+    assert outcome.state is TrainingRunState.SUCCEEDED
+    assert tuple(item.role for item in outcome.artifacts) == tuple(
+        sorted(role.value for role in ArtifactRole)
+    )
+    assert verification.verified is True
+    assert repository.load("project-1", "run-1").canonical_bytes == before
+
+
+def test_stream_is_single_use_and_rechecks_digest_and_size(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    expected = b"unrelated-final_model"
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", len(expected)))
+
+    assert b"".join(stream.iter_bytes()) == expected
+    with pytest.raises(RunOperationError) as reused:
+        list(stream.iter_bytes())
+    assert reused.value.code is RunOperationCode.ARTIFACT_CONTENT_INVALID
+
+
+def test_same_size_mutation_after_manifest_snapshot_is_rejected(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    expected = b"unrelated-final_model"
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", len(expected)))
+    path = "operations/effect-run-1/output/final_model"
+    FakeVolume.registry["artifact-name"].files[path] = b"x" * len(expected)
+
+    with pytest.raises(RunOperationError) as changed:
+        list(stream.iter_bytes())
+    assert changed.value.code is RunOperationCode.ARTIFACT_CONTENT_INVALID
+
+
+def test_stream_rejects_provider_chunk_above_public_bound(tmp_path, monkeypatch):
+    api, reads, _repository = _verified_reads(tmp_path)
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", 2_000_000))
+
+    def oversized(_self, _volume_id, _path, *, max_bytes):
+        assert max_bytes == 2_000_000
+        yield b"x" * 1_048_577
+
+    monkeypatch.setattr(type(reads._facade), "iter_complete", oversized)
+    with pytest.raises(RunOperationError) as invalid:
+        list(stream.iter_bytes())
+    assert invalid.value.code is RunOperationCode.ARTIFACT_CONTENT_INVALID
+
+
+@pytest.mark.parametrize("mode", ["empty", "short", "excess", "failure"])
+def test_stream_closes_malformed_provider_results(tmp_path, monkeypatch, mode):
+    api, reads, _repository = _verified_reads(tmp_path)
+    expected = b"unrelated-final_model"
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", 1000))
+
+    def malformed(_self, _volume_id, _path, *, max_bytes):
+        if mode == "failure":
+            raise RuntimeError("raw provider failure")
+        if mode == "empty":
+            return
+        if mode == "short":
+            yield expected[:-1]
+        else:
+            yield expected + b"x"
+
+    monkeypatch.setattr(type(reads._facade), "iter_complete", malformed)
+    with pytest.raises(RunOperationError) as invalid:
+        list(stream.iter_bytes())
+    assert invalid.value.code is RunOperationCode.ARTIFACT_CONTENT_INVALID
+
+
+def test_stream_public_bindings_are_frozen(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", 1000))
+    for name, value in (
+        ("run", TrainingRunRef("other", "project-1")),
+        ("artifact", stream.artifact),
+        ("maximum_bytes", 1),
+        ("_path", "other"),
+    ):
+        with pytest.raises(FrozenInstanceError):
+            setattr(stream, name, value)
+    assert not hasattr(stream, "_state")
+
+
+def test_concurrent_stream_claim_has_exactly_one_winner(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", 1000))
+    barrier = Barrier(2)
+
+    def claim():
+        barrier.wait()
+        try:
+            iterator = stream.iter_bytes()
+        except RunOperationError as error:
+            return error.code
+        return b"".join(iterator)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = tuple(executor.map(lambda _index: claim(), range(2)))
+    assert results.count(b"unrelated-final_model") == 1
+    assert results.count(RunOperationCode.ARTIFACT_CONTENT_INVALID) == 1
+
+
+def test_verified_inventory_is_reused_until_explicit_reverify(tmp_path, monkeypatch):
+    api, reads, _repository = _verified_reads(tmp_path)
+    plane_type = type(reads._completion)
+    original = plane_type.validate
+    calls = []
+
+    def counted(self, effect_id):
+        calls.append(effect_id)
+        return original(self, effect_id)
+
+    monkeypatch.setattr(plane_type, "validate", counted)
+    api.show(RUN)
+    api.show(RUN)
+    streams = [
+        api.artifacts(RunArtifactRequest(RUN, role.value, 1000))
+        for role in ArtifactRole
+    ]
+    assert len(streams) == 5
+    assert calls == ["effect-run-1"]
+    api.reverify(RUN)
+    assert calls == ["effect-run-1", "effect-run-1"]
+
+
+def test_ledger_drift_after_stream_creation_refuses_before_provider_io(tmp_path):
+    api, _reads, repository = _verified_reads(tmp_path)
+    stream = api.artifacts(RunArtifactRequest(RUN, "final_model", 1000))
+    record = repository.load("project-1", "run-1")
+    repository.records[("project-1", "run-1")] = replace(
+        record, updated_at="2026-08-25T12:03:01Z"
+    )
+    calls = list(FakeVolume.calls)
+    with pytest.raises(RunOperationError) as drifted:
+        list(stream.iter_bytes())
+    assert drifted.value.code is RunOperationCode.ARTIFACT_CONTENT_INVALID
+    assert FakeVolume.calls == calls
+
+
+def test_cross_project_run_refuses_before_provider_io(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    calls = list(FakeVolume.calls)
+    with pytest.raises(RunOperationError) as refused:
+        api.show(TrainingRunRef("run-1", "other-project"))
+    assert refused.value.code is RunOperationCode.READ_INELIGIBLE
+    assert FakeVolume.calls == calls
+
+
+def test_effect_drift_refuses_before_provider_io(tmp_path):
+    api, _reads, repository = _verified_reads(tmp_path)
+    record = repository.load("project-1", "run-1")
+    effect = record.effects[0]
+    changed_effect = replace(
+        effect, identity=replace(effect.identity, effect_id="effect-other")
+    )
+    repository.records[("project-1", "run-1")] = replace(
+        record, effects=(changed_effect,)
+    )
+    calls = list(FakeVolume.calls)
+    with pytest.raises(RunOperationError) as refused:
+        api.show(RUN)
+    assert refused.value.code is RunOperationCode.READ_INELIGIBLE
+    assert FakeVolume.calls == calls
+
+
+def test_authenticated_metadata_drift_is_rejected_on_refresh(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    api.show(RUN)
+    path = "operations/effect-run-1/output/final_model"
+    FakeVolume.registry["artifact-name"].files[path] += b"x"
+    with pytest.raises(RunOperationError) as drifted:
+        api.reverify(RUN)
+    assert drifted.value.code is RunOperationCode.PROVIDER_READ_INVALID
+
+
+def test_failed_reverify_evicts_prior_verified_inventory(tmp_path, monkeypatch):
+    api, reads, _repository = _verified_reads(tmp_path)
+    api.show(RUN)
+    plane_type = type(reads._completion)
+    original = plane_type.validate
+    calls = []
+
+    def counted(self, effect_id):
+        calls.append(effect_id)
+        return original(self, effect_id)
+
+    monkeypatch.setattr(plane_type, "validate", counted)
+    path = "operations/effect-run-1/output/final_model"
+    FakeVolume.registry["artifact-name"].files[path] += b"x"
+    with pytest.raises(RunOperationError):
+        api.reverify(RUN)
+    with pytest.raises(RunOperationError):
+        api.artifacts(RunArtifactRequest(RUN, "tokenizer", 1000))
+    assert calls == ["effect-run-1", "effect-run-1"]
+
+
+def test_role_and_caller_limit_are_closed(tmp_path):
+    api, _reads, _repository = _verified_reads(tmp_path)
+    with pytest.raises(RunOperationError) as missing:
+        api.artifacts(RunArtifactRequest(RUN, "missing", 1000))
+    assert missing.value.code is RunOperationCode.ARTIFACT_ROLE_MISSING
+    with pytest.raises(RunOperationError) as bounded:
+        api.artifacts(RunArtifactRequest(RUN, "final_model", 1))
+    assert bounded.value.code is RunOperationCode.ARTIFACT_LIMIT_EXCEEDED
+
+
+def test_non_verified_run_refuses_before_completion_io(tmp_path):
+    api, reads, repository = _verified_reads(tmp_path)
+    record = repository.load("project-1", "run-1")
+    repository.records[("project-1", "run-1")] = replace(
+        record, verification=record.verification.NOT_READY
+    )
+    calls = list(FakeVolume.calls)
+
+    with pytest.raises(RunOperationError) as refused:
+        api.show(RUN)
+    assert refused.value.code is RunOperationCode.READ_INELIGIBLE
+    assert FakeVolume.calls == calls
+
+
+def test_unsupported_operations_are_explicitly_unavailable(tmp_path):
+    _api, reads, _repository = _verified_reads(tmp_path)
+    for invoke in (
+        lambda: reads.list(RunListRequest("project-1")),
+        lambda: reads.logs(object()),
+        lambda: reads.cancel(RUN, "reason"),
+        lambda: reads.reconcile(RUN),
+    ):
+        with pytest.raises(RunOperationError) as unavailable:
+            invoke()
+        assert unavailable.value.code is RunOperationCode.CAPABILITY_UNAVAILABLE

--- a/tuner/execution/providers/modal/run_reads.py
+++ b/tuner/execution/providers/modal/run_reads.py
@@ -1,0 +1,396 @@
+"""Read-only public Runs operations for verified Modal training outputs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from threading import RLock
+from typing import Callable
+
+from synaptic_tuner.api.v1.results import (
+    TrainingRunRef,
+    TrainingRunState,
+    VerifiedArtifact,
+)
+from synaptic_tuner.api.v1.runs_facade import (
+    RunArtifactRequest,
+    RunListRequest,
+    RunLogsRequest,
+    RunOperationCode,
+    RunOperationError,
+    RunOutcome,
+    RunVerification,
+)
+from tuner.execution.contracts import LifecyclePhase, VerificationStatus
+from tuner.project.context import ProjectContext
+
+from .contracts import ArtifactMemberV1
+from .control import TerminalControlPlane
+from .logs import LogControlPlane
+from .manifest import CompletionControlPlane
+from .facade import ExplicitModal154ReadFacade
+from .training import (
+    ModalDurablePreparationV1,
+    ModalPreparedRunV1,
+    _ExpectationStore,
+    _prepared_record_prefix,
+    _validated_current_record,
+)
+
+
+_MAX_CHUNK_BYTES = 1_048_576
+
+
+def _error(code: RunOperationCode) -> RunOperationError:
+    return RunOperationError(code)
+
+
+def _one_use_claim() -> Callable[[], bool]:
+    lock = RLock()
+    consumed = False
+
+    def claim() -> bool:
+        nonlocal consumed
+        with lock:
+            if consumed:
+                return False
+            consumed = True
+            return True
+
+    return claim
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedMemberV1:
+    role: str
+    path: str
+    sha256: str
+    size_bytes: int
+
+    @classmethod
+    def from_member(cls, value: ArtifactMemberV1) -> "_VerifiedMemberV1":
+        if type(value) is not ArtifactMemberV1:
+            raise ValueError("Modal artifact manifest member is invalid")
+        return cls(value.role.value, value.path, value.sha256, value.size)
+
+    @property
+    def descriptor(self) -> VerifiedArtifact:
+        return VerifiedArtifact(self.role, self.sha256, self.size_bytes)
+
+
+@dataclass(frozen=True, slots=True)
+class _VerifiedSnapshotV1:
+    run: TrainingRunRef
+    preparation_bytes: bytes
+    record_bytes: bytes
+    volume_id: str
+    members: tuple[_VerifiedMemberV1, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _ModalArtifactStreamV1:
+    run: TrainingRunRef
+    artifact: VerifiedArtifact
+    maximum_bytes: int
+    _facade: object
+    _volume_id: str
+    _path: str
+    _durable_guard: object
+    _claim: Callable[[], bool] = field(
+        default_factory=_one_use_claim, repr=False, compare=False
+    )
+
+    def iter_bytes(self):
+        if not self._claim():
+            raise _error(RunOperationCode.ARTIFACT_CONTENT_INVALID)
+        return self._consume()
+
+    def _consume(self):
+        run = TrainingRunRef.from_dict(self.run.to_dict())
+        artifact = VerifiedArtifact.from_dict(self.artifact.to_dict())
+        maximum_bytes = self.maximum_bytes
+        facade = self._facade
+        volume_id = self._volume_id
+        path = self._path
+        durable_guard = self._durable_guard
+        digest = hashlib.sha256()
+        total = 0
+        try:
+            durable_guard()
+            iterator = iter(
+                facade.iter_complete(
+                    volume_id, path, max_bytes=maximum_bytes
+                )
+            )
+            for chunk in iterator:
+                if type(chunk) is not bytes or not chunk or len(chunk) > _MAX_CHUNK_BYTES:
+                    raise ValueError
+                total += len(chunk)
+                if total > maximum_bytes or total > artifact.size_bytes:
+                    raise ValueError
+                digest.update(chunk)
+                yield chunk
+            if (
+                total != artifact.size_bytes
+                or digest.hexdigest() != artifact.sha256
+                or self.run != run
+                or self.artifact != artifact
+                or self.maximum_bytes != maximum_bytes
+                or self._facade is not facade
+                or self._volume_id != volume_id
+                or self._path != path
+                or self._durable_guard is not durable_guard
+            ):
+                raise ValueError
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            raise _error(RunOperationCode.ARTIFACT_CONTENT_INVALID) from None
+
+
+class ModalVerifiedRunsOperationsV1:
+    """Bounded reads from already verified, host-persisted Modal runs."""
+
+    __slots__ = (
+        "_context", "_repository", "_facade", "_completion", "_clock",
+        "_cache", "_lock",
+    )
+
+    def __init__(
+        self,
+        *,
+        context: ProjectContext,
+        repository: object,
+        authenticator: object,
+        modal_reads: ExplicitModal154ReadFacade,
+        clock: object,
+    ) -> None:
+        if not isinstance(context, ProjectContext) or context.mode != "host":
+            raise ValueError("Modal run reads require a host project context")
+        required = (
+            "load", "load_modal_preparation", "load_modal_preparation_by_effect"
+        )
+        if any(not callable(getattr(repository, name, None)) for name in required):
+            raise TypeError("repository must provide exact Modal run reads")
+        if not callable(getattr(authenticator, "verify", None)):
+            raise TypeError("authenticator must provide evidence verification")
+        if type(modal_reads) is not ExplicitModal154ReadFacade:
+            raise TypeError("modal_reads must be the exact explicit Modal facade")
+        if not callable(clock):
+            raise TypeError("clock must be callable")
+        self._context = context
+        self._repository = repository
+        self._facade = modal_reads
+        self._clock = clock
+        expectations = _ExpectationStore(repository)
+        terminal = TerminalControlPlane(expectations, authenticator, modal_reads)
+        logs = LogControlPlane(expectations, authenticator, modal_reads)
+        self._completion = CompletionControlPlane(
+            expectations, authenticator, modal_reads, terminal, logs
+        )
+        self._cache: dict[tuple[str, str], _VerifiedSnapshotV1] = {}
+        self._lock = RLock()
+
+    @staticmethod
+    def _run(value: object) -> TrainingRunRef:
+        if type(value) is not TrainingRunRef:
+            raise _error(RunOperationCode.PROVIDER_READ_INVALID)
+        return TrainingRunRef.from_dict(value.to_dict())
+
+    def _durable(self, public_run: TrainingRunRef):
+        run = self._run(public_run)
+        repository = self._repository
+        try:
+            preparation = repository.load_modal_preparation(
+                run.project_ref, run.run_id
+            )
+            record = repository.load(run.project_ref, run.run_id)
+            if type(preparation) is not ModalDurablePreparationV1:
+                raise ValueError
+            prepared = ModalPreparedRunV1(
+                _prepared_record_prefix(record), preparation
+            )
+            current = _validated_current_record(
+                record,
+                prepared=prepared,
+                expected_effect=preparation.operation.effect,
+                require_ready_grant_ref=None,
+            )
+            if (
+                current.project_ref != run.project_ref
+                or current.run_id != run.run_id
+                or preparation.context.project_ref != run.project_ref
+                or preparation.operation.project_ref != run.project_ref
+                or preparation.operation.run_id != run.run_id
+                or current.phase is not LifecyclePhase.SUCCEEDED
+                or current.verification is not VerificationStatus.VERIFIED
+            ):
+                raise ValueError
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            raise _error(RunOperationCode.READ_INELIGIBLE) from None
+        return run, preparation, current
+
+    def _snapshot(self, public_run: TrainingRunRef, *, refresh: bool = False):
+        requested = self._run(public_run)
+        key = (requested.project_ref, requested.run_id)
+        if refresh:
+            with self._lock:
+                self._cache.pop(key, None)
+        try:
+            run, preparation, current = self._durable(requested)
+        except BaseException:
+            with self._lock:
+                self._cache.pop(key, None)
+            raise
+        repository = self._repository
+        preparation_bytes = preparation.canonical_bytes
+        record_bytes = current.canonical_bytes
+        with self._lock:
+            cached = self._cache.get(key)
+        if (
+            not refresh
+            and cached is not None
+            and cached.preparation_bytes == preparation_bytes
+            and cached.record_bytes == record_bytes
+        ):
+            return cached
+        if cached is not None:
+            with self._lock:
+                self._cache.pop(key, None)
+        try:
+            manifest = self._completion.validate(
+                preparation.operation.effect.effect_id
+            )
+            members = tuple(
+                sorted(
+                    (_VerifiedMemberV1.from_member(item) for item in manifest.members),
+                    key=lambda item: item.role,
+                )
+            )
+            after_preparation = repository.load_modal_preparation(
+                run.project_ref, run.run_id
+            )
+            after_record = repository.load(run.project_ref, run.run_id)
+            if (
+                after_preparation != preparation
+                or after_record.canonical_bytes != current.canonical_bytes
+                or len(members) != 5
+                or len({item.role for item in members}) != 5
+            ):
+                raise ValueError
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception:
+            with self._lock:
+                self._cache.pop(key, None)
+            raise _error(RunOperationCode.PROVIDER_READ_INVALID) from None
+        snapshot = _VerifiedSnapshotV1(
+            run,
+            bytes(preparation_bytes),
+            bytes(record_bytes),
+            preparation.context.artifact_volume_id,
+            members,
+        )
+        with self._lock:
+            self._cache[key] = snapshot
+        return snapshot
+
+    def _guard_snapshot(self, snapshot: _VerifiedSnapshotV1) -> None:
+        key = (snapshot.run.project_ref, snapshot.run.run_id)
+        try:
+            run, preparation, current = self._durable(snapshot.run)
+            if (
+                run != snapshot.run
+                or preparation.canonical_bytes != snapshot.preparation_bytes
+                or current.canonical_bytes != snapshot.record_bytes
+            ):
+                raise _error(RunOperationCode.READ_INELIGIBLE)
+        except BaseException:
+            with self._lock:
+                self._cache.pop(key, None)
+            raise
+
+    @staticmethod
+    def _outcome(
+        run: TrainingRunRef, members: tuple[_VerifiedMemberV1, ...]
+    ) -> RunOutcome:
+        return RunOutcome(
+            "synaptic-run-outcome/v1",
+            run,
+            TrainingRunState.SUCCEEDED,
+            tuple(item.descriptor for item in members),
+        )
+
+    def show(self, run: TrainingRunRef) -> RunOutcome:
+        snapshot = self._snapshot(run)
+        return self._outcome(snapshot.run, snapshot.members)
+
+    def outcome(self, run: TrainingRunRef) -> RunOutcome:
+        return self.show(run)
+
+    def verify(self, run: TrainingRunRef) -> RunVerification:
+        snapshot = self._snapshot(run)
+        return RunVerification(snapshot.run, True, self._clock())
+
+    def reverify(self, run: TrainingRunRef) -> RunVerification:
+        snapshot = self._snapshot(run, refresh=True)
+        return RunVerification(snapshot.run, True, self._clock())
+
+    def artifacts(self, request: RunArtifactRequest):
+        if type(request) is not RunArtifactRequest:
+            raise _error(RunOperationCode.ARTIFACT_CONTENT_INVALID)
+        snapshot = self._snapshot(request.run)
+        matches = tuple(item for item in snapshot.members if item.role == request.role)
+        if len(matches) != 1:
+            raise _error(RunOperationCode.ARTIFACT_ROLE_MISSING)
+        member = matches[0]
+        if member.size_bytes > request.maximum_bytes:
+            raise _error(RunOperationCode.ARTIFACT_LIMIT_EXCEEDED)
+        return _ModalArtifactStreamV1(
+            snapshot.run,
+            member.descriptor,
+            request.maximum_bytes,
+            self._facade,
+            snapshot.volume_id,
+            member.path,
+            lambda: self._guard_snapshot(snapshot),
+        )
+
+    @staticmethod
+    def list(_request: RunListRequest):
+        raise _error(RunOperationCode.CAPABILITY_UNAVAILABLE)
+
+    @staticmethod
+    def logs(_request: RunLogsRequest):
+        raise _error(RunOperationCode.CAPABILITY_UNAVAILABLE)
+
+    @staticmethod
+    def cancel(_run: TrainingRunRef, _reason: str):
+        raise _error(RunOperationCode.CAPABILITY_UNAVAILABLE)
+
+    @staticmethod
+    def reconcile(_run: TrainingRunRef):
+        raise _error(RunOperationCode.CAPABILITY_UNAVAILABLE)
+
+
+def compose_modal_verified_run_reads(
+    *,
+    context: ProjectContext,
+    repository: object,
+    authenticator: object,
+    modal_reads: ExplicitModal154ReadFacade,
+    clock: object,
+) -> ModalVerifiedRunsOperationsV1:
+    """Compose read-only Runs operations over existing Modal run state."""
+    return ModalVerifiedRunsOperationsV1(
+        context=context,
+        repository=repository,
+        authenticator=authenticator,
+        modal_reads=modal_reads,
+        clock=clock,
+    )
+
+
+__all__ = ["ModalVerifiedRunsOperationsV1", "compose_modal_verified_run_reads"]


### PR DESCRIPTION
Adds read-only RunsAPI operations for already verified Modal outputs. Authenticates the exact five-artifact inventory and exposes bounded single-use byte streams. No provider mutation, SDK client construction, Host database, filesystem writes, publication, or chat serving is added. Independent source audit accepted the exact three-file range c2ae4d03..f00cef358ec825c696f99890496219a8cded6cc7. Clean release validation: 468 passed, including the full Modal engine lane, public Runs/Training contracts, and optional-dependency checks. Fake providers and credential-free environment only; no live smoke claimed. Target is the existing feature branch, never main.